### PR TITLE
feat: add witness-based finite sum evaluator and associated tactics

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -31,6 +31,10 @@ import LeanCert.Engine.IntervalEvalDyadic
 import LeanCert.Engine.CompPoly
 -- v1.2: Reflective sum evaluator (O(1) proof size for finite sums)
 import LeanCert.Engine.ReflectiveSum
+-- v1.3: General finite sum evaluator (O(1) proof size for any Core.Expr body)
+import LeanCert.Engine.FinSumDyadic
+-- v1.3: Witness-based finite sum evaluator (user-provided per-term evaluator)
+import LeanCert.Engine.WitnessSum
 
 -- Global Optimization
 import LeanCert.Engine.Optimization.Box
@@ -69,6 +73,10 @@ import LeanCert.Tactic.Bound
 import LeanCert.Tactic.VecSimp
 -- Finset sum expansion (intervals, explicit sets, and Fin sums)
 import LeanCert.Tactic.FinSumExpand
+-- O(1) proof-size finite sum bounds via native_decide
+import LeanCert.Tactic.FinSumBound
+-- Witness-based finite sum bounds (user-provided evaluator + correctness proof)
+import LeanCert.Tactic.FinSumWitness
 
 -- Discovery Mode
 import LeanCert.Discovery

--- a/LeanCert/Core/Expr.lean
+++ b/LeanCert/Core/Expr.lean
@@ -451,6 +451,14 @@ theorem eval_abs (ρ : Nat → ℝ) (e : Expr) :
     eval ρ (abs e) = |eval ρ e| := by
   simp only [abs, eval_sqrt, eval_mul, ← sq, Real.sqrt_sq_eq_abs]
 
+/-- Evaluation of sqrt(x * x) = |x| (unfolded form of `abs`). -/
+theorem eval_sqrt_mul_self_eq_abs (ρ : Nat → ℝ) (e : Expr) :
+    eval ρ (sqrt (mul e e)) = |eval ρ e| := eval_abs ρ e
+
+/-- `√(x * x) = |x|` — LeanCert-namespaced alias of `Real.sqrt_mul_self_eq_abs`. -/
+theorem sqrt_mul_self_eq_abs (x : ℝ) : Real.sqrt (x * x) = |x| :=
+  Real.sqrt_mul_self_eq_abs x
+
 /-- For positive x, sqrt(x²) = x -/
 theorem eval_sqrt_sq_of_pos (ρ : Nat → ℝ) (e : Expr) (hpos : 0 < eval ρ e) :
     eval ρ (sqrt (mul e e)) = eval ρ e := by

--- a/LeanCert/Core/IntervalDyadic.lean
+++ b/LeanCert/Core/IntervalDyadic.lean
@@ -378,6 +378,26 @@ def upperBoundedBy (I : IntervalDyadic) (q : ℚ) : Bool :=
 def lowerBoundedBy (I : IntervalDyadic) (q : ℚ) : Bool :=
   q ≤ I.lo.toRat
 
+/-- Upper bound extraction from membership -/
+theorem le_hi_of_mem {x : ℝ} {I : IntervalDyadic} (hx : x ∈ I) :
+    x ≤ (I.hi.toRat : ℝ) := hx.2
+
+/-- Lower bound extraction from membership -/
+theorem lo_le_of_mem {x : ℝ} {I : IntervalDyadic} (hx : x ∈ I) :
+    (I.lo.toRat : ℝ) ≤ x := hx.1
+
+/-- What upperBoundedBy means: the interval's hi endpoint is ≤ q -/
+theorem upperBoundedBy_spec {I : IntervalDyadic} {q : ℚ}
+    (h : I.upperBoundedBy q = true) : (I.hi.toRat : ℝ) ≤ q := by
+  simp only [upperBoundedBy, decide_eq_true_eq] at h
+  exact_mod_cast h
+
+/-- What lowerBoundedBy means: q is ≤ the interval's lo endpoint -/
+theorem lowerBoundedBy_spec {I : IntervalDyadic} {q : ℚ}
+    (h : I.lowerBoundedBy q = true) : (q : ℝ) ≤ I.lo.toRat := by
+  simp only [lowerBoundedBy, decide_eq_true_eq] at h
+  exact_mod_cast h
+
 /-! ### Helper for Transcendentals -/
 
 /-- Convert from IntervalRat (for transcendental results) -/

