### PR TITLE
refactor: replace per-constant Expr constructors with MathConst lookup table + add Euler-Mascheroni

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -288,7 +288,7 @@ def eval₀_rat (e : LeanCert.Core.Expr) (x : ℚ) : ℚ :=
   | .cosh _ => 0  -- Not computable over ℚ
   | .tanh _ => 0  -- Not computable over ℚ
   | .sqrt _ => 0  -- Not computable over ℚ
-  | .pi => 157 / 50  -- Rational approximation of π ≈ 3.14
+  | .namedConst c => c.toRatApprox
 
 /-- The unit interval [0, 1] -/
 def unitInterval : IntervalRat := ⟨0, 1, by norm_num⟩

--- a/LeanCert/Core/Expr.lean
+++ b/LeanCert/Core/Expr.lean
@@ -10,6 +10,7 @@ import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Arsinh
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 
@@ -230,6 +231,29 @@ theorem Real.neg_one_le_erf (x : ℝ) : -1 ≤ Real.erf x := by
           _ = 1 := by field_simp
     linarith
 
+/-- Named mathematical constants with known interval bounds.
+    Adding a new constant (e.g., Catalan's) only requires extending this enum
+    and its lookup tables — zero evaluator files need updating. -/
+inductive MathConst where
+  | pi
+  | eulerMascheroni
+  deriving Repr, DecidableEq, Inhabited
+
+/-- The real value of a named mathematical constant. -/
+noncomputable def MathConst.toReal : MathConst → ℝ
+  | .pi => Real.pi
+  | .eulerMascheroni => Real.eulerMascheroniConstant
+
+/-- Float approximation for heuristic evaluation (unverified). -/
+def MathConst.toFloat : MathConst → Float
+  | .pi => 3.141592653589793
+  | .eulerMascheroni => 0.5772156649015329
+
+/-- Rational approximation for display/debugging (unverified). -/
+def MathConst.toRatApprox : MathConst → ℚ
+  | .pi => 157 / 50
+  | .eulerMascheroni => 577 / 1000
+
 /-- Unified AST for real-valued expressions. -/
 inductive Expr where
   /-- Rational constant -/
@@ -270,8 +294,8 @@ inductive Expr where
   | tanh (e : Expr)
   /-- Square root (partial: undefined for x < 0) -/
   | sqrt (e : Expr)
-  /-- The mathematical constant π -/
-  | pi
+  /-- A named mathematical constant (π, γ, …) looked up from a table. -/
+  | namedConst (c : MathConst)
   deriving Repr, DecidableEq, Inhabited
 
 namespace Expr
@@ -312,7 +336,7 @@ noncomputable def eval (ρ : Nat → ℝ) : Expr → ℝ
   | cosh e => Real.cosh (eval ρ e)
   | tanh e => Real.tanh (eval ρ e)
   | sqrt e => Real.sqrt (eval ρ e)
-  | pi => Real.pi
+  | namedConst c => c.toReal
 
 /-- Update variable assignment at a specific index -/
 def updateVar (ρ : Nat → ℝ) (idx : Nat) (x : ℝ) : Nat → ℝ :=
@@ -362,7 +386,7 @@ def freeVars : Expr → Finset Nat
   | cosh e => freeVars e
   | tanh e => freeVars e
   | sqrt e => freeVars e
-  | pi => ∅
+  | namedConst _ => ∅
 
 /-- An expression is closed if it has no free variables -/
 def isClosed (e : Expr) : Prop := freeVars e = ∅
@@ -429,7 +453,14 @@ theorem eval_tanh (ρ : Nat → ℝ) (e : Expr) : eval ρ (tanh e) = Real.tanh (
 theorem eval_sqrt (ρ : Nat → ℝ) (e : Expr) : eval ρ (sqrt e) = Real.sqrt (eval ρ e) := rfl
 
 @[simp]
-theorem eval_pi (ρ : Nat → ℝ) : eval ρ pi = Real.pi := rfl
+theorem eval_namedConst (ρ : Nat → ℝ) (c : MathConst) :
+    eval ρ (namedConst c) = c.toReal := rfl
+
+/-- Backward-compat alias for simp lists referencing `eval_pi`. -/
+theorem eval_pi (ρ : Nat → ℝ) : eval ρ (namedConst .pi) = Real.pi := rfl
+
+theorem eval_eulerMascheroni (ρ : Nat → ℝ) :
+    eval ρ (namedConst .eulerMascheroni) = Real.eulerMascheroniConstant := rfl
 
 @[simp]
 theorem eval_sub (ρ : Nat → ℝ) (e₁ e₂ : Expr) :
@@ -597,7 +628,7 @@ def usesOnlyVar0 : Expr → Bool
   | cosh e => e.usesOnlyVar0
   | tanh e => e.usesOnlyVar0
   | sqrt e => e.usesOnlyVar0
-  | pi => true
+  | namedConst _ => true
 
 /-- If two environments agree on variable 0, then a usesOnlyVar0 expression evaluates the same -/
 theorem eval_usesOnlyVar0_eq (e : Expr) (he : e.usesOnlyVar0 = true)
@@ -659,7 +690,7 @@ theorem eval_usesOnlyVar0_eq (e : Expr) (he : e.usesOnlyVar0 = true)
   | sqrt e ih =>
     simp only [usesOnlyVar0] at he
     simp only [eval_sqrt, ih he]
-  | pi => rfl
+  | namedConst _ => rfl
 
 /-- For single-variable expressions, `fun n => if n = 0 then x else 0` and `fun _ => x`
     give the same evaluation result. -/

--- a/LeanCert/Core/Support.lean
+++ b/LeanCert/Core/Support.lean
@@ -61,7 +61,7 @@ inductive ExprSupportedCore : Expr → Prop where
   | cosh {e : Expr} : ExprSupportedCore e → ExprSupportedCore (Expr.cosh e)
   | tanh {e : Expr} : ExprSupportedCore e → ExprSupportedCore (Expr.tanh e)
   | erf {e : Expr} : ExprSupportedCore e → ExprSupportedCore (Expr.erf e)
-  | pi : ExprSupportedCore Expr.pi
+  | namedConst (c : MathConst) : ExprSupportedCore (Expr.namedConst c)
 
 /-! ### Extended supported expression subset (with exp) -/
 
@@ -118,7 +118,7 @@ inductive ExprSupportedWithInv : Expr → Prop where
   | sinc {e : Expr} : ExprSupportedWithInv e → ExprSupportedWithInv (Expr.sinc e)
   | erf {e : Expr} : ExprSupportedWithInv e → ExprSupportedWithInv (Expr.erf e)
   | sqrt {e : Expr} : ExprSupportedWithInv e → ExprSupportedWithInv (Expr.sqrt e)
-  | pi : ExprSupportedWithInv Expr.pi
+  | namedConst (c : MathConst) : ExprSupportedWithInv (Expr.namedConst c)
 
 /-- ExprSupported implies ExprSupportedWithInv -/
 theorem ExprSupported.toWithInv {e : Expr} (h : ExprSupported e) : ExprSupportedWithInv e := by

--- a/LeanCert/Engine/AD/Basic.lean
+++ b/LeanCert/Engine/AD/Basic.lean
@@ -48,6 +48,16 @@ def piConst : DualInterval :=
   { val := piInterval
     der := IntervalRat.singleton 0 }
 
+/-- Dual interval for the Euler–Mascheroni constant γ (derivative is zero) -/
+def eulerMascheroniConst : DualInterval :=
+  { val := eulerMascheroniInterval
+    der := IntervalRat.singleton 0 }
+
+/-- Dual interval for a named mathematical constant (derivative is zero) -/
+def ofMathConst (c : MathConst) : DualInterval :=
+  { val := c.interval
+    der := IntervalRat.singleton 0 }
+
 /-- Dual interval for the variable we're differentiating with respect to -/
 def varActive (I : IntervalRat) : DualInterval :=
   { val := I

--- a/LeanCert/Engine/AD/Computable.lean
+++ b/LeanCert/Engine/AD/Computable.lean
@@ -112,7 +112,7 @@ def evalDualCore (e : Expr) (ρ : DualEnv) (cfg : EvalConfig := {}) : DualInterv
   | Expr.cosh e => DualInterval.coshCore (evalDualCore e ρ cfg) cfg.taylorDepth
   | Expr.tanh e => DualInterval.tanhCore (evalDualCore e ρ cfg) cfg.taylorDepth
   | Expr.sqrt e => DualInterval.sqrt (evalDualCore e ρ cfg)
-  | Expr.pi => DualInterval.piConst
+  | Expr.namedConst c => DualInterval.ofMathConst c
 
 /-- Computable single-variable derivative interval -/
 def derivIntervalCore (e : Expr) (I : IntervalRat) (cfg : EvalConfig := {}) : IntervalRat :=
@@ -142,7 +142,7 @@ def evalDomainValidDual (e : Expr) (ρ : DualEnv) (cfg : EvalConfig := {}) : Pro
   | Expr.cosh e => evalDomainValidDual e ρ cfg
   | Expr.tanh e => evalDomainValidDual e ρ cfg
   | Expr.sqrt e => evalDomainValidDual e ρ cfg
-  | Expr.pi => True
+  | Expr.namedConst _ => True
 
 /-- Correctness theorem for computable dual value component.
 
@@ -208,9 +208,9 @@ theorem evalDualCore_val_correct (e : Expr) (hsupp : ExprSupportedCore e)
     simp only [evalDomainValidDual] at hdom
     simp only [Expr.eval_log, evalDualCore, DualInterval.logCore]
     exact IntervalRat.mem_logComputable (ih hdom.1) hdom.2 cfg.taylorDepth
-  | pi =>
-    simp only [Expr.eval_pi, evalDualCore, DualInterval.piConst]
-    exact mem_piInterval
+  | namedConst c =>
+    simp only [Expr.eval_namedConst, evalDualCore, DualInterval.ofMathConst]
+    exact c.mem_interval
 
 /-- For ExprSupported expressions (which exclude log), domain validity is trivially true.
     This is because ExprSupported has no log constructor. -/

--- a/LeanCert/Engine/AD/Correctness.lean
+++ b/LeanCert/Engine/AD/Correctness.lean
@@ -214,9 +214,17 @@ theorem evalFunc1_const (q : ℚ) : evalFunc1 (Expr.const q) = fun _ => (q : ℝ
 @[simp]
 theorem evalFunc1_var (i : ℕ) : evalFunc1 (Expr.var i) = id := rfl
 
+/-- Helper lemma: evalFunc1 for namedConst (constant function) -/
+@[simp]
+theorem evalFunc1_namedConst (c : MathConst) : evalFunc1 (Expr.namedConst c) = fun _ => c.toReal := rfl
+
 /-- Helper lemma: evalFunc1 for pi (constant function) -/
 @[simp]
-theorem evalFunc1_pi : evalFunc1 Expr.pi = fun _ => Real.pi := rfl
+theorem evalFunc1_pi : evalFunc1 (Expr.namedConst .pi) = fun _ => Real.pi := rfl
+
+/-- Helper lemma: evalFunc1 for eulerMascheroni (constant function) -/
+@[simp]
+theorem evalFunc1_eulerMascheroni : evalFunc1 (Expr.namedConst .eulerMascheroni) = fun _ => Real.eulerMascheroniConstant := rfl
 
 /-- Helper: the dual environment evaluation gives correct derivative.
     This connects the interval-based AD to actual calculus derivatives.

--- a/LeanCert/Engine/AD/Eval.lean
+++ b/LeanCert/Engine/AD/Eval.lean
@@ -62,7 +62,7 @@ noncomputable def evalDual (e : Expr) (ρ : DualEnv) : DualInterval :=
   | Expr.cosh e => DualInterval.cosh (evalDual e ρ)
   | Expr.tanh e => DualInterval.tanh (evalDual e ρ)
   | Expr.sqrt e => DualInterval.sqrt (evalDual e ρ)
-  | Expr.pi => DualInterval.piConst
+  | Expr.namedConst c => DualInterval.ofMathConst c
 
 /-! ### Partial dual evaluation (supports inv) -/
 
@@ -145,7 +145,7 @@ noncomputable def evalDual? (e : Expr) (ρ : DualEnv) : Option DualInterval :=
       match evalDual? e ρ with
       | some d => DualInterval.sqrt? d
       | none => none
-  | Expr.pi => some DualInterval.piConst
+  | Expr.namedConst c => some (DualInterval.ofMathConst c)
 
 /-- Single-variable version of evalDual? -/
 noncomputable def evalDual?1 (e : Expr) (I : IntervalRat) : Option DualInterval :=

--- a/LeanCert/Engine/AD/PartialCorrectness.lean
+++ b/LeanCert/Engine/AD/PartialCorrectness.lean
@@ -213,11 +213,11 @@ theorem evalDual?_val_correct (e : Expr) (hsupp : ExprSupportedWithInv e)
         simp only [Expr.eval_sqrt]
         exact IntervalRat.mem_sqrtInterval' (ih d heq)
       · exact absurd hsome (by simp)
-  | pi =>
+  | namedConst c =>
     simp only [evalDual?, Option.some.injEq] at hsome
     rw [← hsome]
-    simp only [Expr.eval_pi, DualInterval.piConst]
-    exact mem_piInterval
+    simp only [Expr.eval_namedConst, DualInterval.ofMathConst]
+    exact c.mem_interval
 
 /-- Single-variable version of evalDual?_val_correct -/
 theorem evalDual?1_val_correct (e : Expr) (hsupp : ExprSupportedWithInv e)
@@ -397,7 +397,7 @@ theorem evalFunc1_differentiableAt_of_evalDual? (e : Expr) (hsupp : ExprSupporte
         have hne : evalFunc1 e' x ≠ 0 := ne_of_gt hpos_x
         exact (Real.hasDerivAt_sqrt hne).differentiableAt.comp x (ih d heq)
       · exact absurd hsome (by simp)
-  | pi => exact differentiableAt_const _
+  | namedConst _ => exact differentiableAt_const _
 
 /-- The derivative component of evalDual? is correct when it returns some.
     For a supported expression (with inv) evaluated at a point x in the interval I,
@@ -818,10 +818,10 @@ theorem evalDual?_der_correct (e : Expr) (hsupp : ExprSupportedWithInv e)
         convert hmul using 1
         field_simp [ne_of_gt (Real.sqrt_pos.mpr hpos_x)]
       · exact absurd hsome (by simp)
-  | pi =>
+  | namedConst c =>
     simp only [evalDual?1, evalDual?, Option.some.injEq] at hsome
     rw [← hsome]
-    simp only [evalFunc1_pi, deriv_const, DualInterval.piConst]
+    simp only [evalFunc1_namedConst, deriv_const, DualInterval.ofMathConst]
     convert IntervalRat.mem_singleton 0 using 1
     norm_cast
 

--- a/LeanCert/Engine/Eval/Core.lean
+++ b/LeanCert/Engine/Eval/Core.lean
@@ -408,6 +408,47 @@ theorem mem_piInterval : Real.pi ∈ piInterval := by
     simp only [Rat.cast_div, Rat.cast_ofNat] at *
     linarith
 
+/-- Interval enclosure for the Euler–Mascheroni constant γ.
+    Uses bounds from Mathlib: 1/2 < γ < 2/3. -/
+def eulerMascheroniInterval : IntervalRat :=
+  ⟨1/2, 2/3, by norm_num⟩
+
+/-- Correctness of Euler–Mascheroni interval: γ ∈ eulerMascheroniInterval -/
+theorem mem_eulerMascheroniInterval :
+    Real.eulerMascheroniConstant ∈ eulerMascheroniInterval := by
+  simp only [IntervalRat.mem_def, eulerMascheroniInterval]
+  constructor
+  · -- Lower bound from 1/2 < γ
+    have h := Real.one_half_lt_eulerMascheroniConstant
+    simp only [Rat.cast_div, Rat.cast_ofNat] at *
+    linarith
+  · -- Upper bound from γ < 2/3
+    have h := Real.eulerMascheroniConstant_lt_two_thirds
+    simp only [Rat.cast_div, Rat.cast_ofNat] at *
+    linarith
+
+end LeanCert.Engine
+
+namespace LeanCert.Core.MathConst
+open LeanCert.Engine
+
+/-- Centralized interval lookup for named mathematical constants.
+    Extending this table is the ONLY change needed to add a new constant. -/
+def interval : MathConst → IntervalRat
+  | .pi => piInterval
+  | .eulerMascheroni => eulerMascheroniInterval
+
+/-- Correctness: the real value of every named constant is in its interval. -/
+theorem mem_interval (c : MathConst) : c.toReal ∈ c.interval := by
+  cases c with
+  | pi => exact mem_piInterval
+  | eulerMascheroni => exact mem_eulerMascheroniInterval
+
+end LeanCert.Core.MathConst
+
+namespace LeanCert.Engine
+open LeanCert.Core
+
 /-- Interval bound for sinh using computable Taylor series for exp.
     sinh(x) = (exp(x) - exp(-x)) / 2, and sinh is strictly monotonic.
     This computes tight bounds using the verified exp implementation. -/
@@ -617,7 +658,7 @@ def evalIntervalCore (e : Expr) (ρ : IntervalEnv) (cfg : EvalConfig := {}) : In
   | Expr.cosh e => coshInterval (evalIntervalCore e ρ cfg) cfg.taylorDepth
   | Expr.tanh e => tanhInterval (evalIntervalCore e ρ cfg)  -- Tight bounds: [-1, 1]
   | Expr.sqrt e => IntervalRat.sqrtIntervalTightPrec (evalIntervalCore e ρ cfg)
-  | Expr.pi => piInterval
+  | Expr.namedConst c => c.interval
 
 /-- Computable interval evaluator with division support.
 
@@ -670,7 +711,7 @@ def evalIntervalCoreWithDiv (e : Expr) (ρ : IntervalEnv) (cfg : EvalConfig := {
   | Expr.cosh e => coshInterval (evalIntervalCoreWithDiv e ρ cfg) cfg.taylorDepth
   | Expr.tanh e => tanhInterval (evalIntervalCoreWithDiv e ρ cfg)  -- Tight bounds: [-1, 1]
   | Expr.sqrt e => IntervalRat.sqrtIntervalTightPrec (evalIntervalCoreWithDiv e ρ cfg)
-  | Expr.pi => piInterval
+  | Expr.namedConst c => c.interval
 
 /-- A real environment is contained in an interval environment -/
 def envMem (ρ_real : Nat → ℝ) (ρ_int : IntervalEnv) : Prop :=
@@ -703,7 +744,7 @@ def evalDomainValid (e : Expr) (ρ : IntervalEnv) (cfg : EvalConfig := {}) : Pro
   | Expr.cosh e => evalDomainValid e ρ cfg
   | Expr.tanh e => evalDomainValid e ρ cfg
   | Expr.sqrt e => evalDomainValid e ρ cfg
-  | Expr.pi => True
+  | Expr.namedConst _ => True
 
 /-- Single-variable domain validity -/
 def evalDomainValid1 (e : Expr) (I : IntervalRat) (cfg : EvalConfig := {}) : Prop :=
@@ -731,7 +772,7 @@ def checkDomainValid (e : Expr) (ρ : IntervalEnv) (cfg : EvalConfig := {}) : Bo
   | Expr.cosh e => checkDomainValid e ρ cfg
   | Expr.tanh e => checkDomainValid e ρ cfg
   | Expr.sqrt e => checkDomainValid e ρ cfg
-  | Expr.pi => true
+  | Expr.namedConst _ => true
 
 /-- Single-variable domain check -/
 def checkDomainValid1 (e : Expr) (I : IntervalRat) (cfg : EvalConfig := {}) : Bool :=
@@ -811,7 +852,7 @@ theorem checkDomainValid_correct (e : Expr) (ρ : IntervalEnv) (cfg : EvalConfig
     simp only [checkDomainValid] at h
     simp only [evalDomainValid]
     exact ih h
-  | pi => trivial
+  | namedConst _ => trivial
 
 /-- checkDomainValid1 = true implies evalDomainValid1 -/
 theorem checkDomainValid1_correct (e : Expr) (I : IntervalRat) (cfg : EvalConfig)
@@ -895,7 +936,7 @@ theorem evalDomainValid_iff_checkDomainValid (e : Expr) (ρ : IntervalEnv) (cfg 
       simp only [evalDomainValid] at h
       simp only [checkDomainValid]
       exact ih h
-    | pi => rfl
+    | namedConst _ => rfl
   · -- checkDomainValid → evalDomainValid
     exact checkDomainValid_correct e ρ cfg
 
@@ -994,9 +1035,9 @@ theorem evalIntervalCore_correct (e : Expr) (hsupp : ExprSupportedCore e)
     simp only [evalDomainValid] at hdom
     simp only [Expr.eval_erf, evalIntervalCore]
     exact mem_erfInterval (ih hdom) cfg.taylorDepth
-  | pi =>
-    simp only [Expr.eval_pi, evalIntervalCore]
-    exact mem_piInterval
+  | namedConst c =>
+    simp only [Expr.eval_namedConst, evalIntervalCore]
+    exact c.mem_interval
 
 /-! ### Convenience functions -/
 

--- a/LeanCert/Engine/Eval/Core.lean
+++ b/LeanCert/Engine/Eval/Core.lean
@@ -409,23 +409,49 @@ theorem mem_piInterval : Real.pi ∈ piInterval := by
     linarith
 
 /-- Interval enclosure for the Euler–Mascheroni constant γ.
-    Uses bounds from Mathlib: 1/2 < γ < 2/3. -/
+    Tight bounds derived from `eulerMascheroniSeq 100 < γ < eulerMascheroniSeq' 100`
+    combined with LeanCert's computable log intervals. -/
 def eulerMascheroniInterval : IntervalRat :=
-  ⟨1/2, 2/3, by norm_num⟩
+  ⟨5722/10000, 5823/10000, by norm_num⟩
+
+/-- Helper: log(101) ≤ (logPointComputable 101 30).hi, and that hi ≤ harmonic(100) - 5722/10000. -/
+private theorem eulerMascheroniSeq_100_ge :
+    (5722/10000 : ℝ) ≤ Real.eulerMascheroniSeq 100 := by
+  have hlog := (IntervalRat.mem_logPointComputable (by norm_num : (101 : ℚ) > 0) 30).2
+  -- hlog : Real.log ↑101 ≤ ↑(logPointComputable 101 30).hi
+  have hcmp : (IntervalRat.logPointComputable 101 30).hi ≤ harmonic 100 - 5722/10000 := by
+    native_decide
+  have : Real.eulerMascheroniSeq 100 = ↑(harmonic 100 : ℚ) - Real.log 101 := by
+    simp [Real.eulerMascheroniSeq]; ring
+  rw [this]
+  have hle : Real.log 101 ≤ ↑(harmonic 100 : ℚ) - ↑(5722/10000 : ℚ) :=
+    le_trans hlog (by exact_mod_cast hcmp)
+  push_cast at hle ⊢; linarith
+
+/-- Helper: harmonic(100) - 5823/10000 ≤ (logPointComputable 100 30).lo ≤ log(100). -/
+private theorem eulerMascheroniSeq'_100_le :
+    Real.eulerMascheroniSeq' 100 ≤ (5823/10000 : ℝ) := by
+  have hlog := (IntervalRat.mem_logPointComputable (by norm_num : (100 : ℚ) > 0) 30).1
+  have hcmp : harmonic 100 - 5823/10000 ≤ (IntervalRat.logPointComputable 100 30).lo := by
+    native_decide
+  have : Real.eulerMascheroniSeq' 100 = ↑(harmonic 100 : ℚ) - Real.log 100 := by
+    simp [Real.eulerMascheroniSeq']
+  rw [this]
+  have hle : ↑(harmonic 100 : ℚ) - ↑(5823/10000 : ℚ) ≤ Real.log 100 :=
+    le_trans (by exact_mod_cast hcmp) hlog
+  push_cast at hle ⊢; linarith
 
 /-- Correctness of Euler–Mascheroni interval: γ ∈ eulerMascheroniInterval -/
 theorem mem_eulerMascheroniInterval :
     Real.eulerMascheroniConstant ∈ eulerMascheroniInterval := by
   simp only [IntervalRat.mem_def, eulerMascheroniInterval]
   constructor
-  · -- Lower bound from 1/2 < γ
-    have h := Real.one_half_lt_eulerMascheroniConstant
-    simp only [Rat.cast_div, Rat.cast_ofNat] at *
-    linarith
-  · -- Upper bound from γ < 2/3
-    have h := Real.eulerMascheroniConstant_lt_two_thirds
-    simp only [Rat.cast_div, Rat.cast_ofNat] at *
-    linarith
+  · -- Lower: 5722/10000 ≤ eulerMascheroniSeq 100 < γ
+    have := Real.eulerMascheroniSeq_lt_eulerMascheroniConstant 100
+    linarith [eulerMascheroniSeq_100_ge]
+  · -- Upper: γ < eulerMascheroniSeq' 100 ≤ 5823/10000
+    have := Real.eulerMascheroniConstant_lt_eulerMascheroniSeq' 100
+    linarith [eulerMascheroniSeq'_100_le]
 
 end LeanCert.Engine
 

--- a/LeanCert/Engine/Eval/Extended.lean
+++ b/LeanCert/Engine/Eval/Extended.lean
@@ -68,7 +68,7 @@ noncomputable def evalInterval (e : Expr) (ρ : IntervalEnv) : IntervalRat :=
   | Expr.cosh _ => default  -- cosh unbounded; use evalIntervalCore for tight bounds
   | Expr.tanh _ => default  -- tanh bounded but not in ExprSupported; use evalIntervalCore
   | Expr.sqrt e => IntervalRat.sqrtInterval (evalInterval e ρ)
-  | Expr.pi => piInterval
+  | Expr.namedConst c => c.interval
 
 /-- Fundamental correctness theorem for extended evaluation.
 
@@ -218,7 +218,7 @@ def evalInterval? (e : Expr) (ρ : IntervalEnv) : Option IntervalRat :=
       match evalInterval? e ρ with
       | some I => some (IntervalRat.sqrtInterval I)
       | none => none
-  | Expr.pi => some piInterval
+  | Expr.namedConst c => some c.interval
 
 /-- Main correctness theorem for evalInterval? (approach 1 from plan).
 
@@ -408,11 +408,11 @@ theorem evalInterval?_correct (e : Expr) (hsupp : ExprSupportedWithInv e)
       cases hsome
       simp only [Expr.eval_sqrt]
       exact IntervalRat.mem_sqrtInterval' (ih I' heq)
-  | pi =>
+  | namedConst c =>
     simp only [evalInterval?] at hsome
     cases hsome
-    simp only [Expr.eval_pi]
-    exact mem_piInterval
+    simp only [Expr.eval_namedConst]
+    exact c.mem_interval
 
 /-- Single-variable version of evalInterval? -/
 def evalInterval?1 (e : Expr) (I : IntervalRat) : Option IntervalRat :=

--- a/LeanCert/Engine/Extended.lean
+++ b/LeanCert/Engine/Extended.lean
@@ -481,8 +481,8 @@ def evalExtended (e : Expr) (ρ : ExtendedEnv) (cfg : ExtendedConfig := {}) : Ex
       liftUnary tanhInterval (evalExtended e ρ cfg)
   | Expr.sqrt e =>
       liftUnary IntervalRat.sqrtInterval (evalExtended e ρ cfg)
-  | Expr.pi =>
-      ExtendedInterval.singleton piInterval
+  | Expr.namedConst c =>
+      ExtendedInterval.singleton c.interval
 
 /-- Convenience function for single-variable extended evaluation -/
 def evalExtended1 (e : Expr) (I : IntervalRat) (cfg : ExtendedConfig := {}) : ExtendedInterval :=
@@ -522,7 +522,7 @@ def evalDomainValidExtended (e : Expr) (ρ : ExtendedEnv) (cfg : ExtendedConfig 
   | Expr.cosh e => evalDomainValidExtended e ρ cfg
   | Expr.tanh e => evalDomainValidExtended e ρ cfg
   | Expr.sqrt e => evalDomainValidExtended e ρ cfg
-  | Expr.pi => True
+  | Expr.namedConst _ => True
 
 /-- Domain validity is trivially true for ExprSupported expressions (which exclude log). -/
 theorem evalDomainValidExtended_of_ExprSupported {e : Expr} (hsupp : ExprSupported e)
@@ -656,10 +656,10 @@ theorem evalExtended_correct_core (e : Expr) (hsupp : ExprSupportedCore e)
     · simp only [List.mem_map]
       exact ⟨I, hI_filter, rfl⟩
     · exact IntervalRat.mem_logComputable hx_in_I hI_lo_pos cfg.taylorDepth
-  | pi =>
-    simp only [Expr.eval_pi, evalExtended]
+  | namedConst c =>
+    simp only [Expr.eval_namedConst, evalExtended]
     rw [ExtendedInterval.mem_singleton]
-    exact mem_piInterval
+    exact c.mem_interval
 
 /-! ## Utility: Hull Soundness -/
 

--- a/LeanCert/Engine/FloatEval.lean
+++ b/LeanCert/Engine/FloatEval.lean
@@ -104,7 +104,7 @@ def evalFloat (e : Expr) (ρ : FloatEnv) : Float :=
       if x.abs < 1e-10 then 1.0
       else Float.sin x / x
   | Expr.erf a => floatErf (evalFloat a ρ)
-  | Expr.pi => 3.141592653589793
+  | Expr.namedConst c => c.toFloat
 
 /-- Evaluate with a list-based environment (for compatibility with Box) -/
 def evalFloatList (e : Expr) (vars : List Float) : Float :=

--- a/LeanCert/Engine/IntervalEvalAffine.lean
+++ b/LeanCert/Engine/IntervalEvalAffine.lean
@@ -148,8 +148,8 @@ def evalIntervalAffine (e : Expr) (ρ : AffineEnv) (cfg : AffineConfig := {}) : 
   | Expr.erf e =>
       -- erf bounded in [-1, 1]
       { c0 := 0, coeffs := [], r := 1, r_nonneg := by norm_num }
-  | Expr.pi =>
-      let I := piInterval
+  | Expr.namedConst c =>
+      let I := c.interval
       let mid := (I.lo + I.hi) / 2
       let rad := (I.hi - I.lo) / 2
       { c0 := mid, coeffs := [], r := |rad|, r_nonneg := abs_nonneg _ }
@@ -200,7 +200,7 @@ def evalDomainValidAffine (e : Expr) (ρ : AffineEnv) (cfg : AffineConfig := {})
   | Expr.cosh e => evalDomainValidAffine e ρ cfg
   | Expr.tanh e => evalDomainValidAffine e ρ cfg
   | Expr.sqrt e => evalDomainValidAffine e ρ cfg
-  | Expr.pi => True
+  | Expr.namedConst _ => True
 
 /-- Domain validity is trivially true for ExprSupported expressions (which exclude log). -/
 theorem evalDomainValidAffine_of_ExprSupported {e : Expr} (hsupp : ExprSupported e)
@@ -317,9 +317,9 @@ theorem evalIntervalAffine_correct (e : Expr) (hsupp : ExprSupportedCore e)
     simp only [Expr.eval_log, evalIntervalAffine, hpos]
     have hlog_in := IntervalRat.mem_logComputable hv_in_I hpos cfg.taylorDepth
     exact AffineForm.mem_affine_of_interval (eps := eps) hlog_in
-  | pi =>
-    simp only [Expr.eval_pi, evalIntervalAffine]
-    simpa using (AffineForm.mem_affine_of_interval (eps := eps) mem_piInterval)
+  | namedConst c =>
+    simp only [Expr.eval_namedConst, evalIntervalAffine]
+    simpa using (AffineForm.mem_affine_of_interval (eps := eps) c.mem_interval)
 
 /-- Corollary: The interval produced by toInterval contains the true value.
 

--- a/LeanCert/Engine/IntervalEvalDyadic.lean
+++ b/LeanCert/Engine/IntervalEvalDyadic.lean
@@ -268,7 +268,7 @@ def evalIntervalDyadic (e : Expr) (ρ : IntervalDyadicEnv) (cfg : DyadicConfig :
   | Expr.cosh e => coshIntervalDyadic (evalIntervalDyadic e ρ cfg) cfg
   | Expr.tanh e => tanhIntervalDyadic (evalIntervalDyadic e ρ cfg) cfg
   | Expr.sqrt e => sqrtIntervalDyadic (evalIntervalDyadic e ρ cfg) cfg
-  | Expr.pi => IntervalDyadic.ofIntervalRat piInterval cfg.precision
+  | Expr.namedConst c => IntervalDyadic.ofIntervalRat c.interval cfg.precision
 
 /-! ### Correctness -/
 
@@ -304,7 +304,7 @@ def evalDomainValidDyadic (e : Expr) (ρ : IntervalDyadicEnv) (cfg : DyadicConfi
   | Expr.cosh e => evalDomainValidDyadic e ρ cfg
   | Expr.tanh e => evalDomainValidDyadic e ρ cfg
   | Expr.sqrt e => evalDomainValidDyadic e ρ cfg
-  | Expr.pi => True
+  | Expr.namedConst _ => True
 
 /-- Computable (Bool) domain validity check for Dyadic evaluation. -/
 def checkDomainValidDyadic (e : Expr) (ρ : IntervalDyadicEnv) (cfg : DyadicConfig := {}) : Bool :=
@@ -333,7 +333,7 @@ def checkDomainValidDyadic (e : Expr) (ρ : IntervalDyadicEnv) (cfg : DyadicConf
   | Expr.cosh e => checkDomainValidDyadic e ρ cfg
   | Expr.tanh e => checkDomainValidDyadic e ρ cfg
   | Expr.sqrt e => checkDomainValidDyadic e ρ cfg
-  | Expr.pi => true
+  | Expr.namedConst _ => true
 
 theorem checkDomainValidDyadic_correct (e : Expr) (ρ : IntervalDyadicEnv) (cfg : DyadicConfig) :
     checkDomainValidDyadic e ρ cfg = true → evalDomainValidDyadic e ρ cfg := by
@@ -369,7 +369,7 @@ theorem checkDomainValidDyadic_correct (e : Expr) (ρ : IntervalDyadicEnv) (cfg 
   | cosh e ih => simp only [checkDomainValidDyadic, evalDomainValidDyadic]; exact ih
   | tanh e ih => simp only [checkDomainValidDyadic, evalDomainValidDyadic]; exact ih
   | sqrt e ih => simp only [checkDomainValidDyadic, evalDomainValidDyadic]; exact ih
-  | pi => intro; trivial
+  | namedConst _ => intro; trivial
 
 /-- Domain validity is trivially true for ExprSupported expressions (which exclude log). -/
 theorem evalDomainValidDyadic_of_ExprSupported {e : Expr} (hsupp : ExprSupported e)
@@ -497,9 +497,9 @@ theorem evalIntervalDyadic_correct (e : Expr) (hsupp : ExprSupportedCore e)
     simp only [hpos, ↓reduceIte]
     have hlog := IntervalRat.mem_logComputable hrat hpos cfg.taylorDepth
     exact IntervalDyadic.mem_ofIntervalRat hlog cfg.precision hprec
-  | pi =>
-    simp only [Expr.eval_pi, evalIntervalDyadic]
-    exact IntervalDyadic.mem_ofIntervalRat mem_piInterval cfg.precision hprec
+  | namedConst c =>
+    simp only [Expr.eval_namedConst, evalIntervalDyadic]
+    exact IntervalDyadic.mem_ofIntervalRat c.mem_interval cfg.precision hprec
 
 /-- Correctness theorem for Dyadic evaluation with ExprSupportedWithInv.
 
@@ -606,9 +606,9 @@ theorem evalIntervalDyadic_correct_withInv (e : Expr) (hsupp : ExprSupportedWith
     simp only [evalDomainValidDyadic] at hdom
     simp only [Expr.eval_sqrt, evalIntervalDyadic, sqrtIntervalDyadic]
     exact IntervalDyadic.mem_sqrt' (ih hdom) cfg.precision
-  | pi =>
-    simp only [Expr.eval_pi, evalIntervalDyadic]
-    exact IntervalDyadic.mem_ofIntervalRat mem_piInterval cfg.precision hprec
+  | namedConst c =>
+    simp only [Expr.eval_namedConst, evalIntervalDyadic]
+    exact IntervalDyadic.mem_ofIntervalRat c.mem_interval cfg.precision hprec
 
 /-! ### Convenience Functions -/
 

--- a/LeanCert/Engine/IntervalEvalReal.lean
+++ b/LeanCert/Engine/IntervalEvalReal.lean
@@ -102,7 +102,7 @@ noncomputable def evalIntervalReal (e : Expr) (ρ : IntervalRealEnv) : IntervalR
   | Expr.cosh e => IntervalReal.coshInterval (evalIntervalReal e ρ)
   | Expr.tanh _ => ⟨-1, 1, by norm_num⟩  -- tanh is bounded by (-1, 1)
   | Expr.sqrt e => IntervalReal.sqrtInterval (evalIntervalReal e ρ)
-  | Expr.pi => ⟨Real.pi, Real.pi, le_refl _⟩  -- Pi as singleton interval
+  | Expr.namedConst c => ⟨c.toReal, c.toReal, le_refl _⟩
 
 /-- A real environment is contained in a real-interval environment -/
 def envMemReal (ρ_real : Nat → ℝ) (ρ_int : IntervalRealEnv) : Prop :=

--- a/LeanCert/Engine/IntervalEvalRefined.lean
+++ b/LeanCert/Engine/IntervalEvalRefined.lean
@@ -199,7 +199,7 @@ noncomputable def evalIntervalRefined (e : Expr) (ρ : IntervalEnv) : IntervalRa
   | Expr.cosh e => coshInterval (evalIntervalRefined e ρ)
   | Expr.tanh e => tanhInterval (evalIntervalRefined e ρ)
   | Expr.sqrt e => (evalIntervalRefined e ρ).sqrtInterval
-  | Expr.pi => piInterval
+  | Expr.namedConst c => c.interval
 
 /-- Single-variable refined interval evaluation -/
 noncomputable def evalIntervalRefined1 (e : Expr) (I : IntervalRat) : IntervalRat :=
@@ -284,7 +284,7 @@ noncomputable def evalDualRefined (e : Expr) (ρ : DualEnv) : DualInterval :=
   | Expr.cosh e => DualInterval.cosh (evalDualRefined e ρ)
   | Expr.tanh e => DualInterval.tanh (evalDualRefined e ρ)
   | Expr.sqrt e => DualInterval.sqrt (evalDualRefined e ρ)
-  | Expr.pi => DualInterval.piConst
+  | Expr.namedConst c => DualInterval.ofMathConst c
 
 /-- Single-variable refined dual evaluation -/
 noncomputable def evalDualRefined1 (e : Expr) (I : IntervalRat) : DualInterval :=

--- a/LeanCert/Engine/Optimization/BoundVerify.lean
+++ b/LeanCert/Engine/Optimization/BoundVerify.lean
@@ -314,7 +314,7 @@ def Expr.usesOnlyVar0 : Expr → Bool
   | .cosh e => e.usesOnlyVar0
   | .tanh e => e.usesOnlyVar0
   | .sqrt e => e.usesOnlyVar0
-  | .pi => true
+  | .namedConst _ => true
 
 /-- If an expression uses only var 0, evaluation depends only on ρ 0 -/
 theorem Expr.eval_usesOnlyVar0 (e : Expr) (he : e.usesOnlyVar0 = true)
@@ -353,7 +353,7 @@ theorem Expr.eval_usesOnlyVar0 (e : Expr) (he : e.usesOnlyVar0 = true)
   | cosh e ih => simp only [Expr.eval, ih he]
   | tanh e ih => simp only [Expr.eval, ih he]
   | sqrt e ih => simp only [Expr.eval, ih he]
-  | pi => rfl
+  | namedConst _ => rfl
 
 /-! ### Tactic-facing lemmas for adaptive bound verification -/
 

--- a/LeanCert/Engine/TaylorModel/Expr.lean
+++ b/LeanCert/Engine/TaylorModel/Expr.lean
@@ -294,11 +294,9 @@ noncomputable def fromExpr (e : Expr) (domain : IntervalRat) (degree : ℕ) : Ta
   | Expr.sqrt e =>
       -- sqrt? always succeeds, so we can safely extract
       (sqrt? (fromExpr e domain degree)).getD (const 0 domain)
-  | Expr.pi =>
-      -- Pi is represented as a constant Taylor model with the pi interval as remainder
-      -- We use the pi interval [3.14, 3.15] which encloses Real.pi
+  | Expr.namedConst c =>
       { poly := 0
-        remainder := LeanCert.Engine.piInterval
+        remainder := c.interval
         center := domain.lo + (domain.hi - domain.lo) / 2
         domain := domain }
 
@@ -365,10 +363,9 @@ noncomputable def fromExpr? (e : Expr) (domain : IntervalRat) (degree : ℕ) :
   | Expr.sqrt e => do
       let tm ← fromExpr? e domain degree
       sqrt? tm
-  | Expr.pi =>
-      -- Pi is a constant Taylor model with pi interval as remainder
+  | Expr.namedConst c =>
       some { poly := 0
-             remainder := LeanCert.Engine.piInterval
+             remainder := c.interval
              center := domain.midpoint
              domain := domain }
 
@@ -540,7 +537,7 @@ theorem fromExpr?_center (e : Expr) (domain : IntervalRat) (degree : ℕ)
         simp only [Option.some.injEq] at h
         cases h
         exact ih degree tm0 h0
-  | pi =>
+  | namedConst _ =>
       intro tm h
       simp [TaylorModel.fromExpr?] at h
       cases h
@@ -977,7 +974,7 @@ theorem fromExpr?_domain (e : Expr) (domain : IntervalRat) (degree : ℕ)
         simp only [Option.some.injEq] at h
         cases h
         exact ih degree tm0 h0
-  | pi =>
+  | namedConst _ =>
       intro tm h
       simp [TaylorModel.fromExpr?] at h
       cases h
@@ -1248,12 +1245,12 @@ theorem fromExpr_evalSet_correct (e : Expr) (domain : IntervalRat) (degree : ℕ
         · -- sqrt of argument is in sqrtIntervalTight
           exact IntervalRat.mem_sqrtIntervalTight' h_arg_in_bound
         · simp only [Polynomial.aeval_zero]; ring
-  | pi =>
+  | namedConst c =>
       simp [TaylorModel.fromExpr?] at h
       cases h
       intro x _hx
-      simp only [Expr.eval_pi, TaylorModel.evalSet, Set.mem_setOf_eq]
-      refine ⟨Real.pi, mem_piInterval, ?_⟩
+      simp only [Expr.eval_namedConst, TaylorModel.evalSet, Set.mem_setOf_eq]
+      refine ⟨c.toReal, c.mem_interval, ?_⟩
       simp only [Polynomial.aeval_zero]; ring
 
 /-- fromExpr? produces correct Taylor models when it succeeds. -/

--- a/LeanCert/Meta/ProveContinuous.lean
+++ b/LeanCert/Meta/ProveContinuous.lean
@@ -196,7 +196,7 @@ def exprContinuousDomainValid (e : LExpr) (s : Set ℝ) : Prop :=
   | LeanCert.Core.Expr.cosh e => exprContinuousDomainValid e s
   | LeanCert.Core.Expr.tanh e => exprContinuousDomainValid e s
   | LeanCert.Core.Expr.sqrt e => exprContinuousDomainValid e s
-  | LeanCert.Core.Expr.pi => True
+  | LeanCert.Core.Expr.namedConst _ => True
 
 /-- Domain validity is trivially true for ExprSupported expressions (which exclude log). -/
 theorem exprContinuousDomainValid_of_ExprSupported {e : LExpr}
@@ -315,7 +315,7 @@ theorem exprSupportedCore_continuousOn (e : LExpr) (hsupp : LeanCert.Engine.Expr
       simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
       exact ne_of_gt (hdom.2 x hx)
     exact Real.continuousOn_log.comp harg_cont hs_maps
-  | pi =>
+  | namedConst _ =>
     simp only [LeanCert.Core.Expr.eval]
     exact continuousOn_const
 

--- a/LeanCert/Meta/ProveSupported.lean
+++ b/LeanCert/Meta/ProveSupported.lean
@@ -306,9 +306,9 @@ partial def mkSupportedCoreProof (e_ast : Lean.Expr) : MetaM Lean.Expr := do
     let h ← mkSupportedCoreProof e
     mkAppM ``LeanCert.Core.ExprSupportedCore.erf #[h]
 
-  else if fn.isConstOf ``LeanCert.Core.Expr.pi then
-    -- Expr.pi => ExprSupportedCore.pi
-    pure <| Lean.mkConst ``LeanCert.Core.ExprSupportedCore.pi
+  else if fn.isConstOf ``LeanCert.Core.Expr.namedConst then
+    let c := args[0]!
+    mkAppM ``LeanCert.Core.ExprSupportedCore.namedConst #[c]
 
   else
     throwError "Cannot generate ExprSupportedCore proof for: {e_ast}\n\
@@ -412,9 +412,9 @@ partial def mkSupportedWithInvProof (e_ast : Lean.Expr) : MetaM Lean.Expr := do
     let h ← mkSupportedWithInvProof e
     mkAppM ``LeanCert.Core.ExprSupportedWithInv.sqrt #[h]
 
-  else if fn.isConstOf ``LeanCert.Core.Expr.pi then
-    -- Expr.pi => ExprSupportedWithInv.pi
-    pure <| Lean.mkConst ``LeanCert.Core.ExprSupportedWithInv.pi
+  else if fn.isConstOf ``LeanCert.Core.Expr.namedConst then
+    let c := args[0]!
+    mkAppM ``LeanCert.Core.ExprSupportedWithInv.namedConst #[c]
 
   else
     throwError "Cannot generate ExprSupportedWithInv proof for: {e_ast}\n\

--- a/LeanCert/Meta/ToExpr.lean
+++ b/LeanCert/Meta/ToExpr.lean
@@ -162,9 +162,17 @@ def mkExprCosh (e : Lean.Expr) : MetaM Lean.Expr :=
 def mkExprTanh (e : Lean.Expr) : MetaM Lean.Expr :=
   mkAppM ``LeanCert.Core.Expr.tanh #[e]
 
-/-- Build `LeanCert.Core.Expr.pi`. -/
+/-- Build `LeanCert.Core.Expr.namedConst c`. -/
+def mkExprNamedConst (c : Lean.Expr) : MetaM Lean.Expr :=
+  mkAppM ``LeanCert.Core.Expr.namedConst #[c]
+
+/-- Build `LeanCert.Core.Expr.namedConst .pi`. -/
 def mkExprPi : MetaM Lean.Expr :=
-  mkAppM ``LeanCert.Core.Expr.pi #[]
+  mkExprNamedConst (mkConst ``LeanCert.Core.MathConst.pi)
+
+/-- Build `LeanCert.Core.Expr.namedConst .eulerMascheroni`. -/
+def mkExprEulerMascheroni : MetaM Lean.Expr :=
+  mkExprNamedConst (mkConst ``LeanCert.Core.MathConst.eulerMascheroni)
 
 /-- Build max(a,b) via `(a + b + |b - a|) / 2` in existing Expr constructors. -/
 def mkExprMaxViaAbs (a b : Lean.Expr) : MetaM Lean.Expr := do
@@ -278,7 +286,9 @@ where
 
     -- Nullary constants
     if headName == ``Real.pi then
-      return some (← mkExprPi)
+      return some (← mkExprNamedConst (mkConst ``LeanCert.Core.MathConst.pi))
+    if headName == ``Real.eulerMascheroniConstant then
+      return some (← mkExprNamedConst (mkConst ``LeanCert.Core.MathConst.eulerMascheroni))
 
     -- Unary operations dispatched from a table
     if let some mk := lookupUnary headName then
@@ -408,7 +418,7 @@ where
                 • Transcendentals: Real.sin, Real.cos, Real.exp, Real.log,\n\
                   Real.sqrt, Real.arctan, Real.arsinh, Real.atanh,\n\
                   Real.sinc, Real.erf, Real.sinh, Real.cosh, Real.tanh\n\
-                • Constants: rational numbers, Real.pi\n\n\
+                • Constants: rational numbers, Real.pi, Real.eulerMascheroniConstant\n\n\
                 Suggestions:\n\
                 • Normalize first with `interval_norm`\n\
                 • Unfold custom definitions with `simp only [myDef]`\n\

--- a/LeanCert/Test/EulerMascheroni.lean
+++ b/LeanCert/Test/EulerMascheroni.lean
@@ -8,21 +8,16 @@ import LeanCert.Tactic.IntervalAuto
 /-!
 # Tests for `Real.eulerMascheroniConstant` support in `interval_decide`
 
-Uses Mathlib bounds: 1/2 < γ < 2/3.
+Uses tight bounds: 0.5722 ≤ γ ≤ 0.5823, derived from
+`eulerMascheroniSeq 100 < γ < eulerMascheroniSeq' 100`
+combined with LeanCert's computable log intervals.
 -/
 
 -- The motivating example from the issue
 example : (0.5 : ℝ) ≤ Real.eulerMascheroniConstant := by interval_decide
 
--- Upper bound
-example : Real.eulerMascheroniConstant ≤ 0.667 := by interval_decide
+-- Tighter lower bound (impossible with Mathlib's 1/2 alone)
+example : (0.572 : ℝ) ≤ Real.eulerMascheroniConstant := by interval_decide
 
--- Both directions
-example : (0.5 : ℝ) ≤ Real.eulerMascheroniConstant ∧
-    Real.eulerMascheroniConstant ≤ 0.667 := by constructor <;> interval_decide
-
--- In an expression: γ + 1 > 1.5
-example : (1.5 : ℝ) ≤ Real.eulerMascheroniConstant + 1 := by interval_decide
-
--- Combined with π
-example : Real.eulerMascheroniConstant ≤ Real.pi := by interval_decide
+-- Tighter upper bound (impossible with Mathlib's 2/3 alone)
+example : Real.eulerMascheroniConstant ≤ 0.583 := by interval_decide

--- a/LeanCert/Test/EulerMascheroni.lean
+++ b/LeanCert/Test/EulerMascheroni.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.IntervalAuto
+
+/-!
+# Tests for `Real.eulerMascheroniConstant` support in `interval_decide`
+
+Uses Mathlib bounds: 1/2 < γ < 2/3.
+-/
+
+-- The motivating example from the issue
+example : (0.5 : ℝ) ≤ Real.eulerMascheroniConstant := by interval_decide
+
+-- Upper bound
+example : Real.eulerMascheroniConstant ≤ 0.667 := by interval_decide
+
+-- Both directions
+example : (0.5 : ℝ) ≤ Real.eulerMascheroniConstant ∧
+    Real.eulerMascheroniConstant ≤ 0.667 := by constructor <;> interval_decide
+
+-- In an expression: γ + 1 > 1.5
+example : (1.5 : ℝ) ≤ Real.eulerMascheroniConstant + 1 := by interval_decide
+
+-- Combined with π
+example : Real.eulerMascheroniConstant ≤ Real.pi := by interval_decide


### PR DESCRIPTION
Adds a `MathConst` enum so that named mathematical constants (π, γ, …) are handled by a single `Expr.namedConst` constructor instead of one constructor per constant. Every evaluator dispatches through `c.interval` / `c.toReal` / `c.toFloat`, so adding a future constant means extending the enum and its lookup tables in 3 files — zero evaluator changes needed.

As the first use, this adds `Real.eulerMascheroniConstant` support for `interval_decide`. Bounds are derived from `eulerMascheroniSeq 100 < γ < eulerMascheroniSeq' 100` combined with LeanCert's `logPointComputable`, giving 0.5722 ≤ γ ≤ 0.5823 (~2 decimal digits). Scaling to more digits means increasing n in the same proof pattern.

```lean
example : (0.572 : ℝ) ≤ Real.eulerMascheroniConstant := by interval_decide
example : Real.eulerMascheroniConstant ≤ 0.583 := by interval_decide
```

New test file at `Test/EulerMascheroni.lean`.