--- a/LeanCert/Engine/FinSumDyadic.lean
+++ b/LeanCert/Engine/FinSumDyadic.lean
@@ -1,0 +1,438 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Engine.IntervalEvalDyadic
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Order.Interval.Finset.Nat
+
+/-!
+# General Finite Sum Evaluator with O(1) Proof Size
+
+This module provides a general accumulator-based evaluator for finite sums
+over `Core.Expr`, achieving O(1) proof term size via `native_decide`.
+
+## Motivation
+
+`finsum_expand` expands `∑ k ∈ Icc a b, f k` into `f a + f(a+1) + ... + f b`,
+creating an O(N) expression tree that blows up for N > ~100.
+
+`ReflectiveSum` solves this with an accumulator + `native_decide`, but is
+hardcoded for one specific function (BKLNW's `x^(1/k - 1/3)`).
+
+This module generalizes the pattern: any function expressible as a `Core.Expr`
+(with `var 0` as the summation index) can be bounded via the same accumulator
+loop, using `evalIntervalDyadic` per term.
+
+## Main definitions
+
+* `finSumDyadic` - Interval bound for `∑ k ∈ Icc a b, Expr.eval [k] body`
+* `checkFinSumUpperBound` - Certificate checker for upper bounds
+* `checkFinSumLowerBound` - Certificate checker for lower bounds
+* `verify_finsum_upper` - Bridge theorem: checker = true → sum ≤ target
+* `verify_finsum_lower` - Bridge theorem: checker = true → target ≤ sum
+
+## Usage
+
+```lean
+-- Verify ∑ k ∈ Icc 1 100, 1/k² ≤ 2 with O(1) proof:
+example : checkFinSumUpperBound (Expr.inv (Expr.mul (Expr.var 0) (Expr.var 0)))
+    1 100 2 { precision := -53 } = true := by native_decide
+```
+
+## Architecture
+
+```
+evalIntervalDyadic (per-term, from IntervalEvalDyadic.lean)
+  ↓
+finSumAux (accumulator loop)
+  ↓
+checkFinSumUpperBound : Bool
+  ↓  native_decide
+verify_finsum_upper (bridge theorem)
+```
+-/
+
+namespace LeanCert.Engine
+
+open LeanCert.Core
+
+/-! ### Sum Lemmas
+
+These are general lemmas for peeling elements from Finset sums.
+Reusable by any accumulator-based sum evaluator. -/
+
+/-- Sum over Icc starting at first element -/
+theorem Finset.sum_Icc_eq_add_sum_Ioc' {α : Type*} [AddCommMonoid α] (f : ℕ → α) (a b : ℕ)
+    (h : a ≤ b) : ∑ k ∈ Finset.Icc a b, f k = f a + ∑ k ∈ Finset.Ioc a b, f k := by
+  rw [← Finset.sum_insert (s := Finset.Ioc a b) (a := a)]
+  · congr 1
+    ext k
+    simp only [Finset.mem_insert, Finset.mem_Icc, Finset.mem_Ioc]
+    omega
+  · simp only [Finset.mem_Ioc]
+    omega
+
+/-- Ioc a b equals Icc (a+1) b -/
+theorem Finset.Ioc_eq_Icc_succ' (a b : ℕ) : Finset.Ioc a b = Finset.Icc (a + 1) b := by
+  ext k
+  simp only [Finset.mem_Ioc, Finset.mem_Icc]
+  omega
+
+/-! ### Environment Helpers -/
+
+/-- Environment for evaluating the sum body at index k.
+    Maps all variables to the singleton interval [k, k].
+
+    For single-variable bodies (var 0 = summation index), this is sufficient.
+    For multi-variable bodies, a shifted version would be needed (future work). -/
+def sumBodyEnvSimple (k : Nat) (prec : Int) : IntervalDyadicEnv :=
+  fun _ => IntervalDyadic.ofIntervalRat (IntervalRat.singleton (k : ℚ)) prec
+
+/-- Real environment: all variables equal (k : ℝ). -/
+noncomputable def sumBodyRealEnv (k : Nat) : Nat → ℝ := fun _ => (k : ℝ)
+
+/-- The real environment is contained in the dyadic environment. -/
+theorem sumBodyEnvSimple_correct (k : Nat) (prec : Int) (hprec : prec ≤ 0) :
+    envMemDyadic (sumBodyRealEnv k) (sumBodyEnvSimple k prec) := by
+  intro i
+  simp only [sumBodyRealEnv, sumBodyEnvSimple]
+  apply IntervalDyadic.mem_ofIntervalRat _ prec hprec
+  have : ((k : ℚ) : ℝ) = (k : ℝ) := by push_cast; ring
+  rw [← this]
+  exact IntervalRat.mem_singleton (k : ℚ)
+
+/-! ### Per-term Evaluation -/
+
+/-- Evaluate a single term of the sum: body evaluated at index k. -/
+def evalSumTermDyadic (body : Expr) (k : Nat) (cfg : DyadicConfig) : IntervalDyadic :=
+  evalIntervalDyadic body (sumBodyEnvSimple k cfg.precision) cfg
+
+/-! ### Accumulator Loop -/
+
+/-- Zero interval for accumulator initialization. -/
+def finSumZero : IntervalDyadic := IntervalDyadic.singleton Core.Dyadic.zero
+
+/-- Zero is in the zero interval. -/
+theorem mem_finSumZero : (0 : ℝ) ∈ finSumZero := by
+  simp only [finSumZero, IntervalDyadic.singleton, IntervalDyadic.mem_def]
+  have hz : Core.Dyadic.zero.toRat = 0 := Core.Dyadic.toRat_zero
+  simp only [hz, Rat.cast_zero, le_refl, and_self]
+
+/-- Accumulator loop for general finite sums.
+    Computes an interval containing `∑ k ∈ Icc current limit, Expr.eval [k] body`. -/
+def finSumAux (body : Expr) (current limit : Nat)
+    (acc : IntervalDyadic) (cfg : DyadicConfig) : IntervalDyadic :=
+  if h : current > limit then
+    acc
+  else
+    let term := evalSumTermDyadic body current cfg
+    let newAcc := (IntervalDyadic.add acc term).roundOut cfg.precision
+    finSumAux body (current + 1) limit newAcc cfg
+  termination_by limit + 1 - current
+
+/-- Main entry point: interval for `∑ k ∈ Icc a b, Expr.eval [k] body`. -/
+def finSumDyadic (body : Expr) (a b : Nat) (cfg : DyadicConfig := {}) : IntervalDyadic :=
+  finSumAux body a b finSumZero cfg
+
+/-! ### Certificate Checkers -/
+
+/-- Check if `∑ k ∈ Icc a b, Expr.eval [k] body ≤ target`. -/
+def checkFinSumUpperBound (body : Expr) (a b : Nat) (target : ℚ)
+    (cfg : DyadicConfig := {}) : Bool :=
+  (finSumDyadic body a b cfg).upperBoundedBy target
+
+/-- Check if `target ≤ ∑ k ∈ Icc a b, Expr.eval [k] body`. -/
+def checkFinSumLowerBound (body : Expr) (a b : Nat) (target : ℚ)
+    (cfg : DyadicConfig := {}) : Bool :=
+  (finSumDyadic body a b cfg).lowerBoundedBy target
+
+/-! ### Correctness Theorems -/
+
+/-- Per-term correctness: the true value is in the computed interval. -/
+theorem mem_evalSumTermDyadic (body : Expr) (hsupp : ExprSupportedCore body)
+    (k : Nat) (cfg : DyadicConfig) (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg) :
+    Expr.eval (sumBodyRealEnv k) body ∈ evalSumTermDyadic body k cfg :=
+  evalIntervalDyadic_correct body hsupp (sumBodyRealEnv k)
+    (sumBodyEnvSimple k cfg.precision) (sumBodyEnvSimple_correct k cfg.precision hprec)
+    cfg hprec hdom
+
+/-- Accumulator correctness: if we've accumulated correctly so far,
+    adding terms preserves correctness.
+
+    Proof structure mirrors `mem_bklnwSumAux` from ReflectiveSum.lean. -/
+theorem mem_finSumAux (body : Expr) (hsupp : ExprSupportedCore body)
+    (current limit : Nat) (acc : IntervalDyadic) (partialSum : ℝ)
+    (hacc : partialSum ∈ acc)
+    (cfg : DyadicConfig) (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, current ≤ k → k ≤ limit →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg) :
+    (partialSum + ∑ k ∈ Finset.Icc current limit, Expr.eval (sumBodyRealEnv k) body)
+      ∈ finSumAux body current limit acc cfg := by
+  generalize hm : limit + 1 - current = m
+  induction m using Nat.strongRecOn generalizing current acc partialSum with
+  | ind m ih =>
+    unfold finSumAux
+    split_ifs with h
+    · -- Base case: current > limit, sum is empty
+      simp only [Finset.Icc_eq_empty (by omega : ¬current ≤ limit), Finset.sum_empty, add_zero]
+      exact hacc
+    · -- Inductive case: peel first element and recurse
+      have hcur_le : current ≤ limit := Nat.le_of_not_gt h
+      -- Split the sum
+      rw [Finset.sum_Icc_eq_add_sum_Ioc' _ current limit hcur_le]
+      rw [Finset.Ioc_eq_Icc_succ']
+      -- Reassociate
+      rw [← add_assoc]
+      -- Term membership
+      have hterm := mem_evalSumTermDyadic body hsupp current cfg hprec
+        (hdom current (Nat.le_refl current) hcur_le)
+      -- (partialSum + term) ∈ newAcc
+      have hnewAcc : partialSum + Expr.eval (sumBodyRealEnv current) body ∈
+          (IntervalDyadic.add acc (evalSumTermDyadic body current cfg)).roundOut cfg.precision := by
+        apply IntervalDyadic.roundOut_contains
+        exact IntervalDyadic.mem_add hacc hterm
+      -- Apply induction hypothesis
+      have hm' : limit + 1 - (current + 1) < m := by omega
+      have hdom' : ∀ k, current + 1 ≤ k → k ≤ limit →
+          evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg :=
+        fun k hk1 hk2 => hdom k (by omega) hk2
+      exact ih (limit + 1 - (current + 1)) hm' (current + 1) _ _ hnewAcc hdom' rfl
+
+/-- Main correctness theorem: the computed interval contains the true sum.
+
+    This is the "golden theorem" connecting the computable evaluator to the
+    mathematical definition of the finite sum. -/
+theorem mem_finSumDyadic (body : Expr) (hsupp : ExprSupportedCore body)
+    (a b : Nat) (cfg : DyadicConfig := {}) (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, a ≤ k → k ≤ b →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg) :
+    (∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body) ∈ finSumDyadic body a b cfg := by
+  unfold finSumDyadic
+  have h := mem_finSumAux body hsupp a b finSumZero 0 mem_finSumZero cfg hprec hdom
+  simp only [zero_add] at h
+  exact h
+
+/-! ### Bridge Theorems -/
+
+/-- If checkFinSumUpperBound returns true, the sum is bounded above.
+
+    This connects `native_decide` verification to mathematical truth. -/
+theorem verify_finsum_upper (body : Expr) (hsupp : ExprSupportedCore body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, a ≤ k → k ≤ b →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg)
+    (h_check : checkFinSumUpperBound body a b target cfg = true) :
+    ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body ≤ target := by
+  have hmem := mem_finSumDyadic body hsupp a b cfg hprec hdom
+  have hhi : ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body ≤
+      ((finSumDyadic body a b cfg).hi.toRat : ℝ) := hmem.2
+  simp only [checkFinSumUpperBound, IntervalDyadic.upperBoundedBy, decide_eq_true_eq] at h_check
+  exact le_trans hhi (by exact_mod_cast h_check)
+
+/-- If checkFinSumLowerBound returns true, the sum is bounded below. -/
+theorem verify_finsum_lower (body : Expr) (hsupp : ExprSupportedCore body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, a ≤ k → k ≤ b →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg)
+    (h_check : checkFinSumLowerBound body a b target cfg = true) :
+    target ≤ ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body := by
+  have hmem := mem_finSumDyadic body hsupp a b cfg hprec hdom
+  have hlo : ((finSumDyadic body a b cfg).lo.toRat : ℝ) ≤
+      ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body := hmem.1
+  simp only [checkFinSumLowerBound, IntervalDyadic.lowerBoundedBy, decide_eq_true_eq] at h_check
+  exact le_trans (by exact_mod_cast h_check) hlo
+
+/-! ### Domain Validity Checking Over Range -/
+
+/-- Check domain validity for all indices in [current, limit]. -/
+def checkDomainValidAllAux (body : Expr) (current limit : Nat)
+    (cfg : DyadicConfig) : Bool :=
+  if current > limit then true
+  else
+    checkDomainValidDyadic body (sumBodyEnvSimple current cfg.precision) cfg &&
+    checkDomainValidAllAux body (current + 1) limit cfg
+  termination_by limit + 1 - current
+
+/-- Check domain validity for all indices in [a, b]. -/
+def checkDomainValidAll (body : Expr) (a b : Nat) (cfg : DyadicConfig) : Bool :=
+  checkDomainValidAllAux body a b cfg
+
+/-- Bridge theorem: if checkDomainValidAllAux returns true,
+    domain validity holds for all indices in [current, limit]. -/
+theorem checkDomainValidAllAux_correct (body : Expr) (current limit : Nat)
+    (cfg : DyadicConfig)
+    (h : checkDomainValidAllAux body current limit cfg = true) :
+    ∀ k, current ≤ k → k ≤ limit →
+      evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg := by
+  generalize hm : limit + 1 - current = m
+  induction m using Nat.strongRecOn generalizing current with
+  | ind m ih =>
+    unfold checkDomainValidAllAux at h
+    split_ifs at h with hgt
+    · -- current > limit: vacuously true
+      intro k hk1 hk2; omega
+    · -- current ≤ limit: split the && check
+      have hcur_le : current ≤ limit := Nat.le_of_not_gt hgt
+      rw [Bool.and_eq_true] at h
+      intro k hk1 hk2
+      by_cases heq : k = current
+      · subst heq
+        exact checkDomainValidDyadic_correct body
+          (sumBodyEnvSimple k cfg.precision) cfg h.1
+      · have hk1' : current + 1 ≤ k := by omega
+        have hm' : limit + 1 - (current + 1) < m := by omega
+        exact ih (limit + 1 - (current + 1)) hm' (current + 1) h.2 rfl k hk1' hk2
+
+/-- Bridge theorem for checkDomainValidAll. -/
+theorem checkDomainValidAll_correct (body : Expr) (a b : Nat) (cfg : DyadicConfig)
+    (h : checkDomainValidAll body a b cfg = true) :
+    ∀ k, a ≤ k → k ≤ b →
+      evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg :=
+  checkDomainValidAllAux_correct body a b cfg h
+
+/-! ### Combined Certificate Checkers (Domain + Bound) -/
+
+/-- Check upper bound with integrated domain validity. -/
+def checkFinSumUpperBoundFull (body : Expr) (a b : Nat) (target : ℚ)
+    (cfg : DyadicConfig := {}) : Bool :=
+  checkDomainValidAll body a b cfg && checkFinSumUpperBound body a b target cfg
+
+/-- Check lower bound with integrated domain validity. -/
+def checkFinSumLowerBoundFull (body : Expr) (a b : Nat) (target : ℚ)
+    (cfg : DyadicConfig := {}) : Bool :=
+  checkDomainValidAll body a b cfg && checkFinSumLowerBound body a b target cfg
+
+/-! ### Combined Bridge Theorems (ExprSupportedCore) -/
+
+/-- If checkFinSumUpperBoundFull returns true, the sum is bounded above.
+    Domain validity is verified as part of the check. -/
+theorem verify_finsum_upper_full (body : Expr) (hsupp : ExprSupportedCore body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkFinSumUpperBoundFull body a b target cfg = true) :
+    ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body ≤ target := by
+  simp only [checkFinSumUpperBoundFull, Bool.and_eq_true] at h_check
+  exact verify_finsum_upper body hsupp a b target cfg hprec
+    (checkDomainValidAll_correct body a b cfg h_check.1) h_check.2
+
+/-- If checkFinSumLowerBoundFull returns true, the sum is bounded below.
+    Domain validity is verified as part of the check. -/
+theorem verify_finsum_lower_full (body : Expr) (hsupp : ExprSupportedCore body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkFinSumLowerBoundFull body a b target cfg = true) :
+    target ≤ ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body := by
+  simp only [checkFinSumLowerBoundFull, Bool.and_eq_true] at h_check
+  exact verify_finsum_lower body hsupp a b target cfg hprec
+    (checkDomainValidAll_correct body a b cfg h_check.1) h_check.2
+
+/-! ### WithInv Correctness Chain -/
+
+/-- Per-term correctness for ExprSupportedWithInv bodies. -/
+theorem mem_evalSumTermDyadic_withInv (body : Expr) (hsupp : ExprSupportedWithInv body)
+    (k : Nat) (cfg : DyadicConfig) (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg) :
+    Expr.eval (sumBodyRealEnv k) body ∈ evalSumTermDyadic body k cfg :=
+  evalIntervalDyadic_correct_withInv body hsupp (sumBodyRealEnv k)
+    (sumBodyEnvSimple k cfg.precision) (sumBodyEnvSimple_correct k cfg.precision hprec)
+    cfg hprec hdom
+
+/-- Accumulator correctness for ExprSupportedWithInv bodies. -/
+theorem mem_finSumAux_withInv (body : Expr) (hsupp : ExprSupportedWithInv body)
+    (current limit : Nat) (acc : IntervalDyadic) (partialSum : ℝ)
+    (hacc : partialSum ∈ acc)
+    (cfg : DyadicConfig) (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, current ≤ k → k ≤ limit →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg) :
+    (partialSum + ∑ k ∈ Finset.Icc current limit, Expr.eval (sumBodyRealEnv k) body)
+      ∈ finSumAux body current limit acc cfg := by
+  generalize hm : limit + 1 - current = m
+  induction m using Nat.strongRecOn generalizing current acc partialSum with
+  | ind m ih =>
+    unfold finSumAux
+    split_ifs with h
+    · simp only [Finset.Icc_eq_empty (by omega : ¬current ≤ limit), Finset.sum_empty, add_zero]
+      exact hacc
+    · have hcur_le : current ≤ limit := Nat.le_of_not_gt h
+      rw [Finset.sum_Icc_eq_add_sum_Ioc' _ current limit hcur_le]
+      rw [Finset.Ioc_eq_Icc_succ']
+      rw [← add_assoc]
+      have hterm := mem_evalSumTermDyadic_withInv body hsupp current cfg hprec
+        (hdom current (Nat.le_refl current) hcur_le)
+      have hnewAcc : partialSum + Expr.eval (sumBodyRealEnv current) body ∈
+          (IntervalDyadic.add acc (evalSumTermDyadic body current cfg)).roundOut cfg.precision := by
+        apply IntervalDyadic.roundOut_contains
+        exact IntervalDyadic.mem_add hacc hterm
+      have hm' : limit + 1 - (current + 1) < m := by omega
+      have hdom' : ∀ k, current + 1 ≤ k → k ≤ limit →
+          evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg :=
+        fun k hk1 hk2 => hdom k (by omega) hk2
+      exact ih (limit + 1 - (current + 1)) hm' (current + 1) _ _ hnewAcc hdom' rfl
+
+/-- Golden theorem for ExprSupportedWithInv bodies. -/
+theorem mem_finSumDyadic_withInv (body : Expr) (hsupp : ExprSupportedWithInv body)
+    (a b : Nat) (cfg : DyadicConfig := {}) (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, a ≤ k → k ≤ b →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg) :
+    (∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body) ∈ finSumDyadic body a b cfg := by
+  unfold finSumDyadic
+  have h := mem_finSumAux_withInv body hsupp a b finSumZero 0 mem_finSumZero cfg hprec hdom
+  simp only [zero_add] at h
+  exact h
+
+/-- Bridge theorem: upper bound for ExprSupportedWithInv. -/
+theorem verify_finsum_upper_withInv (body : Expr) (hsupp : ExprSupportedWithInv body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, a ≤ k → k ≤ b →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg)
+    (h_check : checkFinSumUpperBound body a b target cfg = true) :
+    ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body ≤ target := by
+  have hmem := mem_finSumDyadic_withInv body hsupp a b cfg hprec hdom
+  have hhi : ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body ≤
+      ((finSumDyadic body a b cfg).hi.toRat : ℝ) := hmem.2
+  simp only [checkFinSumUpperBound, IntervalDyadic.upperBoundedBy, decide_eq_true_eq] at h_check
+  exact le_trans hhi (by exact_mod_cast h_check)
+
+/-- Bridge theorem: lower bound for ExprSupportedWithInv. -/
+theorem verify_finsum_lower_withInv (body : Expr) (hsupp : ExprSupportedWithInv body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (hdom : ∀ k, a ≤ k → k ≤ b →
+        evalDomainValidDyadic body (sumBodyEnvSimple k cfg.precision) cfg)
+    (h_check : checkFinSumLowerBound body a b target cfg = true) :
+    target ≤ ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body := by
+  have hmem := mem_finSumDyadic_withInv body hsupp a b cfg hprec hdom
+  have hlo : ((finSumDyadic body a b cfg).lo.toRat : ℝ) ≤
+      ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body := hmem.1
+  simp only [checkFinSumLowerBound, IntervalDyadic.lowerBoundedBy, decide_eq_true_eq] at h_check
+  exact le_trans (by exact_mod_cast h_check) hlo
+
+/-! ### Combined Bridge Theorems (ExprSupportedWithInv) -/
+
+/-- Combined upper bound check for ExprSupportedWithInv bodies. -/
+theorem verify_finsum_upper_full_withInv (body : Expr) (hsupp : ExprSupportedWithInv body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkFinSumUpperBoundFull body a b target cfg = true) :
+    ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body ≤ target := by
+  simp only [checkFinSumUpperBoundFull, Bool.and_eq_true] at h_check
+  exact verify_finsum_upper_withInv body hsupp a b target cfg hprec
+    (checkDomainValidAll_correct body a b cfg h_check.1) h_check.2
+
+/-- Combined lower bound check for ExprSupportedWithInv bodies. -/
+theorem verify_finsum_lower_full_withInv (body : Expr) (hsupp : ExprSupportedWithInv body)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkFinSumLowerBoundFull body a b target cfg = true) :
+    target ≤ ∑ k ∈ Finset.Icc a b, Expr.eval (sumBodyRealEnv k) body := by
+  simp only [checkFinSumLowerBoundFull, Bool.and_eq_true] at h_check
+  exact verify_finsum_lower_withInv body hsupp a b target cfg hprec
+    (checkDomainValidAll_correct body a b cfg h_check.1) h_check.2
+
+end LeanCert.Engine

--- a/LeanCert/Engine/ReflectiveSum.lean
+++ b/LeanCert/Engine/ReflectiveSum.lean
@@ -249,26 +249,6 @@ theorem mem_zeroDyadic : (0 : ℝ) ∈ zeroDyadic := by
   have hz : Core.Dyadic.zero.toRat = 0 := Core.Dyadic.toRat_zero
   simp only [hz, Rat.cast_zero, le_refl, and_self]
 
-/-- Upper bound extraction from membership -/
-theorem IntervalDyadic.le_hi_of_mem {x : ℝ} {I : IntervalDyadic} (hx : x ∈ I) :
-    x ≤ (I.hi.toRat : ℝ) := hx.2
-
-/-- Lower bound extraction from membership -/
-theorem IntervalDyadic.lo_le_of_mem {x : ℝ} {I : IntervalDyadic} (hx : x ∈ I) :
-    (I.lo.toRat : ℝ) ≤ x := hx.1
-
-/-- What upperBoundedBy means for membership -/
-theorem IntervalDyadic.upperBoundedBy_spec {I : IntervalDyadic} {q : ℚ}
-    (h : I.upperBoundedBy q = true) : (I.hi.toRat : ℝ) ≤ q := by
-  simp only [IntervalDyadic.upperBoundedBy, decide_eq_true_eq] at h
-  exact_mod_cast h
-
-/-- What lowerBoundedBy means for membership -/
-theorem IntervalDyadic.lowerBoundedBy_spec {I : IntervalDyadic} {q : ℚ}
-    (h : I.lowerBoundedBy q = true) : (q : ℝ) ≤ I.lo.toRat := by
-  simp only [IntervalDyadic.lowerBoundedBy, decide_eq_true_eq] at h
-  exact_mod_cast h
-
 /-- Membership in ofIntervalRat from Set.Icc membership -/
 theorem IntervalDyadic.mem_ofIntervalRat_of_Icc {x : ℝ} {lo hi : ℚ} (hle : lo ≤ hi)
     (hx : x ∈ Set.Icc (lo : ℝ) hi) (prec : Int) (hprec : prec ≤ 0 := by norm_num) :

--- a/LeanCert/Engine/WitnessSum.lean
+++ b/LeanCert/Engine/WitnessSum.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Engine.FinSumDyadic
+
+/-!
+# Witness-Based Finite Sum Evaluator
+
+Generic accumulator loop for finite sums parameterized by a user-provided
+per-term evaluator. Unlike `FinSumDyadic` (which uses `Core.Expr` + `evalIntervalDyadic`),
+this module accepts any computable evaluator `Nat → DyadicConfig → IntervalDyadic`
+paired with a correctness proof.
+
+## Motivation
+
+`finsum_bound` auto-reifies to `Core.Expr`, which covers +, *, inv, exp, sin, log, etc.
+Functions outside `Core.Expr` (like `rpow` in BKLNW's `x^(1/k - 1/3)`) need a custom
+evaluator. The witness API provides the accumulator + bridge theorems; the user provides
+the per-term evaluator + its correctness proof.
+
+## Usage
+
+```lean
+-- User defines:
+def myEval (k : Nat) (cfg : DyadicConfig) : IntervalDyadic := ...
+theorem myEval_correct (k : Nat) ... : myF k ∈ myEval k cfg := ...
+
+-- Prove bound:
+example : ∑ k ∈ Finset.Icc 1 100, myF k ≤ target :=
+  verify_witness_sum_upper myF myEval 1 100 target cfg myEval_correct (by native_decide)
+```
+-/
+
+namespace LeanCert.Engine
+
+open LeanCert.Core
+
+/-! ### Accumulator Loop -/
+
+/-- Accumulator loop parameterized by a user-provided evaluator.
+    Computes an interval containing `∑ k ∈ Icc current limit, f k`. -/
+def witnessSumAux (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (current limit : Nat) (acc : IntervalDyadic)
+    (cfg : DyadicConfig) : IntervalDyadic :=
+  if current > limit then acc
+  else
+    let term := evalTerm current cfg
+    let newAcc := (IntervalDyadic.add acc term).roundOut cfg.precision
+    witnessSumAux evalTerm (current + 1) limit newAcc cfg
+  termination_by limit + 1 - current
+
+/-- Main entry point: interval for `∑ k ∈ Icc a b, f k` using a witness evaluator. -/
+def witnessSumDyadic (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (cfg : DyadicConfig) : IntervalDyadic :=
+  witnessSumAux evalTerm a b finSumZero cfg
+
+/-! ### Certificate Checkers -/
+
+/-- Check if `∑ k ∈ Icc a b, f k ≤ target` using the witness evaluator. -/
+def checkWitnessSumUpperBound (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig) : Bool :=
+  (witnessSumDyadic evalTerm a b cfg).upperBoundedBy target
+
+/-- Check if `target ≤ ∑ k ∈ Icc a b, f k` using the witness evaluator. -/
+def checkWitnessSumLowerBound (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig) : Bool :=
+  (witnessSumDyadic evalTerm a b cfg).lowerBoundedBy target
+
+/-! ### Correctness Theorems -/
+
+/-- Accumulator correctness: if the evaluator is sound for each term,
+    the accumulator produces a sound interval for the partial sum. -/
+theorem mem_witnessSumAux (f : Nat → ℝ) (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (current limit : Nat) (acc : IntervalDyadic) (partialSum : ℝ)
+    (hacc : partialSum ∈ acc) (cfg : DyadicConfig)
+    (hmem : ∀ k, current ≤ k → k ≤ limit → f k ∈ evalTerm k cfg) :
+    (partialSum + ∑ k ∈ Finset.Icc current limit, f k)
+      ∈ witnessSumAux evalTerm current limit acc cfg := by
+  generalize hm : limit + 1 - current = m
+  induction m using Nat.strongRecOn generalizing current acc partialSum with
+  | ind m ih =>
+    unfold witnessSumAux
+    split_ifs with h
+    · simp only [Finset.Icc_eq_empty (by omega : ¬current ≤ limit), Finset.sum_empty, add_zero]
+      exact hacc
+    · have hcur_le : current ≤ limit := Nat.le_of_not_gt h
+      rw [Finset.sum_Icc_eq_add_sum_Ioc' _ current limit hcur_le]
+      rw [Finset.Ioc_eq_Icc_succ']
+      rw [← add_assoc]
+      have hterm := hmem current (Nat.le_refl current) hcur_le
+      have hnewAcc : partialSum + f current ∈
+          (IntervalDyadic.add acc (evalTerm current cfg)).roundOut cfg.precision := by
+        apply IntervalDyadic.roundOut_contains
+        exact IntervalDyadic.mem_add hacc hterm
+      have hm' : limit + 1 - (current + 1) < m := by omega
+      have hmem' : ∀ k, current + 1 ≤ k → k ≤ limit → f k ∈ evalTerm k cfg :=
+        fun k hk1 hk2 => hmem k (by omega) hk2
+      exact ih (limit + 1 - (current + 1)) hm' (current + 1) _ _ hnewAcc hmem' rfl
+
+/-- Golden theorem: the computed interval contains the true sum. -/
+theorem mem_witnessSumDyadic (f : Nat → ℝ) (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (cfg : DyadicConfig)
+    (hmem : ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg) :
+    (∑ k ∈ Finset.Icc a b, f k) ∈ witnessSumDyadic evalTerm a b cfg := by
+  unfold witnessSumDyadic
+  have h := mem_witnessSumAux f evalTerm a b finSumZero 0 mem_finSumZero cfg hmem
+  simp only [zero_add] at h
+  exact h
+
+/-! ### Bridge Theorems -/
+
+/-- If checkWitnessSumUpperBound returns true, the sum is bounded above. -/
+theorem verify_witness_sum_upper (f : Nat → ℝ)
+    (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig)
+    (hmem : ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg)
+    (h_check : checkWitnessSumUpperBound evalTerm a b target cfg = true) :
+    ∑ k ∈ Finset.Icc a b, f k ≤ target := by
+  have hsum := mem_witnessSumDyadic f evalTerm a b cfg hmem
+  have hhi : ∑ k ∈ Finset.Icc a b, f k ≤
+      ((witnessSumDyadic evalTerm a b cfg).hi.toRat : ℝ) := hsum.2
+  simp only [checkWitnessSumUpperBound, IntervalDyadic.upperBoundedBy,
+    decide_eq_true_eq] at h_check
+  exact le_trans hhi (by exact_mod_cast h_check)
+
+/-- If checkWitnessSumLowerBound returns true, the sum is bounded below. -/
+theorem verify_witness_sum_lower (f : Nat → ℝ)
+    (evalTerm : Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig)
+    (hmem : ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg)
+    (h_check : checkWitnessSumLowerBound evalTerm a b target cfg = true) :
+    target ≤ ∑ k ∈ Finset.Icc a b, f k := by
+  have hsum := mem_witnessSumDyadic f evalTerm a b cfg hmem
+  have hlo : ((witnessSumDyadic evalTerm a b cfg).lo.toRat : ℝ) ≤
+      ∑ k ∈ Finset.Icc a b, f k := hsum.1
+  simp only [checkWitnessSumLowerBound, IntervalDyadic.lowerBoundedBy,
+    decide_eq_true_eq] at h_check
+  exact le_trans (by exact_mod_cast h_check) hlo
+
+end LeanCert.Engine

--- a/LeanCert/Meta/ToExpr.lean
+++ b/LeanCert/Meta/ToExpr.lean
@@ -125,6 +125,10 @@ def mkExprErf (e : Lean.Expr) : MetaM Lean.Expr :=
 def mkExprSqrt (e : Lean.Expr) : MetaM Lean.Expr :=
   mkAppM ``LeanCert.Core.Expr.sqrt #[e]
 
+/-- Build `LeanCert.Core.Expr.abs e` (= `Expr.sqrt (Expr.mul e e)`). -/
+def mkExprAbs (e : Lean.Expr) : MetaM Lean.Expr :=
+  mkAppM ``LeanCert.Core.Expr.abs #[e]
+
 /-- Build `LeanCert.Core.Expr.sinh e`. -/
 def mkExprSinh (e : Lean.Expr) : MetaM Lean.Expr :=
   mkAppM ``LeanCert.Core.Expr.sinh #[e]
@@ -232,6 +236,24 @@ where
       | some qnum, some qden => return some (qnum / qden)
       | _, _ => return none
 
+    -- Rat.cast α inst q => extract q (handles ↑(q : ℚ) : ℝ)
+    | Rat.cast _ _ q => toRat? q
+
+    -- RatCast.ratCast α inst q (alternative form)
+    | RatCast.ratCast _ _ q => toRat? q
+
+    -- Nat.cast α inst n => extract n (handles ↑(n : ℕ) : ℝ)
+    | Nat.cast _ _ n => toRat? n
+
+    -- NatCast.natCast α inst n (alternative form)
+    | NatCast.natCast _ _ n => toRat? n
+
+    -- Int.cast α inst z => extract z (handles ↑(z : ℤ) : ℝ)
+    | Int.cast _ _ z => toRat? z
+
+    -- IntCast.intCast α inst z (alternative form)
+    | IntCast.intCast _ _ z => toRat? z
+
     -- OfScientific.ofScientific α inst mantissa exponentSign decimalExponent
     -- Represents: mantissa * 10^(if exponentSign then -decimalExponent else decimalExponent)
     -- E.g., 2.5 = 25 * 10^(-1) → mantissa=25, exponentSign=true, decimalExponent=1
@@ -260,23 +282,32 @@ the corresponding LeanCert AST.
 
 Logic:
 1. Check if it's a variable in our context
-2. Check if it's a constant number
-3. Check if it's a known arithmetic operator (+, *, -, /)
-4. Check if it's a known transcendental (sin, cos, exp, log, etc.)
-5. Fail if unrecognized
--/
+2. Try to match a known operator/function (+, *, -, /, sin, cos, exp, etc.)
+3. Check if it's a numeric constant (ℕ, ℤ, ℚ literals and casts)
+4. Reduce with whnf and retry
+5. Unfold definitions and retry
+
+**Important**: Step 2 (operator matching) must come before step 3 (numeric constant).
+Otherwise `toRat?` eagerly constant-folds compound expressions like `↑(-2 : ℤ) + 3`
+into `const(1)`, losing the syntactic structure needed by the bridge converter.
+With operators first, this reifies as `add(const(-2), const(3))` which the bridge
+can match against the goal. -/
 partial def toLeanCertExpr (e : Lean.Expr) : TranslateM Lean.Expr := do
   -- 1. Check if it is a free variable in our context
   if let some idx ← findVarIdx? e then
     return ← mkExprVar idx
 
-  -- 2. Check if it is a numeric constant
-  if let some q ← toRat? e then
-    return ← mkExprConst q
-
-  -- 3. Try to match on unreduced expression first (important!)
+  -- 2. Try to match on unreduced expression first (important!)
+  -- This must come BEFORE toRat? so that compound expressions like
+  -- `↑(-2 : ℤ) + 3` are reified structurally (as add(const(-2), const(3)))
+  -- rather than constant-folded by toRat? (which would produce const(1),
+  -- losing the structure needed for the bridge converter to match the goal).
   if let some result ← tryMatchExpr e then
     return result
+
+  -- 3. Check if it is a numeric constant (leaf values only at this point)
+  if let some q ← toRat? e then
+    return ← mkExprConst q
 
   -- 4. If no match, try reducing with whnf and matching again
   let eReduced ← whnf e
@@ -439,6 +470,12 @@ where
 
     -- The constant π
     | Real.pi => return some (← mkExprPi)
+
+    -- Absolute value: |x| → sqrt(x * x)
+    | abs _ _ _ x =>
+      let ex ← toLeanCertExpr x
+      let ex_sq ← mkExprMul ex ex
+      return some (← mkExprSqrt ex_sq)
 
     | _ => return none
 

--- a/LeanCert/Tactic/BridgeNative.lean
+++ b/LeanCert/Tactic/BridgeNative.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Lean
+
+/-!
+# Shared Bridge + native_decide Infrastructure
+
+Common pattern for `finsum_bound`, `finsum_witness`, and `finmatrix_bound`:
+apply a bridge proof term, close the Bool/ℚ check with `native_decide`,
+and handle the case where the bridge's type isn't defEq to the goal
+via a suffices + converter fallback.
+-/
+
+open Lean Meta Elab Tactic Term
+
+namespace LeanCert.Tactic
+
+/-- Apply a bridge proof and close the certificate check with `native_decide`.
+
+If `proofTy` is definitionally equal to `goalType`, assigns directly.
+Otherwise, uses a suffices + converter pattern:
+1. Creates `suffMVar : proofTy` and `converterMVar : proofTy → goalType`
+2. Assigns `goal := converterMVar suffMVar`
+3. Closes `suffMVar` with the bridge proof
+4. Closes `checkMVar` with `native_decide`
+5. Tries each converter tactic in sequence on `converterMVar`
+
+Parameters:
+- `goal`: the main goal mvar
+- `goalType`: the goal's type
+- `proof`: the bridge proof term (with `checkMVar` as a placeholder argument)
+- `checkMVar`: the mvar for the Bool/ℚ certificate check
+- `tacticName`: name for error messages (e.g., "finsum_bound")
+- `converterSteps`: fallback tactics to try (in order) for converting `proofTy → goalType`
+-/
+def closeBridgeWithNativeDecide
+    (goal : MVarId) (goalType : Lean.Expr)
+    (proof checkMVar : Lean.Expr)
+    (tacticName : String)
+    (converterSteps : Array (TacticM Unit))
+    : TacticM Unit := do
+  let proofTy ← inferType proof
+  if ← isDefEq proofTy goalType then
+    -- Direct path: bridge type matches goal exactly
+    goal.assign proof
+    replaceMainGoal [checkMVar.mvarId!]
+    evalTactic (← `(tactic| native_decide))
+  else
+    -- Suffices fallback: bridge type differs from goal
+    let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
+    let converterMVar ← mkFreshExprMVar
+      (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
+    goal.assign (mkApp converterMVar suffMVar)
+
+    -- 1. Solve suffMVar: assign the bridge proof
+    suffMVar.mvarId!.assign proof
+
+    -- 2. Solve checkMVar with native_decide
+    setGoals [checkMVar.mvarId!]
+    try
+      evalTactic (← `(tactic| native_decide))
+    catch e =>
+      throwError "{tacticName}: native_decide failed on certificate check.\n{e.toMessageData}"
+
+    -- 3. Solve converterMVar: try each converter in sequence
+    setGoals [converterMVar.mvarId!]
+    for step in converterSteps do
+      if (← getGoals).isEmpty then return
+      try
+        step
+        return
+      catch _ => pure ()
+    -- All converters failed
+    let cvGoalType ← converterMVar.mvarId!.getType
+    throwError "{tacticName}: could not convert bridge type to goal type.\n\
+      Converter goal: {← ppExpr cvGoalType}"
+
+end LeanCert.Tactic

--- a/LeanCert/Tactic/FinSumBound.lean
+++ b/LeanCert/Tactic/FinSumBound.lean
@@ -107,6 +107,119 @@ private def parseFinSumGoal (goalType : Lean.Expr) : Option FinSumGoal := do
     return { aExpr := a, bExpr := b, bodyLambda := f, targetExpr := lhs, isUpper := false }
   none
 
+/-! ## Generalized Finset Parsing (List Path) -/
+
+/-- Result of parsing a finite sum bound goal over an arbitrary Finset. -/
+structure FinSumGoalList where
+  /-- The Finset expression from the goal -/
+  finsetExpr : Lean.Expr
+  /-- The List Nat literal of elements -/
+  indicesExpr : Lean.Expr
+  /-- Sum body as lambda (ℕ → ℝ) -/
+  bodyLambda : Lean.Expr
+  /-- Bound target (ℝ expression) -/
+  targetExpr : Lean.Expr
+  /-- true for `sum ≤ target`, false for `target ≤ sum` -/
+  isUpper : Bool
+
+/-- Extract `(Finset, body)` from `Finset.sum S f`. -/
+private def extractFinsetSum (e : Lean.Expr) : Option (Lean.Expr × Lean.Expr) :=
+  let fn := e.getAppFn
+  let args := e.getAppArgs
+  if fn.isConstOf ``Finset.sum && args.size ≥ 5 then
+    some (args[3]!, args[4]!)
+  else
+    none
+
+/-- Try to extract a Nat literal from a Lean expression. -/
+private def extractNatLit (e : Lean.Expr) : MetaM (Option Nat) := do
+  if let some n := e.rawNatLit? then return some n
+  let e' ← whnf e
+  if let some n := e'.rawNatLit? then return some n
+  return none
+
+/-- Recursively extract elements from nested insert/singleton/empty Finset expressions. -/
+private partial def tryExtractExplicitFinset (e : Lean.Expr) : MetaM (Option (List Nat)) := do
+  let fn := e.getAppFn
+  let args := e.getAppArgs
+  -- Insert.insert : {α} → {γ} → [Insert α γ] → α → γ → γ
+  -- For Finset: args = [α, Finset α, Insert inst, elem, rest]
+  if fn.isConstOf ``Insert.insert && args.size ≥ 5 then
+    if let some n := ← extractNatLit args[3]! then
+      if let some rest := ← tryExtractExplicitFinset args[4]! then
+        return some (n :: rest)
+    return none
+  -- Finset.cons : {α} → α → (s : Finset α) → (h : a ∉ s) → Finset α
+  if fn.isConstOf ``Finset.cons && args.size ≥ 4 then
+    if let some n := ← extractNatLit args[1]! then
+      if let some rest := ← tryExtractExplicitFinset args[2]! then
+        return some (n :: rest)
+    return none
+  -- Singleton.singleton : {α} → {γ} → [Singleton α γ] → α → γ
+  -- For Finset: args = [α, Finset α, Singleton inst, elem]
+  if fn.isConstOf ``Singleton.singleton && args.size ≥ 4 then
+    if let some n := ← extractNatLit args[3]! then
+      return some [n]
+    return none
+  -- EmptyCollection.emptyCollection
+  if fn.isConstOf ``EmptyCollection.emptyCollection then
+    return some []
+  -- Try whnf and retry once
+  let e' ← whnf e
+  if e' != e then
+    return ← tryExtractExplicitFinset e'
+  return none
+
+/-- Extract Nat elements from a Finset expression.
+    Supports: Icc, Ico, Ioc, Ioo, range, {a, b, c}. -/
+private def extractFinsetElements (finsetExpr : Lean.Expr) : MetaM (Option (List Nat)) := do
+  let sfn := finsetExpr.getAppFn
+  let sargs := finsetExpr.getAppArgs
+  -- Finset.Icc a b
+  if sfn.isConstOf ``Finset.Icc && sargs.size ≥ 5 then
+    if let (some a, some b) := (← extractNatLit sargs[3]!, ← extractNatLit sargs[4]!) then
+      return some (List.range' a (b + 1 - a))
+    return none
+  -- Finset.Ico a b
+  if sfn.isConstOf ``Finset.Ico && sargs.size ≥ 5 then
+    if let (some a, some b) := (← extractNatLit sargs[3]!, ← extractNatLit sargs[4]!) then
+      return some (List.range' a (b - a))
+    return none
+  -- Finset.Ioc a b
+  if sfn.isConstOf ``Finset.Ioc && sargs.size ≥ 5 then
+    if let (some a, some b) := (← extractNatLit sargs[3]!, ← extractNatLit sargs[4]!) then
+      return some (List.range' (a + 1) (b - a))
+    return none
+  -- Finset.Ioo a b
+  if sfn.isConstOf ``Finset.Ioo && sargs.size ≥ 5 then
+    if let (some a, some b) := (← extractNatLit sargs[3]!, ← extractNatLit sargs[4]!) then
+      if b > a + 1 then
+        return some (List.range' (a + 1) (b - a - 1))
+      else
+        return some []
+    return none
+  -- Finset.range n
+  if sfn.isConstOf ``Finset.range && sargs.size ≥ 1 then
+    if let some n := ← extractNatLit sargs[0]! then
+      return some (List.range n)
+    return none
+  -- Explicit finset: {a, b, c}
+  tryExtractExplicitFinset finsetExpr
+
+/-- Parse a goal for the list path: ∑ k ∈ S, f k ≤ target (any Finset S). -/
+private def parseFinSumGoalList (goalType : Lean.Expr) : MetaM (Option FinSumGoalList) := do
+  let_expr LE.le _ _ lhs rhs := goalType | return none
+  let tryExtract (sumSide otherSide : Lean.Expr) (isUpper : Bool) :
+      MetaM (Option FinSumGoalList) := do
+    if let some (finsetExpr, bodyLambda) := extractFinsetSum sumSide then
+      if let some indices := ← extractFinsetElements finsetExpr then
+        let indicesExpr := toExpr indices
+        return some { finsetExpr, indicesExpr, bodyLambda, targetExpr := otherSide, isUpper }
+    return none
+  if let some g := ← tryExtract lhs rhs true then return some g
+  if let some g := ← tryExtract rhs lhs false then return some g
+  return none
+
 /-! ## Body Reification -/
 
 /-- Replace occurrences of `Nat.cast k` (where `k` is the given fvar) with
@@ -162,14 +275,10 @@ private def detectSupportLevel (ast : Lean.Expr) : MetaM SupportLevel := do
       throwError "finsum_bound: could not prove ExprSupportedCore or ExprSupportedWithInv \
         for the reified body. The body may contain unsupported operations."
 
-/-- Core implementation of `finsum_bound`. -/
-private def finSumBoundCore (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
+/-- Core implementation of `finsum_bound` for Finset.Icc goals. -/
+private def finSumBoundIccCore (fsGoal : FinSumGoal) (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
   let goal ← getMainGoal
   let goalType ← goal.getType
-
-  let some fsGoal := parseFinSumGoal goalType
-    | throwError "finsum_bound: goal is not of the form \
-        `∑ k ∈ Finset.Icc a b, f k ≤ target` or `target ≤ ∑ k ∈ Finset.Icc a b, f k`"
 
   goal.withContext do
     -- Extract target as rational
@@ -246,25 +355,135 @@ private def finSumBoundCore (prec : Int) (taylorDepth : Nat) : TacticM Unit := d
       setGoals [converterMVar.mvarId!]
       try
         evalTactic (← `(tactic|
-          intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv] at h ⊢;
+          intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+            div_eq_mul_inv] at h ⊢;
           norm_num at h ⊢; exact h))
       catch _ =>
         try
           evalTactic (← `(tactic|
-            intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv] at h ⊢;
+            intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+              div_eq_mul_inv] at h ⊢;
             push_cast at h ⊢; linarith))
         catch _ =>
           throwError "finsum_bound: could not convert Expr.eval form to the user's goal.\n\
             Proof type: {← ppExpr proofTy}\n\
             Goal type: {← ppExpr goalType}"
 
+/-- Core implementation of `finsum_bound` for arbitrary Finsets (list path). -/
+private def finSumBoundListCore (fsGoal : FinSumGoalList) (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+
+  goal.withContext do
+    -- Extract target as rational
+    let some target ← Auto.extractRatFromReal fsGoal.targetExpr
+      | throwError "finsum_bound: could not extract rational from bound `{← ppExpr fsGoal.targetExpr}`"
+    let targetExpr := toExpr target
+
+    -- Reify the sum body
+    let ast ← reifyFinSumBody fsGoal.bodyLambda
+    trace[finsum_bound] "Reified AST (list path): {ast}"
+
+    -- Build support proof
+    let support ← detectSupportLevel ast
+
+    -- Build configuration
+    let precExpr := toExpr prec
+    let depthExpr := toExpr taylorDepth
+    let cfgExpr ← mkAppM ``DyadicConfig.mk #[precExpr, depthExpr, toExpr (0 : Nat)]
+
+    -- Precision proof
+    let precLeZeroTy ← mkAppM ``LE.le #[precExpr, toExpr (0 : Int)]
+    let precLeZeroProof ← mkDecideProof precLeZeroTy
+
+    -- Build the combined certificate check (S = indices.toFinset ∧ Nodup ∧ domain ∧ bound)
+    let checkExpr ← if fsGoal.isUpper then
+      mkAppM ``checkFinSumUpperBoundListFull
+        #[ast, fsGoal.finsetExpr, fsGoal.indicesExpr, targetExpr, cfgExpr]
+    else
+      mkAppM ``checkFinSumLowerBoundListFull
+        #[ast, fsGoal.finsetExpr, fsGoal.indicesExpr, targetExpr, cfgExpr]
+
+    let checkEqTrue ← mkAppM ``Eq #[checkExpr, Lean.mkConst ``Bool.true]
+    let checkMVar ← mkFreshExprMVar (some checkEqTrue) (kind := .syntheticOpaque)
+
+    -- Select bridge theorem
+    let (bridgeThm, supportProof) := match support, fsGoal.isUpper with
+      | .core p,    true  => (``verify_finsum_upper_list_full, p)
+      | .core p,    false => (``verify_finsum_lower_list_full, p)
+      | .withInv p, true  => (``verify_finsum_upper_list_full_withInv, p)
+      | .withInv p, false => (``verify_finsum_lower_list_full_withInv, p)
+
+    -- Build bridge proof
+    let proof ← mkAppM bridgeThm
+      #[ast, supportProof, fsGoal.finsetExpr, fsGoal.indicesExpr, targetExpr, cfgExpr,
+        precLeZeroProof, checkMVar]
+
+    -- Try direct assignment
+    let proofTy ← inferType proof
+    if ← isDefEq proofTy goalType then
+      goal.assign proof
+      replaceMainGoal [checkMVar.mvarId!]
+      evalTactic (← `(tactic| native_decide))
+    else
+      -- Suffices fallback (same pattern as Icc path)
+      trace[finsum_bound] "Direct defEq failed (list path), using suffices + simp fallback"
+
+      let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
+      let converterMVar ← mkFreshExprMVar
+        (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
+      goal.assign (mkApp converterMVar suffMVar)
+
+      suffMVar.mvarId!.assign proof
+
+      setGoals [checkMVar.mvarId!]
+      try
+        evalTactic (← `(tactic| native_decide))
+      catch e =>
+        throwError "finsum_bound: native_decide failed on certificate check. \
+          The bound may be too tight for precision ({prec}).\n\
+          Try: `finsum_bound 100`.\n{e.toMessageData}"
+
+      setGoals [converterMVar.mvarId!]
+      try
+        evalTactic (← `(tactic|
+          intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+            div_eq_mul_inv] at h ⊢;
+          norm_num at h ⊢; exact h))
+      catch _ =>
+        try
+          evalTactic (← `(tactic|
+            intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+              div_eq_mul_inv] at h ⊢;
+            push_cast at h ⊢; linarith))
+        catch _ =>
+          throwError "finsum_bound: could not convert Expr.eval form to the user's goal.\n\
+            Proof type: {← ppExpr proofTy}\n\
+            Goal type: {← ppExpr goalType}"
+
+/-- Main dispatch: try Icc path first, then list path. -/
+private def finSumBoundCore (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+  -- Try Icc path first (faster, no Nodup check needed)
+  if let some iccGoal := parseFinSumGoal goalType then
+    finSumBoundIccCore iccGoal prec taylorDepth
+    return
+  -- Fall back to general list path
+  if let some listGoal := ← parseFinSumGoalList goalType then
+    finSumBoundListCore listGoal prec taylorDepth
+    return
+  throwError "finsum_bound: goal is not of the form \
+    `∑ k ∈ S, f k ≤ target` or `target ≤ ∑ k ∈ S, f k` \
+    where S is a recognized Finset (Icc, Ico, Ioc, Ioo, range, or explicit)"
+
 /-! ## Main Tactic -/
 
 /-- Prove bounds on finite sums with O(1) proof size.
 
     Handles goals:
-    - `∑ k ∈ Finset.Icc a b, f k ≤ target`
-    - `target ≤ ∑ k ∈ Finset.Icc a b, f k`
+    - `∑ k ∈ Finset.Icc a b, f k ≤ target` (and Ico, Ioc, Ioo, range, {a,b,c})
+    - `target ≤ ∑ k ∈ S, f k`
 
     Usage:
     - `finsum_bound` — auto-reify, default 53-bit precision

--- a/LeanCert/Tactic/FinSumBound.lean
+++ b/LeanCert/Tactic/FinSumBound.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Lean
+import LeanCert.Engine.FinSumDyadic
+import LeanCert.Meta.ToExpr
+import LeanCert.Meta.ProveSupported
+import LeanCert.Tactic.IntervalAuto
+import LeanCert.Tactic.FinSumWitness
+
+/-!
+# `finsum_bound`: O(1) Proof-Size Tactic for Finite Sum Bounds
+
+Proves bounds of the form `∑ k ∈ Finset.Icc a b, f k ≤ target` (or `≥`)
+using `native_decide` with O(1) proof size, regardless of the number of terms.
+
+## Motivation
+
+`finsum_expand` expands sums symbolically, creating O(N) proof terms that blow up
+for N > ~100. `finsum_bound` uses an accumulator-based evaluator over `Core.Expr`
+with `native_decide`, keeping proof size constant.
+
+## Usage
+
+```lean
+-- Upper bound on harmonic-like sum
+example : ∑ k ∈ Finset.Icc 1 100, (1 : ℝ) / (k * k) ≤ 2 := by
+  finsum_bound
+
+-- Lower bound
+example : (4 : ℝ) ≤ ∑ k ∈ Finset.Icc 1 100, 1 / k := by
+  finsum_bound
+
+-- Higher precision
+example : ∑ k ∈ Finset.Icc 1 500, (1 : ℝ) / (k * k) ≤ 2 := by
+  finsum_bound 100
+```
+
+## Architecture
+
+```
+Parse goal → reify body (ℕ → ℝ) to Core.Expr
+  → build ExprSupportedCore or ExprSupportedWithInv proof
+  → build DyadicConfig
+  → checkFinSumUpperBoundFull/LowerBoundFull : Bool (domain + bound)
+  → native_decide
+  → verify_finsum_upper_full/lower_full (bridge theorem)
+```
+-/
+
+open Lean Meta Elab Tactic Term
+
+namespace LeanCert.Tactic
+
+open LeanCert.Meta
+open LeanCert.Core
+open LeanCert.Engine
+
+initialize registerTraceClass `finsum_bound
+
+/-! ## Goal Parsing -/
+
+/-- Result of parsing a finite sum bound goal. -/
+structure FinSumGoal where
+  /-- Lower range bound (ℕ expression) -/
+  aExpr : Lean.Expr
+  /-- Upper range bound (ℕ expression) -/
+  bExpr : Lean.Expr
+  /-- Sum body as lambda (ℕ → ℝ) -/
+  bodyLambda : Lean.Expr
+  /-- Bound target (ℝ expression) -/
+  targetExpr : Lean.Expr
+  /-- true for `sum ≤ target`, false for `target ≤ sum` -/
+  isUpper : Bool
+
+/-- Extract `(a, b, f)` from `Finset.sum (Finset.Icc a b) f`. -/
+private def extractFinsetIccSum (e : Lean.Expr) : Option (Lean.Expr × Lean.Expr × Lean.Expr) :=
+  let fn := e.getAppFn
+  let args := e.getAppArgs
+  -- Finset.sum : {β} → {α} → [AddCommMonoid β] → Finset α → (α → β) → β
+  -- args = [β, α, inst, s, f]
+  if fn.isConstOf ``Finset.sum && args.size ≥ 5 then
+    let s := args[3]!
+    let f := args[4]!
+    let sfn := s.getAppFn
+    let sargs := s.getAppArgs
+    -- Finset.Icc : {α} → [Preorder α] → [LocallyFiniteOrder α] → α → α → Finset α
+    if sfn.isConstOf ``Finset.Icc && sargs.size ≥ 5 then
+      some (sargs[3]!, sargs[4]!, f)
+    else
+      none
+  else
+    none
+
+/-- Parse a goal of the form `∑ k ∈ Finset.Icc a b, f k ≤ target`
+    or `target ≤ ∑ k ∈ Finset.Icc a b, f k`. -/
+private def parseFinSumGoal (goalType : Lean.Expr) : Option FinSumGoal := do
+  -- Match LE.le _ _ lhs rhs
+  let_expr LE.le _ _ lhs rhs := goalType | none
+  -- Check if lhs is a Finset.Icc sum
+  if let some (a, b, f) := extractFinsetIccSum lhs then
+    return { aExpr := a, bExpr := b, bodyLambda := f, targetExpr := rhs, isUpper := true }
+  -- Check if rhs is a Finset.Icc sum
+  if let some (a, b, f) := extractFinsetIccSum rhs then
+    return { aExpr := a, bExpr := b, bodyLambda := f, targetExpr := lhs, isUpper := false }
+  none
+
+/-! ## Body Reification -/
+
+/-- Replace occurrences of `Nat.cast k` (where `k` is the given fvar) with
+    a replacement expression. Checks both `Nat.cast` and `NatCast.natCast` forms. -/
+private def replaceNatCast (body : Lean.Expr) (kFVarId : FVarId)
+    (replacement : Lean.Expr) : Lean.Expr :=
+  body.replace fun e =>
+    let fn := e.getAppFn
+    let args := e.getAppArgs
+    if args.size ≥ 1 then
+      let lastArg := args.back!
+      if lastArg.isFVar && lastArg.fvarId! == kFVarId then
+        if fn.isConstOf ``Nat.cast || fn.isConstOf ``NatCast.natCast then
+          some replacement
+        else none
+      else none
+    else none
+
+/-- Reify a sum body lambda `(ℕ → ℝ)` to a `Core.Expr` AST.
+    Replaces `Nat.cast k` with a real variable, then reifies. -/
+private def reifyFinSumBody (bodyLambda : Lean.Expr) : MetaM Lean.Expr := do
+  lambdaTelescope bodyLambda fun vars body => do
+    if vars.size < 1 then
+      throwError "finsum_bound: expected a lambda for the sum body"
+    let k := vars[0]!
+    let realTy := Lean.mkConst ``Real
+    withLocalDeclD `_x realTy fun x => do
+      -- Replace Nat.cast k with x
+      let body' := replaceNatCast body k.fvarId! x
+      -- Also try: if k appears bare (e.g. in Nat operations), this won't be caught.
+      -- For now, we just reify what we can.
+      let realLambda ← mkLambdaFVars #[x] body'
+      reify realLambda
+
+/-! ## Tactic Kernel -/
+
+/-- Result of support level detection. -/
+private inductive SupportLevel
+  | core (proof : Lean.Expr)     -- ExprSupportedCore
+  | withInv (proof : Lean.Expr)  -- ExprSupportedWithInv
+
+/-- Try to build a support proof. Tries ExprSupportedCore first,
+    then falls back to ExprSupportedWithInv for bodies with inv/atan/arsinh/atanh. -/
+private def detectSupportLevel (ast : Lean.Expr) : MetaM SupportLevel := do
+  try
+    let proof ← mkSupportedCoreProof ast
+    return .core proof
+  catch _ =>
+    try
+      let proof ← mkSupportedWithInvProof ast
+      return .withInv proof
+    catch _ =>
+      throwError "finsum_bound: could not prove ExprSupportedCore or ExprSupportedWithInv \
+        for the reified body. The body may contain unsupported operations."
+
+/-- Core implementation of `finsum_bound`. -/
+private def finSumBoundCore (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+
+  let some fsGoal := parseFinSumGoal goalType
+    | throwError "finsum_bound: goal is not of the form \
+        `∑ k ∈ Finset.Icc a b, f k ≤ target` or `target ≤ ∑ k ∈ Finset.Icc a b, f k`"
+
+  goal.withContext do
+    -- Extract target as rational
+    let some target ← Auto.extractRatFromReal fsGoal.targetExpr
+      | throwError "finsum_bound: could not extract rational from bound `{← ppExpr fsGoal.targetExpr}`"
+    let targetExpr := toExpr target
+
+    -- Reify the sum body
+    let ast ← reifyFinSumBody fsGoal.bodyLambda
+    trace[finsum_bound] "Reified AST: {ast}"
+
+    -- Build support proof (try Core, fallback WithInv)
+    let support ← detectSupportLevel ast
+
+    -- Build configuration
+    let precExpr := toExpr prec
+    let depthExpr := toExpr taylorDepth
+    let cfgExpr ← mkAppM ``DyadicConfig.mk #[precExpr, depthExpr, toExpr (0 : Nat)]
+
+    -- Precision proof: prec ≤ 0
+    let precLeZeroTy ← mkAppM ``LE.le #[precExpr, toExpr (0 : Int)]
+    let precLeZeroProof ← mkDecideProof precLeZeroTy
+
+    -- Build the combined certificate check expression (domain + bound in one check)
+    let checkExpr ← if fsGoal.isUpper then
+      mkAppM ``checkFinSumUpperBoundFull #[ast, fsGoal.aExpr, fsGoal.bExpr, targetExpr, cfgExpr]
+    else
+      mkAppM ``checkFinSumLowerBoundFull #[ast, fsGoal.aExpr, fsGoal.bExpr, targetExpr, cfgExpr]
+
+    let checkEqTrue ← mkAppM ``Eq #[checkExpr, Lean.mkConst ``Bool.true]
+    let checkMVar ← mkFreshExprMVar (some checkEqTrue) (kind := .syntheticOpaque)
+
+    -- Select bridge theorem based on support level and direction
+    let (bridgeThm, supportProof) := match support, fsGoal.isUpper with
+      | .core p,    true  => (``verify_finsum_upper_full, p)
+      | .core p,    false => (``verify_finsum_lower_full, p)
+      | .withInv p, true  => (``verify_finsum_upper_full_withInv, p)
+      | .withInv p, false => (``verify_finsum_lower_full_withInv, p)
+
+    -- Build bridge theorem proof (no domain proof needed — it's in the checker)
+    let proof ← mkAppM bridgeThm
+      #[ast, supportProof, fsGoal.aExpr, fsGoal.bExpr, targetExpr, cfgExpr,
+        precLeZeroProof, checkMVar]
+
+    -- Try direct assignment (works if Expr.eval defEq to user's body AND target cast matches)
+    let proofTy ← inferType proof
+    if ← isDefEq proofTy goalType then
+      goal.assign proof
+      replaceMainGoal [checkMVar.mvarId!]
+      evalTactic (← `(tactic| native_decide))
+    else
+      -- DefEq failed. Use suffices: prove the Expr.eval form, then convert to user's form.
+      trace[finsum_bound] "Direct defEq failed, using suffices + simp fallback"
+
+      -- Strategy: goal.assign (converter suffMVar) where converter : proofTy → goalType
+      let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
+      let converterMVar ← mkFreshExprMVar
+        (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
+      goal.assign (mkApp converterMVar suffMVar)
+
+      -- 1. Solve suffMVar: assign the bridge theorem proof
+      suffMVar.mvarId!.assign proof
+
+      -- 2. Solve checkMVar with native_decide
+      setGoals [checkMVar.mvarId!]
+      try
+        evalTactic (← `(tactic| native_decide))
+      catch e =>
+        throwError "finsum_bound: native_decide failed on certificate check. \
+          The bound may be too tight for precision ({prec}).\n\
+          Try: `finsum_bound 100`.\n{e.toMessageData}"
+
+      -- 3. Solve converterMVar: proofTy → goalType
+      setGoals [converterMVar.mvarId!]
+      try
+        evalTactic (← `(tactic|
+          intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv] at h ⊢;
+          norm_num at h ⊢; exact h))
+      catch _ =>
+        try
+          evalTactic (← `(tactic|
+            intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv] at h ⊢;
+            push_cast at h ⊢; linarith))
+        catch _ =>
+          throwError "finsum_bound: could not convert Expr.eval form to the user's goal.\n\
+            Proof type: {← ppExpr proofTy}\n\
+            Goal type: {← ppExpr goalType}"
+
+/-! ## Main Tactic -/
+
+/-- Prove bounds on finite sums with O(1) proof size.
+
+    Handles goals:
+    - `∑ k ∈ Finset.Icc a b, f k ≤ target`
+    - `target ≤ ∑ k ∈ Finset.Icc a b, f k`
+
+    Usage:
+    - `finsum_bound` — auto-reify, default 53-bit precision
+    - `finsum_bound 80` — auto-reify, 80-bit precision
+    - `finsum_bound using myEval (fun k _ _ => myProof k _)` — witness mode
+    - `finsum_bound using myEval myProof 100` — witness mode, 100-bit precision -/
+syntax (name := finSumBound) "finsum_bound" ("using" term:max term:max)? (num)? : tactic
+
+elab_rules : tactic
+  | `(tactic| finsum_bound using $evalTerm:term $hmem:term $[$prec:num]?) => do
+    let precision : Int := match prec with
+      | some n => -(n.getNat : Int)
+      | none => -53
+    finSumWitnessCore evalTerm hmem precision
+  | `(tactic| finsum_bound $[$prec:num]?) => do
+    let precision : Int := match prec with
+      | some n => -(n.getNat : Int)
+      | none => -53
+    finSumBoundCore precision 10
+
+end LeanCert.Tactic

--- a/LeanCert/Tactic/FinSumBound.lean
+++ b/LeanCert/Tactic/FinSumBound.lean
@@ -9,12 +9,17 @@ import LeanCert.Meta.ToExpr
 import LeanCert.Meta.ProveSupported
 import LeanCert.Tactic.IntervalAuto
 import LeanCert.Tactic.FinSumWitness
+import LeanCert.Tactic.BridgeNative
+import Mathlib.Algebra.BigOperators.Fin
 
 /-!
 # `finsum_bound`: O(1) Proof-Size Tactic for Finite Sum Bounds
 
-Proves bounds of the form `∑ k ∈ Finset.Icc a b, f k ≤ target` (or `≥`)
+Proves bounds of the form `∑ k ∈ S, f k ≤ target` (or `≥`)
 using `native_decide` with O(1) proof size, regardless of the number of terms.
+
+Supports `Finset.Icc`, `Ico`, `Ioc`, `Ioo`, `range`, explicit sets `{a,b,c}`,
+and `∑ i : Fin n, f ↑i` (auto-rewrites to `Finset.range`).
 
 ## Motivation
 
@@ -33,15 +38,23 @@ example : ∑ k ∈ Finset.Icc 1 100, (1 : ℝ) / (k * k) ≤ 2 := by
 example : (4 : ℝ) ≤ ∑ k ∈ Finset.Icc 1 100, 1 / k := by
   finsum_bound
 
+-- Fin n sums (auto-rewritten to Finset.range)
+example : ∑ i : Fin 5, Real.exp (↑i : ℝ) ≤ 234 := by
+  finsum_bound
+
 -- Higher precision
 example : ∑ k ∈ Finset.Icc 1 500, (1 : ℝ) / (k * k) ≤ 2 := by
   finsum_bound 100
+
+-- Witness mode with auto-proved membership
+example : ∑ _k ∈ Finset.Icc 1 5, (1 : ℝ) ≤ 6 := by
+  finsum_bound auto constOneEval
 ```
 
 ## Architecture
 
 ```
-Parse goal → reify body (ℕ → ℝ) to Core.Expr
+(Fin n rewrite) → Parse goal → reify body (ℕ → ℝ) to Core.Expr
   → build ExprSupportedCore or ExprSupportedWithInv proof
   → build DyadicConfig
   → checkFinSumUpperBoundFull/LowerBoundFull : Bool (domain + bound)
@@ -222,8 +235,22 @@ private def parseFinSumGoalList (goalType : Lean.Expr) : MetaM (Option FinSumGoa
 
 /-! ## Body Reification -/
 
+/-- Check if an expression is `k` or `Fin.val k` (or similar coercions) for the given fvar. -/
+private def isFVarOrFinVal (e : Lean.Expr) (kFVarId : FVarId) : Bool :=
+  if e.isFVar && e.fvarId! == kFVarId then true
+  else
+    -- Check for Fin.val k / Fin.toNat k
+    let fn := e.getAppFn
+    let args := e.getAppArgs
+    if args.size ≥ 1 then
+      let lastArg := args.back!
+      lastArg.isFVar && lastArg.fvarId! == kFVarId &&
+        (fn.isConstOf ``Fin.val || fn.isConstOf ``Fin.toNat)
+    else false
+
 /-- Replace occurrences of `Nat.cast k` (where `k` is the given fvar) with
-    a replacement expression. Checks both `Nat.cast` and `NatCast.natCast` forms. -/
+    a replacement expression. Also handles `Nat.cast (Fin.val k)` for Fin-indexed sums.
+    Checks both `Nat.cast` and `NatCast.natCast` forms. -/
 private def replaceNatCast (body : Lean.Expr) (kFVarId : FVarId)
     (replacement : Lean.Expr) : Lean.Expr :=
   body.replace fun e =>
@@ -231,7 +258,7 @@ private def replaceNatCast (body : Lean.Expr) (kFVarId : FVarId)
     let args := e.getAppArgs
     if args.size ≥ 1 then
       let lastArg := args.back!
-      if lastArg.isFVar && lastArg.fvarId! == kFVarId then
+      if isFVarOrFinVal lastArg kFVarId then
         if fn.isConstOf ``Nat.cast || fn.isConstOf ``NatCast.natCast then
           some replacement
         else none
@@ -323,51 +350,17 @@ private def finSumBoundIccCore (fsGoal : FinSumGoal) (prec : Int) (taylorDepth :
       #[ast, supportProof, fsGoal.aExpr, fsGoal.bExpr, targetExpr, cfgExpr,
         precLeZeroProof, checkMVar]
 
-    -- Try direct assignment (works if Expr.eval defEq to user's body AND target cast matches)
-    let proofTy ← inferType proof
-    if ← isDefEq proofTy goalType then
-      goal.assign proof
-      replaceMainGoal [checkMVar.mvarId!]
-      evalTactic (← `(tactic| native_decide))
-    else
-      -- DefEq failed. Use suffices: prove the Expr.eval form, then convert to user's form.
-      trace[finsum_bound] "Direct defEq failed, using suffices + simp fallback"
-
-      -- Strategy: goal.assign (converter suffMVar) where converter : proofTy → goalType
-      let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
-      let converterMVar ← mkFreshExprMVar
-        (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
-      goal.assign (mkApp converterMVar suffMVar)
-
-      -- 1. Solve suffMVar: assign the bridge theorem proof
-      suffMVar.mvarId!.assign proof
-
-      -- 2. Solve checkMVar with native_decide
-      setGoals [checkMVar.mvarId!]
-      try
-        evalTactic (← `(tactic| native_decide))
-      catch e =>
-        throwError "finsum_bound: native_decide failed on certificate check. \
-          The bound may be too tight for precision ({prec}).\n\
-          Try: `finsum_bound 100`.\n{e.toMessageData}"
-
-      -- 3. Solve converterMVar: proofTy → goalType
-      setGoals [converterMVar.mvarId!]
-      try
-        evalTactic (← `(tactic|
-          intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
-            div_eq_mul_inv] at h ⊢;
-          norm_num at h ⊢; exact h))
-      catch _ =>
-        try
-          evalTactic (← `(tactic|
-            intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
-              div_eq_mul_inv] at h ⊢;
-            push_cast at h ⊢; linarith))
-        catch _ =>
-          throwError "finsum_bound: could not convert Expr.eval form to the user's goal.\n\
-            Proof type: {← ppExpr proofTy}\n\
-            Goal type: {← ppExpr goalType}"
+    -- Apply bridge + native_decide (with converter fallback)
+    closeBridgeWithNativeDecide goal goalType proof checkMVar "finsum_bound" #[
+      do evalTactic (← `(tactic|
+        intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+          div_eq_mul_inv, ← Core.Expr.sqrt_mul_self_eq_abs] at h ⊢;
+        norm_num at h ⊢; exact h)),
+      do evalTactic (← `(tactic|
+        intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+          div_eq_mul_inv, ← Core.Expr.sqrt_mul_self_eq_abs] at h ⊢;
+        push_cast at h ⊢; linarith))
+    ]
 
 /-- Core implementation of `finsum_bound` for arbitrary Finsets (list path). -/
 private def finSumBoundListCore (fsGoal : FinSumGoalList) (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
@@ -419,47 +412,68 @@ private def finSumBoundListCore (fsGoal : FinSumGoalList) (prec : Int) (taylorDe
       #[ast, supportProof, fsGoal.finsetExpr, fsGoal.indicesExpr, targetExpr, cfgExpr,
         precLeZeroProof, checkMVar]
 
-    -- Try direct assignment
-    let proofTy ← inferType proof
-    if ← isDefEq proofTy goalType then
-      goal.assign proof
-      replaceMainGoal [checkMVar.mvarId!]
-      evalTactic (← `(tactic| native_decide))
-    else
-      -- Suffices fallback (same pattern as Icc path)
-      trace[finsum_bound] "Direct defEq failed (list path), using suffices + simp fallback"
+    -- Apply bridge + native_decide (with converter fallback)
+    closeBridgeWithNativeDecide goal goalType proof checkMVar "finsum_bound" #[
+      do evalTactic (← `(tactic|
+        intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+          div_eq_mul_inv, ← Core.Expr.sqrt_mul_self_eq_abs] at h ⊢;
+        norm_num at h ⊢; exact h)),
+      do evalTactic (← `(tactic|
+        intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
+          div_eq_mul_inv, ← Core.Expr.sqrt_mul_self_eq_abs] at h ⊢;
+        push_cast at h ⊢; linarith))
+    ]
 
-      let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
-      let converterMVar ← mkFreshExprMVar
-        (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
-      goal.assign (mkApp converterMVar suffMVar)
-
-      suffMVar.mvarId!.assign proof
-
-      setGoals [checkMVar.mvarId!]
-      try
-        evalTactic (← `(tactic| native_decide))
-      catch e =>
-        throwError "finsum_bound: native_decide failed on certificate check. \
-          The bound may be too tight for precision ({prec}).\n\
-          Try: `finsum_bound 100`.\n{e.toMessageData}"
-
-      setGoals [converterMVar.mvarId!]
-      try
-        evalTactic (← `(tactic|
-          intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
-            div_eq_mul_inv] at h ⊢;
-          norm_num at h ⊢; exact h))
-      catch _ =>
-        try
-          evalTactic (← `(tactic|
-            intro h; simp only [Core.Expr.eval, Engine.sumBodyRealEnv,
-              div_eq_mul_inv] at h ⊢;
-            push_cast at h ⊢; linarith))
-        catch _ =>
-          throwError "finsum_bound: could not convert Expr.eval form to the user's goal.\n\
-            Proof type: {← ppExpr proofTy}\n\
-            Goal type: {← ppExpr goalType}"
+/-- Try to detect `Finset.sum Finset.univ f` where `univ` is over `Fin n` in the goal,
+    and rewrite using `Fin.sum_univ_eq_sum_range f` to convert to a `Finset.range` sum.
+    Unlike `simp only [Fin.sum_univ_eq_sum_range]`, this handles arbitrary bodies
+    by explicitly providing the function argument `f`. -/
+private def tryRewriteFinSum : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+  let_expr LE.le _ _ lhs rhs := goalType | return
+  -- Check both sides for a Fin sum
+  let findFinSum (e : Lean.Expr) : Option Lean.Expr := do
+    let fn := e.getAppFn
+    let args := e.getAppArgs
+    if fn.isConstOf ``Finset.sum && args.size ≥ 5 then
+      let s := args[3]!  -- the Finset
+      let f := args[4]!  -- the body
+      let sfn := s.getAppFn
+      if sfn.isConstOf ``Finset.univ then
+        let sargs := s.getAppArgs
+        let typeArg := sargs[0]!  -- should be Fin n
+        if typeArg.isAppOf ``Fin then
+          return f
+    none
+  let bodyOpt := findFinSum lhs <|> findFinSum rhs
+  let some body := bodyOpt | return
+  -- body : Fin n → β. We need f : ℕ → β such that body i = f (Fin.val i).
+  -- Extract by: lambdaTelescope body, replace Fin.val i with fresh ℕ var.
+  let f ← lambdaTelescope body fun vars innerBody => do
+    if vars.size < 1 then return body
+    let finVar := vars[0]!
+    let natTy := Lean.mkConst ``Nat
+    withLocalDeclD `k natTy fun k => do
+      -- Replace all occurrences of Fin.val finVar (and the composed Fin→ℕ coercion)
+      -- with k
+      let body' := innerBody.replace fun e =>
+        let fn := e.getAppFn
+        let args := e.getAppArgs
+        if args.size ≥ 1 then
+          let lastArg := args.back!
+          if lastArg.isFVar && lastArg.fvarId! == finVar.fvarId! then
+            if fn.isConstOf ``Fin.val || fn.isConstOf ``Fin.toNat then
+              some k
+            else none
+          else none
+        else none
+      mkLambdaFVars #[k] body'
+  -- Rewrite: rw [Fin.sum_univ_eq_sum_range f]
+  let rwLemma ← mkAppM ``Fin.sum_univ_eq_sum_range #[f]
+  let result ← goal.rewrite goalType rwLemma
+  let newGoal ← goal.replaceTargetEq result.eNew result.eqProof
+  replaceMainGoal (newGoal :: result.mvarIds)
 
 /-- Main dispatch: try Icc path first, then list path. -/
 private def finSumBoundCore (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
@@ -483,25 +497,39 @@ private def finSumBoundCore (prec : Int) (taylorDepth : Nat) : TacticM Unit := d
 
     Handles goals:
     - `∑ k ∈ Finset.Icc a b, f k ≤ target` (and Ico, Ioc, Ioo, range, {a,b,c})
+    - `∑ i : Fin n, f i ≤ target` (auto-rewrites to `Finset.range` via `tryRewriteFinSum`)
     - `target ≤ ∑ k ∈ S, f k`
 
     Usage:
     - `finsum_bound` — auto-reify, default 53-bit precision
     - `finsum_bound 80` — auto-reify, 80-bit precision
     - `finsum_bound using myEval (fun k _ _ => myProof k _)` — witness mode
-    - `finsum_bound using myEval myProof 100` — witness mode, 100-bit precision -/
+    - `finsum_bound using myEval myProof 100` — witness mode, 100-bit precision
+    - `finsum_bound auto myEval` — witness mode, auto-prove membership
+    - `finsum_bound auto myEval 80` — auto-hmem, 80-bit precision -/
 syntax (name := finSumBound) "finsum_bound" ("using" term:max term:max)? (num)? : tactic
+syntax (name := finSumBoundAuto) "finsum_bound" "auto" term:max (num)? : tactic
 
 elab_rules : tactic
   | `(tactic| finsum_bound using $evalTerm:term $hmem:term $[$prec:num]?) => do
     let precision : Int := match prec with
       | some n => -(n.getNat : Int)
       | none => -53
+    -- Try rewriting Fin n sums to Finset.range before witness dispatch
+    try tryRewriteFinSum catch _ => pure ()
     finSumWitnessCore evalTerm hmem precision
   | `(tactic| finsum_bound $[$prec:num]?) => do
     let precision : Int := match prec with
       | some n => -(n.getNat : Int)
       | none => -53
+    -- Try rewriting Fin n sums to Finset.range before main dispatch
+    try tryRewriteFinSum catch _ => pure ()
     finSumBoundCore precision 10
+  | `(tactic| finsum_bound auto $evalTerm:term $[$prec:num]?) => do
+    let precision : Int := match prec with
+      | some n => -(n.getNat : Int)
+      | none => -53
+    try tryRewriteFinSum catch _ => pure ()
+    finSumWitnessAutoCore evalTerm precision
 
 end LeanCert.Tactic

--- a/LeanCert/Tactic/FinSumWitness.lean
+++ b/LeanCert/Tactic/FinSumWitness.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Lean
+import LeanCert.Engine.WitnessSum
+import LeanCert.Tactic.IntervalAuto
+
+/-!
+# `finsum_witness`: Tactic for Witness-Based Finite Sum Bounds
+
+Proves bounds of the form `∑ k ∈ Finset.Icc a b, f k ≤ target` (or `≥`)
+using a user-provided per-term evaluator + correctness proof,
+via `native_decide` with O(1) proof size.
+
+## Motivation
+
+`finsum_bound` auto-reifies sum bodies to `Core.Expr`, which covers +, *, inv, exp, sin,
+log, etc. Functions outside `Core.Expr` (like `rpow` in BKLNW's `x^(1/k - 1/3)`) need
+a custom evaluator. `finsum_witness` lets the user provide:
+1. A computable evaluator `Nat → DyadicConfig → IntervalDyadic`
+2. A correctness proof that each term is contained in the evaluator's output
+
+## Usage
+
+```lean
+-- User defines evaluator + correctness proof:
+def myEval (k : Nat) (cfg : DyadicConfig) : IntervalDyadic := ...
+theorem myEval_correct (k : Nat) (cfg : DyadicConfig) : myF k ∈ myEval k cfg := ...
+
+-- Prove bound:
+example : ∑ k ∈ Finset.Icc 1 100, myF k ≤ target := by
+  finsum_witness myEval (fun k _ _ => myEval_correct k _)
+```
+
+## Architecture
+
+```
+Parse goal → extract a, b, body, target
+  → elaborate user's evalTerm and hmem
+  → build DyadicConfig
+  → checkWitnessSumUpperBound/LowerBound : Bool
+  → native_decide
+  → verify_witness_sum_upper/lower (bridge theorem)
+```
+-/
+
+open Lean Meta Elab Tactic Term
+
+namespace LeanCert.Tactic
+
+open LeanCert.Core
+open LeanCert.Engine
+
+initialize registerTraceClass `finsum_witness
+
+/-! ## Goal Parsing -/
+
+/-- Result of parsing a finite sum bound goal. -/
+private structure WitnessGoal where
+  /-- Lower range bound (ℕ expression) -/
+  aExpr : Lean.Expr
+  /-- Upper range bound (ℕ expression) -/
+  bExpr : Lean.Expr
+  /-- Sum body as lambda (ℕ → ℝ) -/
+  bodyLambda : Lean.Expr
+  /-- Bound target (ℝ expression) -/
+  targetExpr : Lean.Expr
+  /-- true for `sum ≤ target`, false for `target ≤ sum` -/
+  isUpper : Bool
+
+/-- Extract `(a, b, f)` from `Finset.sum (Finset.Icc a b) f`. -/
+private def extractFinsetIccSum' (e : Lean.Expr) : Option (Lean.Expr × Lean.Expr × Lean.Expr) :=
+  let fn := e.getAppFn
+  let args := e.getAppArgs
+  -- Finset.sum : {β} → {α} → [AddCommMonoid β] → Finset α → (α → β) → β
+  if fn.isConstOf ``Finset.sum && args.size ≥ 5 then
+    let s := args[3]!
+    let f := args[4]!
+    let sfn := s.getAppFn
+    let sargs := s.getAppArgs
+    -- Finset.Icc : {α} → [Preorder α] → [LocallyFiniteOrder α] → α → α → Finset α
+    if sfn.isConstOf ``Finset.Icc && sargs.size ≥ 5 then
+      some (sargs[3]!, sargs[4]!, f)
+    else
+      none
+  else
+    none
+
+/-- Parse a goal of the form `∑ k ∈ Finset.Icc a b, f k ≤ target`
+    or `target ≤ ∑ k ∈ Finset.Icc a b, f k`. -/
+private def parseWitnessGoal (goalType : Lean.Expr) : Option WitnessGoal := do
+  let_expr LE.le _ _ lhs rhs := goalType | none
+  if let some (a, b, f) := extractFinsetIccSum' lhs then
+    return { aExpr := a, bExpr := b, bodyLambda := f, targetExpr := rhs, isUpper := true }
+  if let some (a, b, f) := extractFinsetIccSum' rhs then
+    return { aExpr := a, bExpr := b, bodyLambda := f, targetExpr := lhs, isUpper := false }
+  none
+
+/-! ## Tactic Implementation -/
+
+/-- Core implementation of `finsum_witness`. -/
+def finSumWitnessCore (evalTermSyn hmemSyn : Syntax) (prec : Int) : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+
+  let some wGoal := parseWitnessGoal goalType
+    | throwError "finsum_witness: goal is not of the form \
+        `∑ k ∈ Finset.Icc a b, f k ≤ target` or `target ≤ ∑ k ∈ Finset.Icc a b, f k`"
+
+  goal.withContext do
+    -- Extract target as rational
+    let some target ← Auto.extractRatFromReal wGoal.targetExpr
+      | throwError "finsum_witness: could not extract rational from bound \
+          `{← ppExpr wGoal.targetExpr}`"
+    let targetExpr := toExpr target
+
+    -- Build configuration
+    let precExpr := toExpr prec
+    let depthExpr := toExpr (10 : Nat)
+    let cfgExpr ← mkAppM ``DyadicConfig.mk #[precExpr, depthExpr, toExpr (0 : Nat)]
+
+    -- Elaborate user's evalTerm
+    let evalTermTy ← mkArrow (Lean.mkConst ``Nat)
+      (← mkArrow (Lean.mkConst ``DyadicConfig) (Lean.mkConst ``IntervalDyadic))
+    let evalTermExpr ← Tactic.elabTermEnsuringType evalTermSyn (some evalTermTy)
+
+    -- Build the expected type for hmem:
+    --   ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg
+    let natTy := Lean.mkConst ``Nat
+    let hmemTy ← withLocalDeclD `k natTy fun k => do
+      let akTy ← mkAppM ``LE.le #[wGoal.aExpr, k]
+      let kbTy ← mkAppM ``LE.le #[k, wGoal.bExpr]
+      let fk := (Lean.mkApp wGoal.bodyLambda k).headBeta
+      let evalk := Lean.mkApp (Lean.mkApp evalTermExpr k) cfgExpr
+      -- Membership.mem takes (container, element) order: mem I x
+      let memTy ← mkAppM ``Membership.mem #[evalk, fk]
+      let body ← mkArrow akTy (← mkArrow kbTy memTy)
+      mkForallFVars #[k] body
+
+    trace[finsum_witness] "Expected hmem type: {hmemTy}"
+
+    -- Elaborate hmem against the expected type
+    let hmemExpr ← Tactic.elabTermEnsuringType hmemSyn (some hmemTy)
+
+    -- Build check expression and native_decide metavar
+    let checkExpr ← if wGoal.isUpper then
+      mkAppM ``checkWitnessSumUpperBound
+        #[evalTermExpr, wGoal.aExpr, wGoal.bExpr, targetExpr, cfgExpr]
+    else
+      mkAppM ``checkWitnessSumLowerBound
+        #[evalTermExpr, wGoal.aExpr, wGoal.bExpr, targetExpr, cfgExpr]
+
+    let checkEqTrue ← mkAppM ``Eq #[checkExpr, Lean.mkConst ``Bool.true]
+    let checkMVar ← mkFreshExprMVar (some checkEqTrue) (kind := .syntheticOpaque)
+
+    -- Build bridge theorem proof
+    let bridgeThm := if wGoal.isUpper then
+      ``verify_witness_sum_upper
+    else
+      ``verify_witness_sum_lower
+    let proof ← mkAppM bridgeThm
+      #[wGoal.bodyLambda, evalTermExpr, wGoal.aExpr, wGoal.bExpr,
+        targetExpr, cfgExpr, hmemExpr, checkMVar]
+
+    -- Try direct assignment
+    let proofTy ← inferType proof
+    if ← isDefEq proofTy goalType then
+      goal.assign proof
+      replaceMainGoal [checkMVar.mvarId!]
+      evalTactic (← `(tactic| native_decide))
+    else
+      -- DefEq failed. Use suffices: prove the bridge form, then convert.
+      trace[finsum_witness] "Direct defEq failed, using suffices fallback"
+
+      let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
+      let converterMVar ← mkFreshExprMVar
+        (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
+      goal.assign (mkApp converterMVar suffMVar)
+
+      -- 1. Solve suffMVar: assign the bridge theorem proof
+      suffMVar.mvarId!.assign proof
+
+      -- 2. Solve checkMVar with native_decide
+      setGoals [checkMVar.mvarId!]
+      try
+        evalTactic (← `(tactic| native_decide))
+      catch e =>
+        throwError "finsum_witness: native_decide failed on certificate check. \
+          The bound may be too tight for precision ({prec}).\n\
+          Try: `finsum_witness ... 100`.\n{e.toMessageData}"
+
+      -- 3. Solve converterMVar: proofTy → goalType
+      setGoals [converterMVar.mvarId!]
+      try
+        evalTactic (← `(tactic| intro h; exact h))
+      catch _ =>
+        try
+          evalTactic (← `(tactic| intro h; push_cast at h ⊢; linarith))
+        catch _ =>
+          throwError "finsum_witness: could not convert proof type to goal type.\n\
+            Proof type: {← ppExpr proofTy}\n\
+            Goal type: {← ppExpr goalType}"
+
+/-! ## Main Tactic -/
+
+/-- Prove bounds on finite sums using a witness evaluator.
+
+    The user provides:
+    - `evalTerm` : `Nat → DyadicConfig → IntervalDyadic` — computable per-term evaluator
+    - `hmem` : proof that `∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg`
+
+    Usage:
+    - `finsum_witness myEval using (fun k _ _ => myCorrectness k _)`
+    - `finsum_witness myEval using myProof 100` — with 100-bit precision -/
+elab "finsum_witness" evalTerm:term "using" hmem:term prec:(num)? : tactic => do
+  let precision : Int := match prec with
+    | some n => -(n.getNat : Int)
+    | none => -53
+  finSumWitnessCore evalTerm hmem precision
+
+end LeanCert.Tactic

--- a/LeanCert/Tactic/FinSumWitness.lean
+++ b/LeanCert/Tactic/FinSumWitness.lean
@@ -6,6 +6,7 @@ Authors: LeanCert Contributors
 import Lean
 import LeanCert.Engine.WitnessSum
 import LeanCert.Tactic.IntervalAuto
+import LeanCert.Tactic.BridgeNative
 
 /-!
 # `finsum_witness`: Tactic for Witness-Based Finite Sum Bounds
@@ -256,39 +257,11 @@ private def finSumWitnessIccCore (wGoal : WitnessGoal) (evalTermSyn hmemSyn : Sy
       #[wGoal.bodyLambda, evalTermExpr, wGoal.aExpr, wGoal.bExpr,
         targetExpr, cfgExpr, hmemExpr, checkMVar]
 
-    let proofTy ← inferType proof
-    if ← isDefEq proofTy goalType then
-      goal.assign proof
-      replaceMainGoal [checkMVar.mvarId!]
-      evalTactic (← `(tactic| native_decide))
-    else
-      trace[finsum_witness] "Direct defEq failed, using suffices fallback"
-
-      let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
-      let converterMVar ← mkFreshExprMVar
-        (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
-      goal.assign (mkApp converterMVar suffMVar)
-
-      suffMVar.mvarId!.assign proof
-
-      setGoals [checkMVar.mvarId!]
-      try
-        evalTactic (← `(tactic| native_decide))
-      catch e =>
-        throwError "finsum_witness: native_decide failed on certificate check. \
-          The bound may be too tight for precision ({prec}).\n\
-          Try: `finsum_witness ... 100`.\n{e.toMessageData}"
-
-      setGoals [converterMVar.mvarId!]
-      try
-        evalTactic (← `(tactic| intro h; exact h))
-      catch _ =>
-        try
-          evalTactic (← `(tactic| intro h; push_cast at h ⊢; linarith))
-        catch _ =>
-          throwError "finsum_witness: could not convert proof type to goal type.\n\
-            Proof type: {← ppExpr proofTy}\n\
-            Goal type: {← ppExpr goalType}"
+    -- Apply bridge + native_decide (with converter fallback)
+    closeBridgeWithNativeDecide goal goalType proof checkMVar "finsum_witness" #[
+      do evalTactic (← `(tactic| intro h; exact h)),
+      do evalTactic (← `(tactic| intro h; push_cast at h ⊢; linarith))
+    ]
 
 /-- Core implementation of `finsum_witness` for arbitrary Finsets (list path). -/
 private def finSumWitnessListCore (wGoal : WitnessGoalList) (evalTermSyn hmemSyn : Syntax)
@@ -343,39 +316,11 @@ private def finSumWitnessListCore (wGoal : WitnessGoalList) (evalTermSyn hmemSyn
       #[wGoal.bodyLambda, evalTermExpr, wGoal.finsetExpr, wGoal.indicesExpr,
         targetExpr, cfgExpr, hmemExpr, checkMVar]
 
-    let proofTy ← inferType proof
-    if ← isDefEq proofTy goalType then
-      goal.assign proof
-      replaceMainGoal [checkMVar.mvarId!]
-      evalTactic (← `(tactic| native_decide))
-    else
-      trace[finsum_witness] "Direct defEq failed (list path), using suffices fallback"
-
-      let suffMVar ← mkFreshExprMVar (some proofTy) (kind := .syntheticOpaque)
-      let converterMVar ← mkFreshExprMVar
-        (some (← mkArrow proofTy goalType)) (kind := .syntheticOpaque)
-      goal.assign (mkApp converterMVar suffMVar)
-
-      suffMVar.mvarId!.assign proof
-
-      setGoals [checkMVar.mvarId!]
-      try
-        evalTactic (← `(tactic| native_decide))
-      catch e =>
-        throwError "finsum_witness: native_decide failed on certificate check. \
-          The bound may be too tight for precision ({prec}).\n\
-          Try: `finsum_witness ... 100`.\n{e.toMessageData}"
-
-      setGoals [converterMVar.mvarId!]
-      try
-        evalTactic (← `(tactic| intro h; exact h))
-      catch _ =>
-        try
-          evalTactic (← `(tactic| intro h; push_cast at h ⊢; linarith))
-        catch _ =>
-          throwError "finsum_witness: could not convert proof type to goal type.\n\
-            Proof type: {← ppExpr proofTy}\n\
-            Goal type: {← ppExpr goalType}"
+    -- Apply bridge + native_decide (with converter fallback)
+    closeBridgeWithNativeDecide goal goalType proof checkMVar "finsum_witness" #[
+      do evalTactic (← `(tactic| intro h; exact h)),
+      do evalTactic (← `(tactic| intro h; push_cast at h ⊢; linarith))
+    ]
 
 /-- Main dispatch: try Icc path first, then list path. -/
 def finSumWitnessCore (evalTermSyn hmemSyn : Syntax) (prec : Int) : TacticM Unit := do
@@ -393,6 +338,193 @@ def finSumWitnessCore (evalTermSyn hmemSyn : Syntax) (prec : Int) : TacticM Unit
     return
 
   throwError "finsum_witness: goal is not of the form \
+    `∑ k ∈ S, f k ≤ target` or `target ≤ ∑ k ∈ S, f k` \
+    where S is a recognized Finset (Icc, Ico, Ioc, Ioo, range, or explicit)"
+
+/-- Try to auto-prove an hmem metavar using several strategies.
+    Works best when the evaluator returns singletons or tight intervals
+    where membership reduces to decidable ℚ comparisons. -/
+private def tryAutoProveHmem (hmemMVar : MVarId) : TacticM Unit := do
+  -- Strategy 1: simp [mem_def] + split into ≤ components + cast to ℚ + native_decide
+  -- Works for constant evaluators (no free variables in the comparison)
+  setGoals [hmemMVar]
+  try
+    evalTactic (← `(tactic|
+      intros;
+      simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton];
+      refine ⟨?_, ?_⟩ <;> exact_mod_cast (by native_decide)))
+    return
+  catch _ => pure ()
+  -- Strategy 2: interval_cases to enumerate k, then per-case native_decide
+  -- Works for k-dependent evaluators on Icc (bounds are concrete literals)
+  setGoals [hmemMVar]
+  try
+    evalTactic (← `(tactic|
+      intro k hlo hhi;
+      interval_cases k <;> {
+        simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton];
+        refine ⟨?_, ?_⟩ <;> exact_mod_cast (by native_decide)
+      }))
+    return
+  catch _ => pure ()
+  -- Strategy 3: fin_cases for list path (1 premise: k ∈ S)
+  setGoals [hmemMVar]
+  try
+    evalTactic (← `(tactic|
+      intro k hk;
+      fin_cases hk <;> {
+        simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton];
+        refine ⟨?_, ?_⟩ <;> exact_mod_cast (by native_decide)
+      }))
+    return
+  catch _ => pure ()
+  -- All strategies failed
+  let hmemTy ← hmemMVar.getType
+  throwError "finsum_bound auto: could not auto-prove membership.\n\
+    Expected type: {← ppExpr hmemTy}\n\
+    Provide hmem explicitly: `finsum_bound using evalTerm hmemProof`"
+
+/-- Core implementation of `finsum_bound auto` for Icc goals. -/
+private def finSumWitnessAutoIccCore (wGoal : WitnessGoal) (evalTermSyn : Syntax)
+    (prec : Int) : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+
+  goal.withContext do
+    let some target ← Auto.extractRatFromReal wGoal.targetExpr
+      | throwError "finsum_bound auto: could not extract rational from bound \
+          `{← ppExpr wGoal.targetExpr}`"
+    let targetExpr := toExpr target
+
+    let precExpr := toExpr prec
+    let depthExpr := toExpr (10 : Nat)
+    let cfgExpr ← mkAppM ``DyadicConfig.mk #[precExpr, depthExpr, toExpr (0 : Nat)]
+
+    let evalTermTy ← mkArrow (Lean.mkConst ``Nat)
+      (← mkArrow (Lean.mkConst ``DyadicConfig) (Lean.mkConst ``IntervalDyadic))
+    let evalTermExpr ← Tactic.elabTermEnsuringType evalTermSyn (some evalTermTy)
+
+    -- Build hmem type: ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg
+    let natTy := Lean.mkConst ``Nat
+    let hmemTy ← withLocalDeclD `k natTy fun k => do
+      let akTy ← mkAppM ``LE.le #[wGoal.aExpr, k]
+      let kbTy ← mkAppM ``LE.le #[k, wGoal.bExpr]
+      let fk := (Lean.mkApp wGoal.bodyLambda k).headBeta
+      let evalk := Lean.mkApp (Lean.mkApp evalTermExpr k) cfgExpr
+      let memTy ← mkAppM ``Membership.mem #[evalk, fk]
+      let body ← mkArrow akTy (← mkArrow kbTy memTy)
+      mkForallFVars #[k] body
+
+    -- Auto-prove hmem
+    let hmemMVar ← mkFreshExprMVar (some hmemTy) (kind := .syntheticOpaque)
+    let savedGoals ← getGoals
+    tryAutoProveHmem hmemMVar.mvarId!
+    setGoals savedGoals
+
+    let hmemExpr := hmemMVar
+
+    -- Rest is identical to finSumWitnessIccCore
+    let checkExpr ← if wGoal.isUpper then
+      mkAppM ``checkWitnessSumUpperBound
+        #[evalTermExpr, wGoal.aExpr, wGoal.bExpr, targetExpr, cfgExpr]
+    else
+      mkAppM ``checkWitnessSumLowerBound
+        #[evalTermExpr, wGoal.aExpr, wGoal.bExpr, targetExpr, cfgExpr]
+
+    let checkEqTrue ← mkAppM ``Eq #[checkExpr, Lean.mkConst ``Bool.true]
+    let checkMVar ← mkFreshExprMVar (some checkEqTrue) (kind := .syntheticOpaque)
+
+    let bridgeThm := if wGoal.isUpper then
+      ``verify_witness_sum_upper
+    else
+      ``verify_witness_sum_lower
+    let proof ← mkAppM bridgeThm
+      #[wGoal.bodyLambda, evalTermExpr, wGoal.aExpr, wGoal.bExpr,
+        targetExpr, cfgExpr, hmemExpr, checkMVar]
+
+    -- Apply bridge + native_decide (with converter fallback)
+    closeBridgeWithNativeDecide goal goalType proof checkMVar "finsum_bound auto" #[
+      do evalTactic (← `(tactic| intro h; exact h)),
+      do evalTactic (← `(tactic| intro h; push_cast at h ⊢; linarith))
+    ]
+
+/-- Core implementation of `finsum_bound auto` for arbitrary Finsets (list path). -/
+private def finSumWitnessAutoListCore (wGoal : WitnessGoalList) (evalTermSyn : Syntax)
+    (prec : Int) : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+
+  goal.withContext do
+    let some target ← Auto.extractRatFromReal wGoal.targetExpr
+      | throwError "finsum_bound auto: could not extract rational from bound \
+          `{← ppExpr wGoal.targetExpr}`"
+    let targetExpr := toExpr target
+
+    let precExpr := toExpr prec
+    let depthExpr := toExpr (10 : Nat)
+    let cfgExpr ← mkAppM ``DyadicConfig.mk #[precExpr, depthExpr, toExpr (0 : Nat)]
+
+    let evalTermTy ← mkArrow (Lean.mkConst ``Nat)
+      (← mkArrow (Lean.mkConst ``DyadicConfig) (Lean.mkConst ``IntervalDyadic))
+    let evalTermExpr ← Tactic.elabTermEnsuringType evalTermSyn (some evalTermTy)
+
+    -- Build hmem type: ∀ k, k ∈ S → f k ∈ evalTerm k cfg
+    let natTy := Lean.mkConst ``Nat
+    let hmemTy ← withLocalDeclD `k natTy fun k => do
+      let memSTy ← mkAppM ``Membership.mem #[wGoal.finsetExpr, k]
+      let fk := (Lean.mkApp wGoal.bodyLambda k).headBeta
+      let evalk := Lean.mkApp (Lean.mkApp evalTermExpr k) cfgExpr
+      let memEvalTy ← mkAppM ``Membership.mem #[evalk, fk]
+      let body ← mkArrow memSTy memEvalTy
+      mkForallFVars #[k] body
+
+    -- Auto-prove hmem
+    let hmemMVar ← mkFreshExprMVar (some hmemTy) (kind := .syntheticOpaque)
+    let savedGoals ← getGoals
+    tryAutoProveHmem hmemMVar.mvarId!
+    setGoals savedGoals
+
+    let hmemExpr := hmemMVar
+
+    -- Rest is identical to finSumWitnessListCore
+    let checkExpr ← if wGoal.isUpper then
+      mkAppM ``checkWitnessSumUpperBoundListFull
+        #[evalTermExpr, wGoal.finsetExpr, wGoal.indicesExpr, targetExpr, cfgExpr]
+    else
+      mkAppM ``checkWitnessSumLowerBoundListFull
+        #[evalTermExpr, wGoal.finsetExpr, wGoal.indicesExpr, targetExpr, cfgExpr]
+
+    let checkEqTrue ← mkAppM ``Eq #[checkExpr, Lean.mkConst ``Bool.true]
+    let checkMVar ← mkFreshExprMVar (some checkEqTrue) (kind := .syntheticOpaque)
+
+    let bridgeThm := if wGoal.isUpper then
+      ``verify_witness_sum_upper_list_full
+    else
+      ``verify_witness_sum_lower_list_full
+    let proof ← mkAppM bridgeThm
+      #[wGoal.bodyLambda, evalTermExpr, wGoal.finsetExpr, wGoal.indicesExpr,
+        targetExpr, cfgExpr, hmemExpr, checkMVar]
+
+    -- Apply bridge + native_decide (with converter fallback)
+    closeBridgeWithNativeDecide goal goalType proof checkMVar "finsum_bound auto" #[
+      do evalTactic (← `(tactic| intro h; exact h)),
+      do evalTactic (← `(tactic| intro h; push_cast at h ⊢; linarith))
+    ]
+
+/-- Main dispatch for auto-hmem mode: try Icc path first, then list path. -/
+def finSumWitnessAutoCore (evalTermSyn : Syntax) (prec : Int) : TacticM Unit := do
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+
+  if let some wGoal := parseWitnessGoal goalType then
+    finSumWitnessAutoIccCore wGoal evalTermSyn prec
+    return
+
+  if let some wGoalList := ← parseWitnessGoalList goalType then
+    finSumWitnessAutoListCore wGoalList evalTermSyn prec
+    return
+
+  throwError "finsum_bound auto: goal is not of the form \
     `∑ k ∈ S, f k ≤ target` or `target ≤ ∑ k ∈ S, f k` \
     where S is a recognized Finset (Icc, Ico, Ioc, Ioo, range, or explicit)"
 

--- a/LeanCert/Tactic/IntervalAuto/Bound.lean
+++ b/LeanCert/Tactic/IntervalAuto/Bound.lean
@@ -283,9 +283,9 @@ where
               -- Handle power expansion (x^2 = x*x, x^3 = x*x*x, etc.)
               if ← tryClose (evalTactic (← `(tactic| simp only [sq, pow_two, pow_succ, pow_zero, pow_one, one_mul, mul_one]))) then continue
               -- Handle Expr.eval unfolding - unfolds Expr.eval to raw arithmetic, then uses ring to close
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; ring))) then continue
               -- Same but with push_cast for rational coercion issues
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; push_cast; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; push_cast; ring))) then continue
               -- Handle decimal bounds (2.72 = ↑(Rat.divInt 68 25))
               -- norm_num converts 2.72 to 68/25, then simp+push_cast closes the equality
               if ← tryClose (evalTactic (← `(tactic| norm_num; simp only [Rat.divInt_eq_div]; push_cast; rfl))) then continue
@@ -338,8 +338,8 @@ where
               if ← tryClose (evalTactic (← `(tactic| rfl))) then continue
               if ← tryClose (evalTactic (← `(tactic| norm_cast))) then continue
               if ← tryClose (evalTactic (← `(tactic| norm_num))) then continue
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; ring))) then continue
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; push_cast; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; push_cast; ring))) then continue
               logWarning m!"interval_bound: Could not close side goal: {← g.getType}"
 
   /-- Prove ∀ x ∈ I, c ≤ f x -/
@@ -426,9 +426,9 @@ where
               -- Handle power expansion (x^2 = x*x, x^3 = x*x*x, etc.)
               if ← tryClose (evalTactic (← `(tactic| simp only [sq, pow_two, pow_succ, pow_zero, pow_one, one_mul, mul_one]))) then continue
               -- Handle Expr.eval unfolding - unfolds Expr.eval to raw arithmetic, then uses ring to close
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; ring))) then continue
               -- Same but with push_cast for rational coercion issues
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; push_cast; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; push_cast; ring))) then continue
               -- Handle decimal bounds (2.72 = ↑(Rat.divInt 68 25)) - fallback tactics
               if ← tryClose (evalTactic (← `(tactic| simp only [Rat.divInt_eq_div]; push_cast; rfl))) then continue
               if ← tryClose (evalTactic (← `(tactic| simp [Rat.divInt_eq_div]))) then continue
@@ -478,8 +478,8 @@ where
               if ← tryClose (evalTactic (← `(tactic| rfl))) then continue
               if ← tryClose (evalTactic (← `(tactic| norm_cast))) then continue
               if ← tryClose (evalTactic (← `(tactic| norm_num))) then continue
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; ring))) then continue
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; push_cast; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; push_cast; ring))) then continue
               logWarning m!"interval_bound: Could not close side goal: {← g.getType}"
 
   /-- Prove ∀ x ∈ I, f x < c -/
@@ -566,9 +566,9 @@ where
               -- Handle power expansion (x^2 = x*x, x^3 = x*x*x, etc.)
               if ← tryClose (evalTactic (← `(tactic| simp only [sq, pow_two, pow_succ, pow_zero, pow_one, one_mul, mul_one]))) then continue
               -- Handle Expr.eval unfolding - unfolds Expr.eval to raw arithmetic, then uses ring to close
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; ring))) then continue
               -- Same but with push_cast for rational coercion issues
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; push_cast; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; push_cast; ring))) then continue
               -- Handle decimal bounds - fallback tactics
               if ← tryClose (evalTactic (← `(tactic| simp only [Rat.divInt_eq_div]; push_cast; rfl))) then continue
               if ← tryClose (evalTactic (← `(tactic| simp [Rat.divInt_eq_div]))) then continue
@@ -678,9 +678,9 @@ where
               -- Handle power expansion (x^2 = x*x, x^3 = x*x*x, etc.)
               if ← tryClose (evalTactic (← `(tactic| simp only [sq, pow_two, pow_succ, pow_zero, pow_one, one_mul, mul_one]))) then continue
               -- Handle Expr.eval unfolding - unfolds Expr.eval to raw arithmetic, then uses ring to close
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; ring))) then continue
               -- Same but with push_cast for rational coercion issues
-              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub]; push_cast; ring))) then continue
+              if ← tryClose (evalTactic (← `(tactic| simp only [LeanCert.Core.Expr.eval_add, LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg, LeanCert.Core.Expr.eval_const, LeanCert.Core.Expr.eval_var, LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos, LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_sub, ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs]; push_cast; ring))) then continue
               -- Handle decimal bounds - fallback tactics
               if ← tryClose (evalTactic (← `(tactic| simp only [Rat.divInt_eq_div]; push_cast; rfl))) then continue
               if ← tryClose (evalTactic (← `(tactic| simp [Rat.divInt_eq_div]))) then continue

--- a/LeanCert/Tactic/IntervalAuto/Extract.lean
+++ b/LeanCert/Tactic/IntervalAuto/Extract.lean
@@ -127,7 +127,7 @@ where
     -- Case 1: Rat.cast q or RatCast.ratCast q
     if fn.isConstOf ``Rat.cast || fn.isConstOf ``RatCast.ratCast then
       if args.size > 0 then
-        return ← extractRatFromRat args.back!
+        return ← LeanCert.Meta.toRat? args.back!
       else return none
 
     -- Case 2: OfNat.ofNat (for numeric literals like 2 : ℝ)

--- a/LeanCert/Tactic/IntervalAuto/PointIneq.lean
+++ b/LeanCert/Tactic/IntervalAuto/PointIneq.lean
@@ -123,6 +123,7 @@ def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr) (taylorDep
                      LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg,
                      LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_log,
                      LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos,
+                     ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs,
                      Rat.cast_ofNat, Rat.cast_intCast, Rat.cast_natCast,
                      Rat.cast_zero, sub_zero, zero_sub, neg_neg] at h0
         )))
@@ -181,6 +182,7 @@ def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr) (taylorDep
                      LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg,
                      LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_log,
                      LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos,
+                     ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs,
                      Rat.cast_ofNat, Rat.cast_intCast, Rat.cast_natCast] at h0
         )))
         evalTactic (← `(tactic| exact h0))
@@ -198,6 +200,7 @@ def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr) (taylorDep
                      LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg,
                      LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_log,
                      LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos,
+                     ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs,
                      Rat.cast_ofNat, Rat.cast_intCast, Rat.cast_natCast,
                      Rat.divInt_eq_div] at h0;
           convert h0 using 1 <;> norm_num
@@ -221,6 +224,7 @@ def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr) (taylorDep
                      LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg,
                      LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_log,
                      LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos,
+                     ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs,
                      Rat.cast_ofNat, Rat.cast_intCast, Rat.cast_natCast,
                      Rat.divInt_eq_div] at h0;
           exact h0
@@ -241,6 +245,7 @@ def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr) (taylorDep
                      LeanCert.Core.Expr.eval_mul, LeanCert.Core.Expr.eval_neg,
                      LeanCert.Core.Expr.eval_exp, LeanCert.Core.Expr.eval_log,
                      LeanCert.Core.Expr.eval_sin, LeanCert.Core.Expr.eval_cos,
+                     ← LeanCert.Core.Expr.sqrt_mul_self_eq_abs,
                      Rat.cast_ofNat, Rat.cast_intCast, Rat.cast_natCast,
                      Rat.divInt_eq_div] at h0;
           exact_mod_cast h0

--- a/LeanCert/Tactic/design-notes.md
+++ b/LeanCert/Tactic/design-notes.md
@@ -1,0 +1,960 @@
+Design Notes (not part of documentation)
+========================================
+
+## dite_simp: Failed approach with custom simproc
+
+We initially attempted a custom `simproc` to match on `dite` applications:
+
+```lean
+simproc diteNatLit (dite _ _ _) := fun e => do
+  -- Check if condition is ℕ comparison, reduce via whnf
+  ...
+```
+
+**Why it failed:** The pattern `dite _ _ _` doesn't match correctly because
+`dite` has implicit type arguments and an auto-bound `Decidable` instance.
+The simproc pattern syntax couldn't reliably match the actual `dite` applications.
+
+### Working approach: simp with decide config
+
+The solution uses Lean's built-in `decide` configuration for `simp`:
+
+```lean
+simp (config := { decide := true }) only [dite_true, dite_false]
+```
+
+**Why it works:**
+1. `config := { decide := true }` tells simp to use `Decidable` instances
+   to evaluate propositions to `True` or `False`
+2. For ℕ literal comparisons like `(1 : ℕ) ≤ 2`, the `Decidable` instance computes
+3. Once reduced to `True`/`False`, `dite_true`/`dite_false` eliminate the `dite`
+
+### Limitations
+
+- Only works for conditions with computable `Decidable` instances
+- Both sides of comparisons must be concrete literals (not variables)
+- Very large literals may be slow to compute
+- Complex expressions (e.g., `Finset.sup'` with nested sums) may hit max recursion;
+  use `vec_simp!` after `fin_cases` breaks down the goal into simple cases
+
+## finsum_expand: Design notes
+
+### Interval sums: simproc + repeat pattern
+For interval finsets, we use Mathlib's existing simprocs to convert intervals
+to explicit sets, then repeatedly apply `Finset.sum_insert`.
+
+### Fin sums: Mathlib's `Fin.sum_univ_ofNat` simproc
+For `∑ i : Fin n, f i`, we use Mathlib's `Fin.sum_univ_ofNat` simproc from
+`Mathlib.Data.Fin.Tuple.Reflection`. This simproc:
+1. Pattern-matches on `∑ _ : Fin n, _`
+2. Extracts `n` as a literal using `n.nat?`
+3. Builds the expanded form `f 0 + f 1 + ... + f (n-1)` via `mkSumEqQ`
+4. Returns the proof using `FinVec.sum_eq`
+
+Works for any concrete literal n.
+
+### Fallback for non-literal Fin dimensions
+When n is not a syntactic literal (e.g., `Fin (2 + 1)` instead of `Fin 3`),
+`n.nat?` returns `none` and the simproc doesn't fire. We fall back to
+repeatedly applying `Fin.sum_univ_succ` to expand element by element.
+
+### Computed interval bounds
+Mathlib's interval simprocs (e.g., `Finset.Icc_ofNat_ofNat`) pattern-match on
+syntactic `OfNat` literals. When bounds are computed expressions like `2 * 2`,
+the simprocs don't fire because `2 * 2` is syntactically `HMul.hMul 2 2`, not `4`.
+
+The `finsum_expand!` variant handles this by first applying `simp only` with
+`Nat.reduceAdd`, `Nat.reduceMul`, `Nat.reduceSub` to normalize arithmetic
+expressions in interval bounds to literals before the expansion.
+
+## vec_simp!: Fixed-point iteration with fail_if_no_progress
+
+### The problem: Matrix.of_apply and vecConsFinMk interaction
+
+`Matrix.of_apply` (unwraps `!![...]` notation) and `vecConsFinMk` (reduces vector
+indexing) cannot be in the same `simp` call - including both breaks the dsimproc.
+But after `vecConsFinMk` reduces one level, `Matrix.of_apply` may be needed again.
+
+**Failed approaches:**
+1. `simp only [Matrix.of_apply, VecUtil.vecConsFinMk, ...]` - breaks vecConsFinMk
+2. `repeat try simp only [Matrix.of_apply]` - infinite loop (`try` always succeeds)
+
+### Working approach: fail_if_no_progress
+
+Use `fail_if_no_progress` from `Mathlib.Tactic.FailIfNoProgress` to detect when
+a tactic makes no progress:
+
+```lean
+-- First pass of main simp
+try simp (config := { decide := true }) only [VecUtil.vecConsFinMk, ...]
+-- Loop: of_apply -> main simp, repeat while of_apply makes progress
+repeat (
+  fail_if_no_progress simp only [Matrix.of_apply]
+  try simp (config := { decide := true }) only [VecUtil.vecConsFinMk, ...]
+)
+```
+
+**Why it works:**
+1. First pass handles cases where Matrix.of_apply isn't needed
+2. `fail_if_no_progress` fails when simp doesn't change the goal
+3. `repeat` stops when `fail_if_no_progress` fails
+4. Inner `try simp` runs unconditionally after each successful `Matrix.of_apply`
+
+This achieves fixed-point iteration: alternate between the two simplifications
+until `Matrix.of_apply` can't unwrap any more `Matrix.of` expressions.
+
+### Example: nested Matrix.of wrapping
+
+```lean
+def wrappedOf (M : Matrix (Fin 2) (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ :=
+  Matrix.of fun i j => M i j + 1
+
+example : wrappedOf ![![1, 2], ![3, 4]] 0 0 = 2 := by vec_simp! [wrappedOf]
+```
+
+After unfolding `wrappedOf`, we have `(Matrix.of fun i j => ![![1,2],[3,4]] i j + 1) 0 0`.
+1. `Matrix.of_apply` → `![![1,2],[3,4]] 0 0 + 1`
+2. `vecConsFinMk` (first pass) → `![1,2] 0 + 1`
+3. `vecConsFinMk` (second pass) → `1 + 1`
+4. `norm_num` → `2`
+
+### Shared module: VecUtil
+
+Reusable tactic macros extracted into `VecUtil` (outside namespace):
+
+| Macro | Description |
+|-------|-------------|
+| `dite_simp` | `if h : 1 ≤ 2 then x else y` → `x` |
+| `abs_simp` | `\|3\|` → `3`, `\|-2\|` → `2` |
+| `vec_index_simp_core` | Vector indexing + Matrix.of_apply iteration |
+| `vec_index_simp_with_dite` | `vec_index_simp_core` + dite/abs + norm_num |
+
+Usage:
+- `vec_simp!` = `vec_index_simp_with_dite` + `norm_num`
+- `finsum_expand!` = `finsum_expand` + Fin processing + `vec_index_simp_with_dite`
+
+## Bug fix: |vecCons ... idx| inside matrix column norms (Feb 2026)
+
+### The problem
+
+When computing matrix column norms like `∑ i, |A i j| * ν^i`, the expression
+`|A i j|` unfolds to `|vecCons ... idx|` where the vecCons is INSIDE the abs.
+
+**Failing case (Example_7_7.colNorm_le):**
+```lean
+-- After finsum_expand!, the goal contained unreduced expressions like:
+⊢ |Matrix.vecCons (1/2) (fun i => Matrix.vecCons (-1/4) (fun _ => 3/8) i) 2| * ν^2 ≤ bound
+```
+
+The vecCons at index 2 should reduce to `3/8`, then `|3/8|` should reduce to `3/8`.
+
+### Root cause analysis
+
+**Issue 1: abs lemmas outside the iteration**
+
+The original `vec_index_simp_with_dite` had abs lemmas in a SEPARATE phase:
+```lean
+-- Phase 1: iteration
+repeat (first | simp [vecConsFinMk, ...] | simp [Matrix.of_apply])
+-- Phase 2: abs (AFTER iteration ended)
+try simp [abs_of_pos, ...]
+```
+
+When we have `|vecCons ...|`:
+1. Phase 1 can't reduce vecCons because it's inside abs (simp can't "see through")
+2. Phase 1 iteration terminates (neither simp makes progress)
+3. Phase 2 tries `abs_of_*` but the argument is still `vecCons ...`, not a literal
+4. FAILURE: vecCons unreduced
+
+**Issue 2: decide can't prove positivity for ℝ**
+
+Even with abs lemmas in the iteration, `abs_of_pos` requires proving the argument
+is positive. For `ℚ`, `config := { decide := true }` works. For `ℝ`, the order
+isn't decidable by `decide` even for literals like `3/8 : ℝ`.
+
+### The fix (two parts)
+
+**Part 1: abs lemmas IN the iteration**
+```lean
+repeat (
+  first
+  | fail_if_no_progress simp (config := { decide := true }) only [
+      VecUtil.vecConsFinMk, ..., abs_of_pos, abs_of_nonneg, abs_of_neg, abs_neg
+    ]
+  | fail_if_no_progress simp only [Matrix.of_apply]
+)
+```
+
+Now simp can:
+1. Descend into `|vecCons ...|`
+2. Apply `vecConsFinMk` to reduce `vecCons ... idx` → literal
+3. Apply `abs_of_*` in the SAME pass once we have a literal (works for ℚ)
+
+**Part 2: norm_num for ℝ**
+```lean
+-- After iteration, handle ℝ literals where decide doesn't work
+try norm_num [abs_of_pos, abs_of_nonneg, abs_of_neg, abs_neg]
+```
+
+`norm_num` can prove `(3/8 : ℝ) > 0` and apply `abs_of_pos`.
+
+### Test cases for this bug
+
+The key pattern is: `|vecCons h (fun i => vecCons ... i) idx|` where:
+- The vecCons is INSIDE abs
+- The tail is a lambda (from matrix column extraction)
+- The index is the LAST element (triggers deepest recursion)
+
+```lean
+-- Lambda tail inside abs, index 2 (last element)
+example : |(![1/2, -1/4, 3/8] : Fin 3 → ℝ) 2| = 3/8 := by vec_simp!
+
+-- Explicit vecCons structure (how it appears after unfolding)
+example : |Matrix.vecCons (1/2 : ℝ)
+    (fun i => Matrix.vecCons (-1/4) (fun _ => 3/8) i) 2| = 3/8 := by vec_simp!
+
+-- In an inequality context (like the actual colNorm_le proof)
+example : 1/2 + (-1/4 * ν + |Matrix.vecCons ... 2| * ν^2) ≤ bound := by
+  finsum_expand!; vec_simp!
+```
+
+### Lessons learned
+
+1. **abs blocks reduction**: Simp can descend into `|...|` but only if the relevant
+   lemmas (like `vecConsFinMk`) are in the same simp call as `abs_of_*`.
+
+2. **Separate phases fail**: If the iteration and abs reduction are separate,
+   the iteration terminates before abs is ready (argument not yet a literal).
+
+3. **ℝ vs ℚ**: `decide := true` works for `ℚ` positivity but not `ℝ`. Always
+   include `norm_num` as a fallback for real number goals.
+
+4. **Test the last index**: Lambda tail patterns are most likely to fail on the
+   last index because it requires the deepest recursion through the tail.
+
+## finsum_bound: O(1) Proof-Size Finite Sum Bounds (Feb 2026)
+
+### Motivation
+
+`finsum_expand` expands `∑ k ∈ Icc a b, f k` into `f a + f(a+1) + ... + f b`,
+creating an O(N) expression tree. For N > ~100, this blows up: Lean's kernel
+chokes on the giant proof term.
+
+`ReflectiveSum` (in Engine/ReflectiveSum.lean) solved this for BKLNW's specific
+function `x^(1/k - 1/3)` using an accumulator loop + `native_decide` for O(1)
+proofs. But it's hardcoded — 20+ nearly-identical theorems in BKLNW_a2_reflective.lean
+for different parameter values.
+
+`finsum_bound` generalizes this: any function expressible as a `Core.Expr` gets
+O(1) proofs automatically.
+
+### Architecture (3 layers)
+
+```
+Layer 1: Engine (FinSumDyadic.lean)
+  evalSumTermDyadic : per-term interval evaluation via evalIntervalDyadic
+  finSumAux : accumulator loop (current → limit, acc += term)
+  checkFinSumUpperBound/LowerBound : Bool certificate checkers
+  verify_finsum_upper/lower : bridge theorems (checker = true → sum ≤ target)
+
+Layer 2: Tactic (FinSumBound.lean)
+  parseFinSumGoal : detect ∑ k ∈ Finset.Icc a b, f k ≤ target
+  reifyFinSumBody : convert ℕ→ℝ lambda to Core.Expr (handles Nat.cast)
+  mkDomainValidProof : structural recursion on AST for domain validity
+  finSumBoundCore : orchestrate reify → support → config → check → bridge
+
+Layer 3: Tests (FinSumBoundTest.lean)
+  Constants, index sums, transcendentals, lower bounds, large N
+```
+
+### Key reuse from existing infrastructure
+
+- `evalIntervalDyadic` + `evalIntervalDyadic_correct` (IntervalEvalDyadic.lean):
+  Per-term interval arithmetic with correctness proof. This is the workhorse.
+- `Core.Expr` AST (Core/Expr.lean): 20+ constructors for arithmetic/transcendentals.
+  The sum body is reified into this AST.
+- `reify` (Meta/ToExpr.lean): Translates Lean expressions to Core.Expr.
+  We wrap it with Nat.cast handling for the ℕ → ℝ sum body.
+- `mkSupportedCoreProof` (Meta/ProveSupported.lean): Generates ExprSupportedCore
+  proofs by structural recursion.
+- `IntervalDyadic.upperBoundedBy/lowerBoundedBy` (Core/IntervalDyadic.lean):
+  Bool-valued bound checks used in certificate checkers.
+- Bridge theorem pattern from DyadicAuto.lean: the same
+  "checker = true → semantic property" structure.
+
+### The Nat.cast challenge
+
+Sum bodies have type `ℕ → ℝ`. The lambda variable `k : ℕ` appears in the body
+as `↑k : ℝ` (via Nat.cast). But `reify` expects `fun (x : ℝ) => ...`.
+
+Solution: `reifyFinSumBody` uses `replaceNatCast` to find all `Nat.cast k` and
+`NatCast.natCast k` subexpressions (by checking the last argument of known cast
+functions) and replaces them with a fresh `ℝ` variable before reifying.
+
+### The definitional equality challenge
+
+The bridge theorem produces:
+  `∑ k ∈ Icc a b, Expr.eval (sumBodyRealEnv k) body ≤ ↑target`
+
+But the user's goal is:
+  `∑ k ∈ Icc a b, f k ≤ literal`
+
+Two issues:
+1. `Expr.eval (sumBodyRealEnv k) body` vs `f k`: noncomputable `Expr.eval` must
+   unfold to match the user's concrete function.
+2. `↑(target : ℚ)` vs `(literal : ℝ)`: Rat.cast of extracted rational vs original
+   real literal.
+
+Solution: Try direct `isDefEq` first (works sometimes). If it fails, use a
+suffices + converter pattern:
+  1. Build a converter metavar: `proofTy → goalType`
+  2. Close it with `simp [Expr.eval, sumBodyRealEnv] + norm_num`
+  3. This unfolds Expr.eval structurally and normalizes casts
+
+### Domain validity
+
+`evalDomainValidDyadic` checks positivity for log, non-zero for inv, etc.
+It's a `Prop` with no `Decidable` instance, and the environment contains
+the free variable `k` (summation index), so `mkDecideProof` fails.
+
+Solution: `mkDomainValidProof` builds the proof by structural recursion on
+the AST at the meta level:
+- const/var/pi → `True.intro`
+- add/mul → `And.intro h₁ h₂`
+- neg/exp/sin/cos/... → recurse into subexpression
+- log/inv/atanh → error (not yet supported; would need per-k checking)
+
+The proof is wrapped in a metavar with the expected type to ensure Lean
+accepts the definitional equality between `True` and `evalDomainValidDyadic ...`.
+
+### Relationship to ReflectiveSum
+
+`finsum_bound` generalizes `ReflectiveSum`:
+- ReflectiveSum: hardcoded `bklnwTermEval` + `bklnwSumAux`
+- finsum_bound: generic `evalSumTermDyadic` + `finSumAux` via Core.Expr
+
+ReflectiveSum's `bklnwTermEval` (which handles rpow) could be wrapped as a
+witness in the future Tier 2 API. The accumulator loop, certificate checkers,
+and bridge theorem structure are identical.
+
+### Future: Witness API (Tier 2)
+
+For functions NOT in Core.Expr (e.g., rpow, user-defined):
+
+```lean
+structure SumTermWitness where
+  eval : Nat → DyadicConfig → IntervalDyadic
+  correct : ∀ k, f k ∈ eval k cfg
+```
+
+The user provides `eval` (computable) and `correct` (bridge). The tactic
+plugs this into the same accumulator loop. ReflectiveSum becomes one instance.
+
+### Key failures during development
+
+1. **Argument order in induction hypothesis** (FinSumDyadic.lean):
+   Swapped `hdom'` and `hnewAcc` in the `ih` call.
+
+2. **Missing helper theorems** (FinSumDyadic.lean):
+   `IntervalDyadic.le_hi_of_mem`, `upperBoundedBy_spec` etc. are defined in
+   ReflectiveSum.lean, not in IntervalDyadic. Inlined with `.2` / `.1` and
+   `simp + exact_mod_cast`.
+
+3. **No Decidable instance for evalDomainValidDyadic** (FinSumBound.lean):
+   Can't use `mkDecideProof` when the environment contains free variable `k`.
+   Fixed with meta-level structural recursion.
+
+4. **Eq argument order** (FinSumBound.lean):
+   `mkAppM ``Eq #[boolTy, checkExpr, true]` — Bool is the type parameter,
+   not a term. Fixed: `mkAppM ``Eq #[checkExpr, true]`.
+
+5. **True.intro has type True, not evalDomainValidDyadic**:
+   Though definitionally equal, Lean's `mkAppM` rejects the type mismatch.
+   Fixed by wrapping in `mkFreshExprMVar (some expectedTy)` + `assign`.
+
+## finsum_bound Tier 2: Domain Validity for inv/log/atanh (Feb 2026)
+
+### Problem
+
+Tier 1 built domain validity proofs statically via `mkDomainValidProof`, which
+recursed on the AST and returned `True.intro` for trivially-valid nodes. This
+fails for `inv` (nonzero check), `log` (positive check), and `atanh` (bounds
+check) because these conditions depend on `evalIntervalDyadic ... (sumBodyEnvSimple k prec)`,
+which varies per summation index `k`.
+
+### Solution: Combined domain+bound checker
+
+Instead of building a domain proof at the tactic level, we integrate domain
+checking into the certificate checker. One `native_decide` verifies both
+domain validity (for all k ∈ [a,b]) and the bound.
+
+**Engine additions (FinSumDyadic.lean):**
+
+```
+checkDomainValidAllAux : loop over k ∈ [current, limit], AND together
+  checkDomainValidDyadic body (sumBodyEnvSimple k prec) cfg
+  for each k.
+
+checkDomainValidAll_correct : bridge theorem, by strong induction on
+  limit + 1 - current (mirrors mem_finSumAux).
+
+checkFinSumUpperBoundFull := checkDomainValidAll && checkFinSumUpperBound
+
+verify_finsum_upper_full : splits the && via Bool.and_eq_true, applies
+  checkDomainValidAll_correct for domain + verify_finsum_upper for bound.
+```
+
+**Key insight**: `checkDomainValidDyadic` (Bool) already exists in
+IntervalEvalDyadic.lean with bridge theorem `checkDomainValidDyadic_correct`.
+We just loop it over all k.
+
+### ExprSupportedWithInv support
+
+`ExprSupportedCore` excludes `inv`, `atan`, `arsinh`, `atanh`. For sums like
+`∑ 1/(k*k)`, we need `ExprSupportedWithInv` which includes all operations.
+
+The WithInv correctness chain duplicates the Core chain using
+`evalIntervalDyadic_correct_withInv` instead of `evalIntervalDyadic_correct`:
+
+```
+mem_evalSumTermDyadic_withInv → mem_finSumAux_withInv → mem_finSumDyadic_withInv
+  → verify_finsum_upper_withInv → verify_finsum_upper_full_withInv
+```
+
+Proofs are identical — only the support predicate and correctness lemma differ.
+
+### Tactic changes (FinSumBound.lean)
+
+1. Removed `mkDomainValidProof` and `buildDomainProof` (no longer needed)
+2. Added `detectSupportLevel`: try `mkSupportedCoreProof`, fallback to
+   `mkSupportedWithInvProof`
+3. Bridge theorem selected by (support level × direction):
+   - Core + upper → `verify_finsum_upper_full`
+   - WithInv + upper → `verify_finsum_upper_full_withInv`
+   etc.
+4. Bridge theorem arguments simplified: no domain proof needed (it's inside
+   the combined checker).
+
+### What this enables
+
+- `∑ k ∈ Icc 1 100, 1/(k*k) ≤ 2` — inv with auto domain check
+- `∑ k ∈ Icc 1 10, log(k) ≤ 16` — log with auto positivity check (k ≥ 1)
+- `∑ k ∈ Icc 1 10, exp(1/k) ≤ 20` — nested inv inside exp
+- `∑ k ∈ Icc 1 500, 1/(k*k) ≤ 2` — O(1) proof, 500 terms with inv
+
+## finsum_witness: Witness API for Custom Functions (Tier 3, Feb 2026)
+
+### Problem
+
+`finsum_bound` (Tiers 1-2) auto-reifies sum bodies to `Core.Expr`. Functions NOT
+in `Core.Expr` (like `rpow` in BKLNW's `x^(1/k - 1/3)`) can't be handled. The
+existing `ReflectiveSum.lean` solves this for one hardcoded function, producing
+22 near-identical theorems in `BKLNW_a2_reflective.lean` for different parameters.
+
+### Solution: Generic Witness API
+
+The user provides:
+1. `evalTerm : Nat → DyadicConfig → IntervalDyadic` — computable per-term evaluator
+2. `hmem` — proof that `∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg`
+
+The engine provides:
+- `witnessSumAux` — generic accumulator loop (same pattern as `finSumAux`)
+- `witnessSumDyadic` — entry point
+- `checkWitnessSumUpperBound/LowerBound` — Bool certificate checkers
+- `verify_witness_sum_upper/lower` — bridge theorems
+- `mem_witnessSumAux/Dyadic` — correctness chain (strong induction)
+
+### Key difference from Expr-based approach
+
+- **No ExprSupportedCore/WithInv** — user handles semantics
+- **No evalDomainValidDyadic** — user's `hmem` proof covers domain
+- **No reification** — evaluator is a plain Lean function
+- **Same accumulator pattern** — reuses `finSumZero`, `mem_finSumZero`,
+  `Finset.sum_Icc_eq_add_sum_Ioc'`, `Finset.Ioc_eq_Icc_succ'`
+
+### Tactic: `finsum_witness`
+
+Syntax: `finsum_witness evalTerm using hmem [prec]`
+
+The `using` keyword separates the evaluator from the proof (needed because
+Lean's `term` parser greedily consumes `evalTerm (fun ...)` as one application).
+
+Flow:
+1. Parse goal (same `parseWitnessGoal` as `finsum_bound`)
+2. Extract target rational via `extractRatFromReal`
+3. Elaborate `evalTerm` against `Nat → DyadicConfig → IntervalDyadic`
+4. Build expected `hmem` type: `∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg`
+   (requires `.headBeta` on `bodyLambda k` for type inference)
+5. Elaborate user's `hmem` against expected type
+6. Build bridge theorem + `native_decide`
+7. Suffices fallback for defEq mismatches
+
+### Membership.mem argument order gotcha
+
+In Lean 4, `Membership.mem` takes `(container, element)` order:
+  `mem : γ → α → Prop`  (with `class Membership (α : outParam ...) (γ : ...)`)
+  `x ∈ S = Membership.mem S x`  (notation swaps)
+
+So `mkAppM ``Membership.mem #[interval, value]` — container first!
+
+### Relationship to ReflectiveSum
+
+ReflectiveSum's `bklnwTermDyadic` is one instance of the witness evaluator:
+```
+bklnwTermDyadic x k cfg  →  evalTerm k cfg  (with x captured in closure)
+mem_bklnwTermDyadic       →  user provides hmem
+```
+
+The 22 theorems in `BKLNW_a2_reflective.lean` could be unified as instances
+of `verify_witness_sum_upper`. This is a follow-up task.
+
+### Files
+
+- `Engine/WitnessSum.lean` — accumulator, checkers, correctness, bridge theorems
+- `Tactic/FinSumWitness.lean` — `finsum_witness` tactic
+- `Test/WitnessSumTest.lean` — tests with constant witness + direct bridge use
+
+## finsum_bound Tier 4: Arbitrary Finite Sets (Feb 2026)
+
+### Problem
+
+Tiers 1-3 only handled `∑ k ∈ Finset.Icc a b, f k`. Users also need:
+- `Finset.range n`, `Finset.Ico a b`, `Finset.Ioc a b`, `Finset.Ioo a b`
+- Explicit finite sets like `{1, 3, 5, 7}`
+
+Key constraint: keep O(1) proof size (no `finsum_expand`-style expansion).
+
+### Core idea: List-based accumulator
+
+A random finite set is not inductively enumerable like `[a, b]`. Solution:
+iterate over a `List Nat` of elements, then bridge to `Finset.sum` via
+Mathlib's `List.sum_toFinset`:
+
+```lean
+theorem List.sum_toFinset (f : ι → M) (hl : l.Nodup) :
+    l.toFinset.sum f = (l.map f).sum
+```
+
+The List accumulator uses structural induction (simpler than `Nat.strongRecOn`
+for Icc). A single `native_decide` verifies:
+  `decide (S = indices.toFinset) && indices.Nodup && domain && bound`
+
+### Engine: List chain (FinSumDyadic.lean)
+
+```
+finSumAuxList : iterate List Nat, accumulate intervals
+finSumDyadicList : entry point (zero-initialized accumulator)
+checkFinSumUpperBoundListFull : combined Bool checker
+  = decide (S = indices.toFinset) && Nodup && domainAll && upperBound
+verify_finsum_upper_list_full : bridge theorem
+```
+
+Correctness proof by List structural induction:
+```lean
+induction indices generalizing acc partialSum with
+| nil => simp; exact hacc
+| cons k rest ih =>
+    -- reassociate: (ps + f(k)) + rest.map.sum
+    -- show ps + f(k) ∈ newAcc via mem_add + roundOut_contains
+    -- apply ih with (fun j hj => hdom j (.tail k hj))
+```
+
+**List.Mem constructors**: `.head rest` for `k ∈ k :: rest`, `.tail k hj` for
+`j ∈ k :: rest` given `hj : j ∈ rest`. Don't use `List.mem_cons_self k rest`
+(all-implicit args — gives "Function expected" error in this Lean version).
+
+Both ExprSupportedCore and ExprSupportedWithInv variants provided.
+
+### Engine: Witness list chain (WitnessSum.lean)
+
+Same pattern but parameterized by `evalTerm : Nat → DyadicConfig → IntervalDyadic`:
+
+```
+witnessSumAuxList / witnessSumDyadicList
+checkWitnessSumUpperBoundListFull : S = toFinset ∧ Nodup ∧ bound
+verify_witness_sum_upper_list_full
+  (hmem : ∀ k, k ∈ S → f k ∈ evalTerm k cfg) : ∑ k ∈ S, f k ≤ target
+```
+
+The combined bridge converts `hmem` from Finset membership to List membership
+using `heq ▸ List.mem_toFinset.mpr hk`.
+
+### Tactic: Finset extraction (FinSumBound.lean)
+
+The tactic extracts elements from any recognized Finset expression:
+
+| Finset form | Extraction |
+|---|---|
+| `Finset.Icc a b` | `List.range' a (b+1-a)` |
+| `Finset.Ico a b` | `List.range' a (b-a)` |
+| `Finset.Ioc a b` | `List.range' (a+1) (b-a)` |
+| `Finset.Ioo a b` | `List.range' (a+1) (b-a-1)` |
+| `Finset.range n` | `List.range n` |
+| `{1, 3, 5, 7}` | recursive Insert.insert/Singleton.singleton |
+
+**Lean 4 Finset expression representation**: `{1, 3, 5}` desugars to
+`Insert.insert 1 (Insert.insert 3 (Singleton.singleton 5))`. The actual
+constants are `Insert.insert` (5 args: [α, γ, inst, elem, rest]) and
+`Singleton.singleton` (4 args: [α, γ, inst, elem]). NOT `Finset.insert` /
+`Finset.singleton` (these don't exist as constants — they're instances).
+
+### Tactic: Dispatch logic
+
+```
+finSumBoundCore:
+  1. Try Icc path first (faster, no Nodup overhead)
+  2. Fall back to list path for other Finsets
+```
+
+The list path builds `checkFinSumUpperBoundListFull body S indices target cfg`
+and closes it with one `native_decide`.
+
+### Tactic: Witness list dispatch (FinSumWitness.lean)
+
+For `finsum_bound using evalTerm hmem` with non-Icc goals:
+
+- Icc path: `hmem : ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm k cfg` (3 arg lambda)
+- List path: `hmem : ∀ k, k ∈ S → f k ∈ evalTerm k cfg` (2 arg lambda)
+
+The user writes `fun k _ => myProof k _` for list goals (vs `fun k _ _ => ...`
+for Icc). Existing Icc tests are unaffected since they take the Icc path.
+
+### Converter fix: div_eq_mul_inv
+
+The suffices fallback converter failed for inv bodies on the list path:
+```
+Proof type: ∑ k ∈ {1,2,4,8}, Expr.eval (sumBodyRealEnv k) (const(1).mul (var 0).inv) ≤ ↑(2/1)
+Goal type:  ∑ k ∈ {1,2,4,8}, 1 / ↑k ≤ 2
+```
+
+After `simp [Expr.eval, sumBodyRealEnv]`, the proof has `↑(1/1) * (↑k)⁻¹` but
+the goal has `1 / ↑k`. Since `a / b = a * b⁻¹` by definition, these should match
+after normalizing the goal's division.
+
+**Fix**: Add `div_eq_mul_inv` to the simp set:
+```lean
+simp only [Core.Expr.eval, Engine.sumBodyRealEnv, div_eq_mul_inv] at h ⊢
+norm_num at h ⊢
+exact h
+```
+
+This normalizes `1 / ↑k` → `1 * (↑k)⁻¹` in the goal, then `norm_num` simplifies
+`↑(Rat.divInt 1 1)` → `1` in the proof hypothesis. Both sides match.
+
+### Finset parsing: shared vs duplicated helpers
+
+`FinSumBound.lean` imports `FinSumWitness.lean`. The Finset extraction functions
+(`extractFinsetSum`, `extractNatLit`, `tryExtractExplicitFinset`, `extractFinsetElements`)
+are needed in both files. Since FinSumWitness can't import FinSumBound (circular),
+the helpers are duplicated (with `'` suffix in FinSumWitness). This is acceptable
+for ~80 lines of simple parsing code. A shared module could be factored out later
+if more tactics need this functionality.
+
+### What this enables
+
+```lean
+-- Finset.range
+example : ∑ _k ∈ Finset.range 10, (1 : ℝ) ≤ 11 := by finsum_bound
+
+-- Finset.Ico with inv
+example : ∑ k ∈ Finset.Ico (1 : ℕ) 11, (1 : ℝ) / ↑k ≤ 4 := by finsum_bound
+
+-- Explicit finset
+example : ∑ k ∈ ({1, 3, 5, 7} : Finset ℕ), (↑k : ℝ) ≤ 17 := by finsum_bound
+
+-- Explicit finset with inv
+example : ∑ k ∈ ({1, 2, 4, 8} : Finset ℕ), (1 : ℝ) / ↑k ≤ 2 := by finsum_bound
+
+-- Sparse set with transcendentals
+example : ∑ k ∈ ({1, 10, 100} : Finset ℕ), Real.exp (-(↑k : ℝ)) ≤ 1 := by finsum_bound
+```
+
+### Files modified
+
+- `Engine/FinSumDyadic.lean` — list-based accumulator + combined checkers + bridge theorems (~220 lines)
+- `Engine/WitnessSum.lean` — list-based witness accumulator + combined checkers (~100 lines)
+- `Tactic/FinSumBound.lean` — Finset extraction, list path dispatch, div_eq_mul_inv converter fix
+- `Tactic/FinSumWitness.lean` — Finset extraction (duplicated), list path dispatch
+- `Test/FinSumBoundTest.lean` — Tier 4 tests (range, Ico, Ioc, explicit sets, inv, exp, lower bounds)
+
+## Fin n sum support: unified `finsum_bound` (Feb 2026)
+
+### Problem
+
+`∑ i : Fin n, f i` elaborates to `Finset.sum Finset.univ (fun i : Fin n => f i)`.
+The original approach used a separate `fin_sum_bound` wrapper that did
+`simp only [Fin.sum_univ_eq_sum_range]; finsum_bound`. Two issues:
+
+1. **Two tactic names** — users had to know when to use `fin_sum_bound` vs `finsum_bound`
+2. **`simp only` fails for complex bodies** — `Fin.sum_univ_eq_sum_range` has type
+   `∀ f : ℕ → M, ∑ i : Fin n, f ↑i = ∑ i ∈ range n, f i`. `simp` needs to infer
+   `f` by higher-order matching, which fails when the body is e.g.
+   `fun i : Fin 5 => exp (↑↑i)` (double coercion `Fin.val` then `Nat.cast`)
+
+### Solution: meta-level `tryRewriteFinSum`
+
+Instead of `simp`, `finsum_bound` detects `Finset.sum Finset.univ body` where
+`univ` is over `Fin n`, then:
+
+1. Extracts `body : Fin n → β` from the goal
+2. Uses `lambdaTelescope` to open the body and replace `Fin.val i` / `Fin.toNat i`
+   with a fresh `k : ℕ` variable
+3. Builds `f : ℕ → β` via `mkLambdaFVars`
+4. Rewrites with `Fin.sum_univ_eq_sum_range f` via `MVarId.rewrite` + `replaceTargetEq`
+
+This handles arbitrary bodies because `f` is constructed explicitly, not inferred
+by simp's pattern matcher.
+
+### Nat.cast + Fin.val handling in reifier
+
+`replaceNatCast` (used by `reifyFinSumBody`) was extended with `isFVarOrFinVal`
+to also match `Nat.cast (Fin.val k)` — the double coercion that appears in
+Fin-indexed sum bodies after the rewrite.
+
+### Witness mode
+
+Both auto-mode and witness-mode elab rules call `tryRewriteFinSum` before
+dispatch. After rewriting, a Fin sum becomes `∑ k ∈ Finset.range n, ...`
+which the existing range/list path handles. For witness mode, the hmem proof
+uses the list path signature `∀ k, k ∈ S → ...` (2 args, not 3).
+
+### Removed
+
+`FinSumBoundFin.lean` and the `fin_sum_bound` syntax are deleted. All Fin sum
+handling is now internal to `finsum_bound`.
+
+## Auto-hmem witness mode: `finsum_bound auto` (Feb 2026)
+
+### Problem
+
+In witness mode (`finsum_bound using eval hmem`), the user must manually write
+`hmem : ∀ k, ... → f k ∈ eval k cfg`. When the evaluator returns singletons
+(exact ℚ values wrapped in `IntervalDyadic.singleton`), this proof is tedious —
+membership reduces to `d.toRat ≤ x ∧ x ≤ d.toRat` which is just reflexivity
+after reducing `Dyadic.toRat`.
+
+### Solution: `finsum_bound auto eval`
+
+New syntax: `finsum_bound auto evalTerm [prec]`. The tactic builds the hmem type,
+creates a fresh metavar, and tries to close it automatically using:
+
+**Strategy 1** (constant evaluators): `simp [mem_def, singleton]` then
+`refine ⟨?_, ?_⟩ <;> exact_mod_cast (by native_decide)`. This pushes the ℝ
+comparison down to ℚ via `exact_mod_cast`, then `native_decide` handles the ℚ
+comparison computationally.
+
+**Strategy 2** (k-dependent evaluators, Icc path): `interval_cases k` to enumerate
+all concrete k values, then Strategy 1 per case. O(N) but works when bounds are
+concrete literals.
+
+**Strategy 3** (k-dependent evaluators, list path): `fin_cases hk` to enumerate
+list membership, then Strategy 1 per case.
+
+### Key insight: `exact_mod_cast (by native_decide)`
+
+`x ∈ IntervalDyadic` is `(lo.toRat : ℝ) ≤ x ∧ x ≤ (hi.toRat : ℝ)` — not
+decidable over ℝ. But `exact_mod_cast` pushes the cast down, producing a ℚ goal
+`lo.toRat ≤ q ∧ q ≤ hi.toRat` which IS decidable and `native_decide` closes it.
+
+### Limitation
+
+`native_decide` can't handle free variables. When the evaluator depends on `k`
+and the range is large, `interval_cases` / `fin_cases` enumerates all values
+(O(N) proof). For large N with k-dependent evaluators, the user should use the
+explicit `finsum_bound using eval hmem` syntax instead.
+
+### TODO: Bool checker approach
+
+For O(1) proof size on k-dependent evaluators, a future improvement would add a
+combined Bool checker: `checkWitnessAutoFull evalTerm bodyQ S indices target cfg`
+that verifies membership AND bound in one `native_decide`. Requires new engine
+theorems and a `bodyQ : ℕ → ℚ` parameter.
+
+## Cast support and reification order fix (Feb 2026)
+
+### Cast patterns in `toRat?`
+
+Added `Rat.cast`, `RatCast.ratCast`, `Nat.cast`, `NatCast.natCast`, `Int.cast`,
+and `IntCast.intCast` patterns to `tryMatchNumeric` in `Meta/ToExpr.lean`.
+Each extracts the inner value and recursively calls `toRat?`.
+
+This lets `↑(q : ℚ)`, `↑(n : ℕ)`, and `↑(z : ℤ)` appearing in sum bodies be
+recognized as constants during reification.
+
+### Reification order: `tryMatchExpr` before `toRat?`
+
+Previously, `toLeanCertExpr` called `toRat?` (step 2) before `tryMatchExpr`
+(step 3). This caused `toRat?` to eagerly constant-fold compound expressions
+like `↑(-2 : ℤ) + 3` into `const(1)`, because `toRat?` handles `HAdd` of
+constants recursively. The bridge converter then couldn't match `Expr.eval ...
+(const 1)` against the goal's `↑(-2) + 3` — the structure was lost.
+
+**Fix**: Swap steps 2 and 3. `tryMatchExpr` now runs first, matching `HAdd` and
+recursively reifying each operand. This produces `add(const(-2), const(3))`,
+which `simp [Expr.eval]` unfolds to `↑(-2 : ℚ) + ↑(3 : ℚ)`, matching the
+goal after `push_cast`. Leaf values (pure literals without operators) still
+fall through to `toRat?`.
+
+**Trade-off**: Expressions like `1/3 : ℝ` are now reified as `mul(const(1),
+inv(const(3)))` instead of `const(1/3)`. This is slightly less compact but
+semantically identical, and the bridge handles it correctly.
+
+## Absolute value support (Feb 2026)
+
+### ToExpr: |x| → sqrt(x * x)
+
+`Meta/ToExpr.lean` pattern-matches on `abs _ _ _ x` (Lean 4's `abs` function
+takes 3 implicit args: type, Lattice instance, AddGroup instance) and produces
+`Expr.sqrt (Expr.mul ex ex)`.
+
+**Why not `Expr.abs`?** `Expr.abs` is a `def` (not a constructor):
+  `def abs (e : Expr) : Expr := sqrt (mul e e)`
+
+Using `mkAppM ``Expr.abs` produces a head constant of `Expr.abs`, which the
+support checker (`mkSupportedCoreProof`) doesn't recognize — it matches on
+head constants like `Expr.sqrt`, `Expr.mul`, etc. By directly producing
+`sqrt(mul e e)`, the existing support checker handles it with no changes.
+
+### Proof bridge: `← sqrt_mul_self_eq_abs`
+
+After `simp [Expr.eval, ...]` unfolds the proof, we get `Real.sqrt (f k * f k)`.
+The goal still has `|f k|`. The bridge lemma `← Expr.sqrt_mul_self_eq_abs`
+(aliased from `Real.sqrt_mul_self_eq_abs`) rewrites `|f k|` in the goal to
+`√(f k * f k)`, making both sides match.
+
+Added to simp sets in:
+- `FinSumBound.lean` — both Icc and list path converters
+- `IntervalAuto/PointIneq.lean` — pointwise inequality prover
+- `IntervalAuto/Bound.lean` — interval bound prover
+
+### Aliased lemma
+
+`Core.Expr.sqrt_mul_self_eq_abs` in `Core/Expr.lean`:
+```lean
+theorem sqrt_mul_self_eq_abs (x : ℝ) : Real.sqrt (x * x) = |x| :=
+  Real.sqrt_mul_self_eq_abs x
+```
+
+All tactic bridges reference this alias instead of the Mathlib original,
+keeping lemma names within the `LeanCert` namespace.
+
+## ↑(q : ℚ) bound target fix (Mar 2026)
+
+### Problem
+
+`finsum_bound` could handle `↑(q : ℚ)` in sum **bodies** (via `Rat.cast` pattern in
+`toRat?`) but failed when `↑(q : ℚ)` appeared as the **bound target**:
+
+```lean
+-- Failed: "could not extract rational from bound `↑(9 / 500)`"
+example : ∑ _k ∈ Icc 1 3, 1/1000 ≤ ↑(9/500 : ℚ) := by finsum_bound
+```
+
+### Root cause
+
+`extractRatFromReal` in `IntervalAuto/Extract.lean` delegates to `extractRatFromRat`
+for `Rat.cast` arguments. But `extractRatFromRat` only handles `Rat.ofInt`, `OfNat`,
+`Nat.cast`, `Int.cast`, and `Rat.mk'` — not `HDiv.hDiv`. When `(9/500 : ℚ)` elaborates
+to `HDiv.hDiv (OfNat 9) (OfNat 500)` in ℚ, `extractRatFromRat` fails.
+
+### Fix
+
+One-line change: in the `Rat.cast` branch of `extractRatFromReal`, replace
+`extractRatFromRat args.back!` with `LeanCert.Meta.toRat? args.back!`. The `toRat?`
+function (in `Meta/ToExpr.lean`) already handles all arithmetic patterns (`HDiv`,
+`HAdd`, `HMul`, `HSub`, `Neg`, `OfScientific`, etc.), so it correctly parses
+`HDiv.hDiv (OfNat 9) (OfNat 500)` as `9/500 : ℚ`.
+
+## BridgeNative: shared bridge+native_decide infrastructure (Mar 2026)
+
+### Problem
+
+The "try defEq → suffices + converter → native_decide" pattern was duplicated
+**6 times** across `finSumBound{Icc,List}Core` and `finSumWitness{Icc,List,AutoIcc,AutoList}Core`
+(~35 lines each, ~210 total). Adding `finmatrix_bound` would create a 7th copy.
+
+### Solution: `closeBridgeWithNativeDecide`
+
+Extracted into `Tactic/BridgeNative.lean`:
+
+```lean
+def closeBridgeWithNativeDecide
+    (goal : MVarId) (goalType : Lean.Expr)
+    (proof checkMVar : Lean.Expr)
+    (tacticName : String)
+    (converterSteps : Array (TacticM Unit))
+    : TacticM Unit
+```
+
+Logic:
+1. `inferType proof` → `proofTy`
+2. If `isDefEq proofTy goalType`: direct assign + `native_decide` on checkMVar
+3. Else: suffMVar + converterMVar pattern, try converterSteps in sequence
+
+Each caller provides its own converter steps inline:
+- `finsum_bound`: `simp [Expr.eval, sumBodyRealEnv, ...] + norm_num`, then `push_cast + linarith`
+- `finsum_witness` / `finmatrix_bound`: `intro h; exact h`, then `push_cast + linarith`
+
+### Refactored files
+
+- `FinSumBound.lean` — 2 blocks → 2 calls to `closeBridgeWithNativeDecide`
+- `FinSumWitness.lean` — 4 blocks → 4 calls to `closeBridgeWithNativeDecide`
+- Net: ~210 lines of duplication → ~40-line shared helper
+
+## finmatrix_bound: matrix norm tactic (Mar 2026)
+
+### Problem
+
+Proving `finWeightedMatrixNorm ν M ≤ C` requires manually writing:
+```lean
+exact l1Weighted.finWeightedMatrixNorm_le_of_Q_le _ cols ν_q hcols hν (by native_decide)
+```
+
+For block-level `finiteBlockMatrixNorm ν A ≤ C`, users must decompose with
+`fin_cases l <;> fin_cases j` producing L×L `native_decide` calls (9 for L=3).
+
+### Design: generic bridge applier
+
+`finmatrix_bound` is a generic "apply bridge term + native_decide" tactic.
+Lives in RadiiPolynomial (not leancert) since its bridge lemmas and test data
+are there. Imports `BridgeNative` from leancert for the shared helper:
+
+```lean
+syntax "finmatrix_bound" term : tactic
+```
+
+The user provides the bridge lemma fully applied except for the final `hle` argument:
+```lean
+finmatrix_bound (l1Weighted.finWeightedMatrixNorm_le_of_Q_le _ cols ν_q hcols hν)
+```
+
+The tactic:
+1. Elaborates the bridge term
+2. Infers its type — should be `(hle : X ≤ C) → goalType`
+3. Creates mvar for `hle`, applies `bridgeExpr checkMVar`
+4. Calls `closeBridgeWithNativeDecide` to close with `native_decide`
+
+### Block extension (RadiiPolynomial — separate project)
+
+`finiteBlockMatrixNormQ` computes the entire block norm in ℚ:
+```lean
+def finiteBlockMatrixNormQ (L N : ℕ) [NeZero L]
+    (blockCols : Fin L → Fin L → Fin (N+1) → Array ℚ) (ν : ℚ) : ℚ :=
+  Finset.univ.sup' Finset.univ_nonempty fun l =>
+    ∑ j : Fin L, finWeightedMatrixNormQ (blockCols l j) ν N
+```
+
+Block bridge lemma `finiteBlockMatrixNorm_le_of_Q_le` reduces the entire block norm
+to a single `native_decide`, eliminating the `fin_cases l <;> fin_cases j` decomposition.
+
+Usage:
+```lean
+-- 1 native_decide instead of 9:
+finmatrix_bound (finiteBlockMatrixNorm_le_of_Q_le _ blockCols ν_q hcols hν)
+```
+
+### Key insight
+
+Matrix norm = max of sums — same computable structure as `finsum_bound` with an
+extra `max` layer. Both `max` (via `Finset.sup'`) and `∑` are decidable over ℚ,
+so `native_decide` handles the whole thing in one shot.

--- a/LeanCert/Test/FinSumBoundTest.lean
+++ b/LeanCert/Test/FinSumBoundTest.lean
@@ -119,4 +119,57 @@ example : ∑ _k ∈ Finset.Icc 1 100, (1 : ℝ) ≤ 101 := by
 example : ∑ k ∈ Finset.Icc (1 : ℕ) 100, (↑k : ℝ) ≤ 5051 := by
   finsum_bound using identityEval (fun k _ _ => identityEval_correct k _)
 
+/-! ## Tier 4: Arbitrary finite sets (list path) -/
+
+-- Finset.range
+example : ∑ _k ∈ Finset.range 10, (1 : ℝ) ≤ 11 := by finsum_bound
+
+-- Finset.Ico
+example : ∑ k ∈ Finset.Ico (1 : ℕ) 11, (1 : ℝ) / ↑k ≤ 4 := by finsum_bound
+
+-- Finset.Ioc
+example : ∑ k ∈ Finset.Ioc (0 : ℕ) 5, (↑k : ℝ) ≤ 16 := by finsum_bound
+
+-- Explicit finset
+example : ∑ k ∈ ({1, 3, 5, 7} : Finset ℕ), (↑k : ℝ) ≤ 17 := by finsum_bound
+
+-- Explicit finset with inv
+example : ∑ k ∈ ({1, 2, 4, 8} : Finset ℕ), (1 : ℝ) / ↑k ≤ 2 := by finsum_bound
+
+-- Lower bound with Finset.range
+example : (10 : ℝ) ≤ ∑ k ∈ Finset.range 6, (↑k : ℝ) := by finsum_bound
+
+-- Sparse set with exp
+example : ∑ k ∈ ({1, 10, 100} : Finset ℕ), Real.exp (-(↑k : ℝ)) ≤ 1 := by finsum_bound
+
+/-! ## Tier 5: Nested inv/exp/log (deep nesting stress tests) -/
+
+-- Nested exp: exp(exp(1/k))
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 5, Real.exp (Real.exp ((1 : ℝ) / ↑k)) ≤ 35 := by
+  finsum_bound
+
+-- Nested inv: 1/(1 + 1/k) = k/(k+1)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, (1 : ℝ) / ((1 : ℝ) + (1 : ℝ) / ↑k) ≤ 9 := by
+  finsum_bound
+
+-- Log with inv: log(k)/k
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, Real.log ↑k / ↑k ≤ 6 := by
+  finsum_bound
+
+-- Deep nesting on explicit finset: 1/(k * log(k))
+example : ∑ k ∈ ({2, 3, 5, 7} : Finset ℕ), (1 : ℝ) / (↑k * Real.log ↑k) ≤ 2 := by
+  finsum_bound
+
+-- Nested exp on explicit finset: exp(exp(1/k))
+example : ∑ k ∈ ({1, 2, 3} : Finset ℕ), Real.exp (Real.exp ((1 : ℝ) / ↑k)) ≤ 26 := by
+  finsum_bound
+
+-- exp of log: exp(log(k)) = k for k ≥ 1
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, Real.exp (Real.log ↑k) ≤ 56 := by
+  finsum_bound
+
+-- Triple nesting: exp(1/(1 + exp(-k)))
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 5, Real.exp ((1 : ℝ) / ((1 : ℝ) + Real.exp (-(↑k : ℝ)))) ≤ 14 := by
+  finsum_bound
+
 end LeanCert.Test.FinSumBound

--- a/LeanCert/Test/FinSumBoundTest.lean
+++ b/LeanCert/Test/FinSumBoundTest.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.FinSumBound
+
+/-!
+# Tests for `finsum_bound`
+
+Verifies that the `finsum_bound` tactic can prove bounds on finite sums
+with O(1) proof size via `native_decide`.
+-/
+
+namespace LeanCert.Test.FinSumBound
+
+-- Basic: sum of constants (upper)
+example : ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) ≤ 11 := by
+  finsum_bound
+
+-- Basic: sum of constants (lower)
+example : (1 : ℝ) ≤ ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) := by
+  finsum_bound
+
+-- Edge: singleton sum
+example : ∑ _k ∈ Finset.Icc 5 5, (1 : ℝ) ≤ 2 := by
+  finsum_bound
+
+-- Edge: empty sum
+example : ∑ _k ∈ Finset.Icc 5 3, (1 : ℝ) ≤ 1 := by
+  finsum_bound
+
+-- Sum using the index: ∑ ↑k (Nat → ℝ cast)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, (↑k : ℝ) ≤ 56 := by
+  finsum_bound
+
+-- Transcendental: ∑ exp(constant)
+example : ∑ _k ∈ Finset.Icc 1 5, Real.exp (1 : ℝ) ≤ 15 := by
+  finsum_bound
+
+-- Larger sum: 100 terms (would blow up with finsum_expand)
+example : ∑ _k ∈ Finset.Icc 1 100, (1 : ℝ) ≤ 101 := by
+  finsum_bound
+
+/-! ## Tier 2: Bodies with inv/log (domain validity checked per-k) -/
+
+-- inv: ∑ 1/(k*k) upper bound (uses ExprSupportedWithInv)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 100, (1 : ℝ) / (↑k * ↑k) ≤ 2 := by
+  finsum_bound
+
+-- inv: harmonic partial sum lower bound
+example : (1 : ℝ) ≤ ∑ k ∈ Finset.Icc (1 : ℕ) 10, (1 : ℝ) / ↑k := by
+  finsum_bound
+
+-- log: ∑ log(k) for k ≥ 1 (positive domain)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, Real.log ↑k ≤ 16 := by
+  finsum_bound
+
+-- Combined: exp(1/k) with inv inside exp
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, Real.exp ((1 : ℝ) / ↑k) ≤ 20 := by
+  finsum_bound
+
+-- Larger N with inv (stress test O(1) proof size)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 500, (1 : ℝ) / (↑k * ↑k) ≤ 2 := by
+  finsum_bound
+
+/-! ## Tier 3: Witness mode (`finsum_bound using`) -/
+
+open LeanCert.Core
+open LeanCert.Engine
+
+/-- Constant evaluator: always returns [1, 1]. -/
+def constEval (_k : Nat) (_cfg : DyadicConfig) : IntervalDyadic :=
+  IntervalDyadic.singleton (Core.Dyadic.ofInt 1)
+
+theorem constEval_correct (k : Nat) (cfg : DyadicConfig) :
+    (1 : ℝ) ∈ constEval k cfg := by
+  show (1 : ℝ) ∈ IntervalDyadic.singleton (Core.Dyadic.ofInt 1)
+  have h := IntervalDyadic.mem_singleton (Core.Dyadic.ofInt 1)
+  rw [Core.Dyadic.toRat_ofInt] at h
+  simpa using h
+
+/-- Identity evaluator: returns [k, k] for each k. -/
+def identityEval (k : Nat) (_cfg : DyadicConfig) : IntervalDyadic :=
+  IntervalDyadic.singleton (Core.Dyadic.ofInt ↑k)
+
+theorem identityEval_correct (k : Nat) (cfg : DyadicConfig) :
+    (↑k : ℝ) ∈ identityEval k cfg := by
+  show (↑k : ℝ) ∈ IntervalDyadic.singleton (Core.Dyadic.ofInt ↑k)
+  have h := IntervalDyadic.mem_singleton (Core.Dyadic.ofInt ↑k)
+  rw [Core.Dyadic.toRat_ofInt] at h
+  simpa using h
+
+-- Witness: constant upper bound
+example : ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) ≤ 11 := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- Witness: constant lower bound
+example : (1 : ℝ) ≤ ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- Witness: identity upper bound (each term = k)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, (↑k : ℝ) ≤ 56 := by
+  finsum_bound using identityEval (fun k _ _ => identityEval_correct k _)
+
+-- Witness: identity lower bound
+example : (50 : ℝ) ≤ ∑ k ∈ Finset.Icc (1 : ℕ) 10, (↑k : ℝ) := by
+  finsum_bound using identityEval (fun k _ _ => identityEval_correct k _)
+
+-- Witness: empty range
+example : ∑ _k ∈ Finset.Icc 5 3, (1 : ℝ) ≤ 1 := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- Witness: larger sum (100 terms)
+example : ∑ _k ∈ Finset.Icc 1 100, (1 : ℝ) ≤ 101 := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- Witness: identity, larger range (∑ k for k=1..100 = 5050)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 100, (↑k : ℝ) ≤ 5051 := by
+  finsum_bound using identityEval (fun k _ _ => identityEval_correct k _)
+
+end LeanCert.Test.FinSumBound

--- a/LeanCert/Test/FinSumBoundTest.lean
+++ b/LeanCert/Test/FinSumBoundTest.lean
@@ -9,7 +9,8 @@ import LeanCert.Tactic.FinSumBound
 # Tests for `finsum_bound`
 
 Verifies that the `finsum_bound` tactic can prove bounds on finite sums
-with O(1) proof size via `native_decide`.
+with O(1) proof size via `native_decide`. Covers auto-reify mode, witness mode
+(`using`), auto-hmem witness mode (`auto`), Fin n sums, and various Finset types.
 -/
 
 namespace LeanCert.Test.FinSumBound
@@ -82,6 +83,26 @@ example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, Real.exp (Real.log ↑k) ≤ 56 := 
 
 -- Triple nesting: exp(1/(1 + exp(-k)))
 example : ∑ k ∈ Finset.Icc (1 : ℕ) 5, Real.exp ((1 : ℝ) / ((1 : ℝ) + Real.exp (-(↑k : ℝ)))) ≤ 14 := by
+  finsum_bound
+
+-- Absolute value: |sin(k)| ≤ 1 per term, so ∑ |sin(k)| ≤ 10
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, |Real.sin ↑k| ≤ 10 := by
+  finsum_bound
+
+-- Rat.cast: body contains ↑(q : ℚ) cast to ℝ
+example : ∑ _k ∈ Finset.Icc (1 : ℕ) 5, ((1/3 : ℚ) : ℝ) ≤ 2 := by
+  finsum_bound
+
+-- Rat.cast in arithmetic: ↑(q : ℚ) * sin(k)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 5, ((1/2 : ℚ) : ℝ) * Real.sin ↑k ≤ 3 := by
+  finsum_bound
+
+-- Int.cast: body contains ↑(z : ℤ) multiplied with k
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 3, ((-1 : ℤ) : ℝ) * Real.sin ↑k ≤ 1 := by
+  finsum_bound
+
+-- Int.cast + constant: ↑(-2 : ℤ) + 3 reified structurally (not constant-folded)
+example : ∑ _k ∈ Finset.Icc (1 : ℕ) 3, (((-2 : ℤ) : ℝ) + 3) ≤ 4 := by
   finsum_bound
 
 /-! ## Tier 3: Witness mode (`finsum_bound using`)
@@ -198,5 +219,51 @@ example : ∑ k ∈ ({2, 3, 5, 7} : Finset ℕ), (1 : ℝ) / (↑k * Real.log �
 
 -- Nested exp on explicit finset: exp(exp(1/k))
 example : ∑ k ∈ ({1, 2, 3} : Finset ℕ), Real.exp (Real.exp ((1 : ℝ) / ↑k)) ≤ 26 := by finsum_bound
+
+/-! ## Tier 5: Fin n sums (auto-rewrite via `tryRewriteFinSum`)
+
+`finsum_bound` detects `∑ i : Fin n, f i` goals, extracts the body lambda,
+replaces `Fin.val i` with a fresh ℕ variable to build `g : ℕ → β`, and
+rewrites via `Fin.sum_univ_eq_sum_range g`. This handles arbitrary bodies
+(not just simple `↑i`), unlike `simp only [Fin.sum_univ_eq_sum_range]` which
+requires first-order matching. -/
+
+-- Fin sum: simple coercion body
+example : ∑ i : Fin 10, (↑i : ℝ) ≤ 46 := by finsum_bound
+
+-- Fin sum: lower bound
+example : (44 : ℝ) ≤ ∑ i : Fin 10, (↑i : ℝ) := by finsum_bound
+
+-- Fin sum: transcendental body (exp ↑i — needs meta-level Fin.val extraction)
+example : ∑ i : Fin 5, Real.exp (↑i : ℝ) ≤ 234 := by finsum_bound
+
+-- Fin sum: witness mode (Fin → range rewrite, then list path)
+example : ∑ i : Fin 5, Real.exp (↑i : ℝ) ≤ 234 := by
+  finsum_bound using expEval (fun k _ => expEval_correct k _)
+
+/-! ## Tier 6: Auto-hmem witness mode (`finsum_bound auto`)
+
+The `auto` keyword provides a witness evaluator without a manual hmem proof.
+The tactic auto-proves `f k ∈ evalTerm k cfg` via `simp [mem_def] + push_cast + norm_num`.
+This works when the evaluator returns singletons where membership reduces to
+`d.toRat ≤ x ∧ x ≤ d.toRat` with `x = ↑(d.toRat)`. -/
+
+/-- Singleton evaluator: returns the exact value 1 for every k. -/
+def constOneEval (_k : Nat) (_cfg : DyadicConfig) : IntervalDyadic :=
+  IntervalDyadic.singleton ⟨1, 0⟩
+
+-- Auto-hmem: constant body, singleton evaluator
+example : ∑ _k ∈ Finset.Icc (1 : ℕ) 5, (1 : ℝ) ≤ 6 := by
+  finsum_bound auto constOneEval
+
+/-! ## Tier 7: ↑(q : ℚ) bound targets (extractRatFromReal with toRat? fallback) -/
+
+-- ↑(q : ℚ) as bound target (was failing before toRat? fix)
+example : ∑ _k ∈ Finset.Icc (1 : ℕ) 3, (1 : ℝ) / 1000 ≤ ↑(9/500 : ℚ) := by
+  finsum_bound
+
+-- ↑(q : ℚ) in body (already worked via Rat.cast pattern in toRat?)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 5, ↑(9/500 : ℚ) * Real.sin (↑k : ℝ) ≤ 1 := by
+  finsum_bound
 
 end LeanCert.Test.FinSumBound

--- a/LeanCert/Test/WitnessSumTest.lean
+++ b/LeanCert/Test/WitnessSumTest.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.FinSumBound
+
+/-!
+# Tests for the Witness Sum API
+
+Verifies:
+- `finsum_witness` tactic (standalone)
+- `finsum_bound using` (integrated witness mode)
+- Bridge theorems (`verify_witness_sum_upper`/`lower`)
+-/
+
+namespace LeanCert.Test.WitnessSum
+
+open LeanCert.Core
+open LeanCert.Engine
+
+/-! ## Witness evaluators for testing -/
+
+/-- Constant evaluator: always returns [1, 1]. -/
+def constEval (_k : Nat) (_cfg : DyadicConfig) : IntervalDyadic :=
+  IntervalDyadic.singleton (Core.Dyadic.ofInt 1)
+
+/-- Correctness: `(1 : ℝ) ∈ constEval k cfg`. -/
+theorem constEval_correct (k : Nat) (cfg : DyadicConfig) :
+    (1 : ℝ) ∈ constEval k cfg := by
+  show (1 : ℝ) ∈ IntervalDyadic.singleton (Core.Dyadic.ofInt 1)
+  have h := IntervalDyadic.mem_singleton (Core.Dyadic.ofInt 1)
+  rw [Core.Dyadic.toRat_ofInt] at h
+  simpa using h
+
+/-- Identity evaluator: returns [k, k] for each k. -/
+def identityEval (k : Nat) (_cfg : DyadicConfig) : IntervalDyadic :=
+  IntervalDyadic.singleton (Core.Dyadic.ofInt ↑k)
+
+/-- Correctness: `(↑k : ℝ) ∈ identityEval k cfg`. -/
+theorem identityEval_correct (k : Nat) (cfg : DyadicConfig) :
+    (↑k : ℝ) ∈ identityEval k cfg := by
+  show (↑k : ℝ) ∈ IntervalDyadic.singleton (Core.Dyadic.ofInt ↑k)
+  have h := IntervalDyadic.mem_singleton (Core.Dyadic.ofInt ↑k)
+  rw [Core.Dyadic.toRat_ofInt] at h
+  simpa using h
+
+/-! ## Tests via `finsum_witness` tactic (standalone) -/
+
+-- Basic: ∑ 1 ≤ 11 via constant witness
+example : ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) ≤ 11 := by
+  finsum_witness constEval using (fun _ _ _ => constEval_correct _ _)
+
+-- Lower bound: 1 ≤ ∑ 1 via constant witness
+example : (1 : ℝ) ≤ ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) := by
+  finsum_witness constEval using (fun _ _ _ => constEval_correct _ _)
+
+-- Empty sum: ∑ over Icc 5 3 (empty range)
+example : ∑ _k ∈ Finset.Icc 5 3, (1 : ℝ) ≤ 1 := by
+  finsum_witness constEval using (fun _ _ _ => constEval_correct _ _)
+
+-- Larger sum: 100 terms via constant witness
+example : ∑ _k ∈ Finset.Icc 1 100, (1 : ℝ) ≤ 101 := by
+  finsum_witness constEval using (fun _ _ _ => constEval_correct _ _)
+
+-- Identity: ∑ k for k ∈ Icc 1 10 ≤ 56 (actual = 55)
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, (↑k : ℝ) ≤ 56 := by
+  finsum_witness identityEval using (fun k _ _ => identityEval_correct k _)
+
+-- Identity lower bound: 50 ≤ ∑ k for k ∈ Icc 1 10
+example : (50 : ℝ) ≤ ∑ k ∈ Finset.Icc (1 : ℕ) 10, (↑k : ℝ) := by
+  finsum_witness identityEval using (fun k _ _ => identityEval_correct k _)
+
+/-! ## Tests via `finsum_bound using` (integrated witness mode) -/
+
+-- finsum_bound using: constant witness upper bound
+example : ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) ≤ 11 := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- finsum_bound using: constant witness lower bound
+example : (1 : ℝ) ≤ ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- finsum_bound using: identity witness upper bound
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 10, (↑k : ℝ) ≤ 56 := by
+  finsum_bound using identityEval (fun k _ _ => identityEval_correct k _)
+
+-- finsum_bound using: identity witness lower bound
+example : (50 : ℝ) ≤ ∑ k ∈ Finset.Icc (1 : ℕ) 10, (↑k : ℝ) := by
+  finsum_bound using identityEval (fun k _ _ => identityEval_correct k _)
+
+-- finsum_bound using: empty range
+example : ∑ _k ∈ Finset.Icc 5 3, (1 : ℝ) ≤ 1 := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- finsum_bound using: larger sum
+example : ∑ _k ∈ Finset.Icc 1 100, (1 : ℝ) ≤ 101 := by
+  finsum_bound using constEval (fun _ _ _ => constEval_correct _ _)
+
+-- finsum_bound using: identity witness, larger range
+example : ∑ k ∈ Finset.Icc (1 : ℕ) 100, (↑k : ℝ) ≤ 5051 := by
+  finsum_bound using identityEval (fun k _ _ => identityEval_correct k _)
+
+/-! ## Tests via direct bridge theorem application -/
+
+-- Direct use of verify_witness_sum_upper (no tactic)
+example : ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) ≤ 11 :=
+  verify_witness_sum_upper (fun _ => 1) constEval 1 10 11
+    { precision := -53, taylorDepth := 10, roundAfterOps := 0 }
+    (fun _ _ _ => constEval_correct _ _)
+    (by native_decide)
+
+-- Direct use of verify_witness_sum_lower (no tactic)
+example : (1 : ℝ) ≤ ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) := by
+  have h := verify_witness_sum_lower (fun _ => (1 : ℝ)) constEval 1 10 1
+    { precision := -53, taylorDepth := 10, roundAfterOps := 0 }
+    (fun _ _ _ => constEval_correct _ _)
+    (by native_decide)
+  norm_cast at h
+
+end LeanCert.Test.WitnessSum


### PR DESCRIPTION
- Add `finsum_bound` tactic for O(1) proof-size finite sum bounds via `native_decide`, supporting auto-reified `Core.Expr` bodies (constants, casts, exp, log, inv, arithmetic)
- Add `finsum_witness` tactic and `finsum_bound` using syntax for custom per-term evaluators not expressible as `Core.Expr` (e.g., `rpow`)
- Add `WitnessSum` engine: generic accumulator loop (`witnessSumDyadic`), certificate checkers, correctness chain, and bridge theorems
- Add combined domain+bound checkers (`checkFinSumUpperBoundFull`) with `ExprSupportedWithInv` support for bodies containing `inv/log/atanh`
- Refactor `ReflectiveSum` to delegate to `witnessSumDyadic` via thin `bklnwEvalTerm` wrapper, removing ~55 lines of duplicated accumulator code