### PR TITLE
Add certified q-product integral framework

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -54,6 +54,9 @@ import LeanCert.Engine.Extended
 -- Search + Certify APIs
 import LeanCert.Engine.SearchAPI
 
+-- Q-product product-integral certificates
+import LeanCert.QProduct
+
 -- Meta (metaprogramming utilities)
 import LeanCert.Meta.ProveContinuous
 import LeanCert.Meta.ProveSupported
@@ -265,6 +268,48 @@ export LeanCert.Engine.SearchAPI (
   isNegativeOn
   getLowerBound
   getUpperBound
+)
+
+-- Re-export QProduct API
+export LeanCert.QProduct (
+  qProd
+  F
+  subsetSign
+  subsetWeight
+  finiteIntegralRat
+  momentRat
+  moment
+  finiteIntegralRat_correct
+  momentRat_correct
+  qProd_powerset_expand
+  qProd_nonneg
+  qProd_le_one
+  pow_mem_unit_interval
+  F_nonneg
+  F_le_one
+  F_antitone
+  one_sub_prod_one_sub_le_sum
+  qProd_sub_le_commonPrefix_sum
+  odd_tail_telescope_bound
+  odd_tail_sum_le_geom
+  checkFiniteIntegralInterval
+  verify_finiteIntegral_interval
+  checkFiniteIntegralUpper
+  checkFiniteIntegralLower
+  verify_finiteIntegral_upper
+  verify_finiteIntegral_lower
+  primesLE
+  primeFRat
+  primeLambda
+  primeFRat_antitone
+  primeLambda_le_trunc
+  primeLambda_lower_of_forall
+  checkPrimeLambdaUpper
+  verify_primeLambda_upper
+  verify_primeLambda_interval_of_forall
+  primeFRat_lower_nineteen_thirtysix
+  primeLambda_lower_nineteen_thirtysix
+  primeLambda_gt_half
 )
 
 /-! ### Convenience abbreviations -/

--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -300,6 +300,9 @@ export LeanCert.QProduct (
   verify_finiteIntegral_lower
   primesLE
   primeFRat
+  primeSandwichErrorRat
+  primeSandwichLowerRat
+  primeSandwichLowerFun
   primeLambda
   primeFRat_antitone
   primeLambda_le_trunc
@@ -307,6 +310,19 @@ export LeanCert.QProduct (
   checkPrimeLambdaUpper
   verify_primeLambda_upper
   verify_primeLambda_interval_of_forall
+  prime_odd_of_gt_two
+  odd_ge_form
+  telescope_odd_sum_bound_from
+  primeSandwichLowerFun_pointwise_of_tail_ge
+  primeSandwichLowerFun_le_prime_truncation_of_tail_ge
+  integral_primeSandwichLowerFun_eq_rat
+  primeSandwichLowerRat_le_truncation_of_tail_ge
+  primeSandwichLowerRat_le_lambda_of_tail_ge
+  primeLambda_rational_sandwich
+  primeLambda_sandwich
+  primeSandwichErrorRat_three_five
+  primeSandwichLowerRat_three_five
+  primeSandwichLowerRat_three_five_le_lambda
   primeFRat_lower_nineteen_thirtysix
   primeLambda_lower_nineteen_thirtysix
   primeLambda_gt_half

--- a/LeanCert/Examples.lean
+++ b/LeanCert/Examples.lean
@@ -7,6 +7,8 @@ import LeanCert.Examples.GlobalOptimization
 import LeanCert.Examples.EdgeCases
 import LeanCert.Examples.NeuralNet
 import LeanCert.Examples.Showcase
+import LeanCert.Examples.QProduct.Basic
+import LeanCert.Examples.QProduct.PrimeLambda
 import LeanCert.Examples.ML.Distillation
 import LeanCert.Examples.ML.SineApprox
 import LeanCert.Examples.ML.SineNetWeights

--- a/LeanCert/Examples/QProduct/Basic.lean
+++ b/LeanCert/Examples/QProduct/Basic.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.QProduct
+
+/-!
+# Basic q-product examples
+-/
+
+open LeanCert.QProduct
+
+example : finiteIntegralRat (∅ : Finset Nat) = 1 := by
+  native_decide
+
+example : finiteIntegralRat ({2} : Finset Nat) = 2 / 3 := by
+  native_decide
+
+example : finiteIntegralRat ({2, 3} : Finset Nat) = 7 / 12 := by
+  native_decide
+
+example : F ({2, 3} : Finset Nat) = (7 : ℝ) / 12 := by
+  have h : finiteIntegralRat ({2, 3} : Finset Nat) = 7 / 12 := by
+    native_decide
+  rw [← finiteIntegralRat_correct]
+  rw [h]
+  norm_num
+
+example :
+    ((7 / 12 : ℚ) : ℝ) ≤ F ({2, 3} : Finset Nat) ∧
+    F ({2, 3} : Finset Nat) ≤ ((7 / 12 : ℚ) : ℝ) :=
+  verify_finiteIntegral_interval ({2, 3} : Finset Nat) (7 / 12) (7 / 12) (by native_decide)
+
+example :
+    F ({2, 3, 5} : Finset Nat) ≤ F ({2, 3} : Finset Nat) := by
+  apply F_antitone
+  intro n hn
+  simp at hn ⊢
+  rcases hn with rfl | rfl <;> simp

--- a/LeanCert/Examples/QProduct/PrimeLambda.lean
+++ b/LeanCert/Examples/QProduct/PrimeLambda.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.QProduct
+
+/-!
+# Prime q-product examples
+-/
+
+open LeanCert.QProduct
+
+example : primeFRat 3 = 7 / 12 := by
+  native_decide
+
+example : primeLambda ≤ ((7 / 12 : ℚ) : ℝ) := by
+  exact verify_primeLambda_upper 3 (7 / 12) (by native_decide)
+
+example : primeLambda ≤ ((133 / 240 : ℚ) : ℝ) := by
+  exact verify_primeLambda_upper 7 (133 / 240) (by native_decide)
+
+example : ((19 / 36 : ℚ) : ℝ) ≤ primeLambda := by
+  exact primeLambda_lower_nineteen_thirtysix
+
+example : (1 : ℝ) / 2 < primeLambda := by
+  exact primeLambda_gt_half

--- a/LeanCert/Examples/QProduct/PrimeLambda.lean
+++ b/LeanCert/Examples/QProduct/PrimeLambda.lean
@@ -21,6 +21,27 @@ example : primeLambda ≤ ((7 / 12 : ℚ) : ℝ) := by
 example : primeLambda ≤ ((133 / 240 : ℚ) : ℝ) := by
   exact verify_primeLambda_upper 7 (133 / 240) (by native_decide)
 
+example : primeSandwichErrorRat 3 5 = 1 / 18 := by
+  exact primeSandwichErrorRat_three_five
+
+example : primeSandwichLowerRat 3 5 = 19 / 36 := by
+  exact primeSandwichLowerRat_three_five
+
+example : (primeSandwichLowerRat 3 5 : ℝ) ≤ primeLambda := by
+  exact primeSandwichLowerRat_three_five_le_lambda
+
+example :
+    ((primeFRat 3 : ℝ) - (primeSandwichErrorRat 3 5 : ℝ) ≤ primeLambda ∧
+      primeLambda ≤ (primeFRat 3 : ℝ)) := by
+  apply primeLambda_sandwich (N := 3) (m := 5) (by norm_num) (by decide)
+  intro p hp_prime hp_gt
+  have hp_ge4 : 4 ≤ p := Nat.succ_le_of_lt hp_gt
+  rcases Nat.lt_or_eq_of_le hp_ge4 with hp4 | hp4
+  · exact Nat.succ_le_of_lt hp4
+  · exfalso
+    rw [← hp4] at hp_prime
+    exact (by native_decide : ¬ Nat.Prime 4) hp_prime
+
 example : ((19 / 36 : ℚ) : ℝ) ≤ primeLambda := by
   exact primeLambda_lower_nineteen_thirtysix
 

--- a/LeanCert/QProduct.lean
+++ b/LeanCert/QProduct.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.QProduct.Finite
+import LeanCert.QProduct.Stability
+import LeanCert.QProduct.Certificate
+import LeanCert.QProduct.PrimeLambda
+
+/-!
+# QProduct
+
+Certified finite q-product integrals and prime-indexed truncations.
+-/
+

--- a/LeanCert/QProduct/Certificate.lean
+++ b/LeanCert/QProduct/Certificate.lean
@@ -35,6 +35,7 @@ def checkFiniteIntegralUpper (S : Finset Nat) (hi : ℚ) : Bool :=
 def checkFiniteIntegralLower (S : Finset Nat) (lo : ℚ) : Bool :=
   decide (lo ≤ finiteIntegralRat S)
 
+/-- Golden theorem for exact finite q-product upper-bound certificates. -/
 theorem verify_finiteIntegral_upper (S : Finset Nat) (hi : ℚ)
     (hcheck : checkFiniteIntegralUpper S hi = true) :
     F S ≤ (hi : ℝ) := by
@@ -42,6 +43,7 @@ theorem verify_finiteIntegral_upper (S : Finset Nat) (hi : ℚ)
   rw [← finiteIntegralRat_correct]
   exact_mod_cast hcheck
 
+/-- Golden theorem for exact finite q-product lower-bound certificates. -/
 theorem verify_finiteIntegral_lower (S : Finset Nat) (lo : ℚ)
     (hcheck : checkFiniteIntegralLower S lo = true) :
     (lo : ℝ) ≤ F S := by

--- a/LeanCert/QProduct/Certificate.lean
+++ b/LeanCert/QProduct/Certificate.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.QProduct.Finite
+
+/-!
+# Boolean certificates for finite q-product integrals
+
+The checker is exact rational arithmetic.  The golden theorem lifts a successful
+boolean check to a semantic interval enclosure for the real integral.
+-/
+
+namespace LeanCert.QProduct
+
+/-- Exact finite q-product interval checker. -/
+def checkFiniteIntegralInterval (S : Finset Nat) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ finiteIntegralRat S) && decide (finiteIntegralRat S ≤ hi)
+
+/-- Golden theorem for exact finite q-product interval certificates. -/
+theorem verify_finiteIntegral_interval (S : Finset Nat) (lo hi : ℚ)
+    (hcheck : checkFiniteIntegralInterval S lo hi = true) :
+    (lo : ℝ) ≤ F S ∧ F S ≤ (hi : ℝ) := by
+  simp only [checkFiniteIntegralInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rw [← finiteIntegralRat_correct]
+  exact ⟨by exact_mod_cast hcheck.1, by exact_mod_cast hcheck.2⟩
+
+/-- Exact finite q-product upper-bound checker. -/
+def checkFiniteIntegralUpper (S : Finset Nat) (hi : ℚ) : Bool :=
+  decide (finiteIntegralRat S ≤ hi)
+
+/-- Exact finite q-product lower-bound checker. -/
+def checkFiniteIntegralLower (S : Finset Nat) (lo : ℚ) : Bool :=
+  decide (lo ≤ finiteIntegralRat S)
+
+theorem verify_finiteIntegral_upper (S : Finset Nat) (hi : ℚ)
+    (hcheck : checkFiniteIntegralUpper S hi = true) :
+    F S ≤ (hi : ℝ) := by
+  simp only [checkFiniteIntegralUpper, decide_eq_true_eq] at hcheck
+  rw [← finiteIntegralRat_correct]
+  exact_mod_cast hcheck
+
+theorem verify_finiteIntegral_lower (S : Finset Nat) (lo : ℚ)
+    (hcheck : checkFiniteIntegralLower S lo = true) :
+    (lo : ℝ) ≤ F S := by
+  simp only [checkFiniteIntegralLower, decide_eq_true_eq] at hcheck
+  rw [← finiteIntegralRat_correct]
+  exact_mod_cast hcheck
+
+end LeanCert.QProduct

--- a/LeanCert/QProduct/Finite.lean
+++ b/LeanCert/QProduct/Finite.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Ring.Parity
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+import Mathlib.Data.Finset.Powerset
+
+/-!
+# Finite q-product integrals
+
+This module contains the exact finite algebra behind product-integral invariants
+
+`F_S = ∫ u in 0..1, ∏ n ∈ S, (1 - u^n)`.
+
+The computable side is rational: finite products are expanded over the powerset,
+then monomials are integrated exactly.
+-/
+
+namespace LeanCert.QProduct
+
+open scoped BigOperators
+
+/-- Finite q-product profile associated to an exponent set. -/
+noncomputable def qProd (S : Finset Nat) (u : ℝ) : ℝ :=
+  ∏ n ∈ S, (1 - u ^ n)
+
+/-- The real product-integral invariant. -/
+noncomputable def F (S : Finset Nat) : ℝ :=
+  ∫ u in (0 : ℝ)..1, qProd S u
+
+/-- The signed powerset coefficient attached to a subset. -/
+def subsetSign (A : Finset Nat) : ℚ :=
+  if Even A.card then 1 else -1
+
+/-- Sum of exponents in a finite subset. -/
+def subsetWeight (A : Finset Nat) : Nat :=
+  ∑ n ∈ A, n
+
+/-- Exact rational value of the finite product integral. -/
+def finiteIntegralRat (S : Finset Nat) : ℚ :=
+  ∑ A ∈ S.powerset, subsetSign A / ((subsetWeight A + 1 : Nat) : ℚ)
+
+/-- Exact rational value of the `k`th monomial moment of the finite product profile. -/
+def momentRat (S : Finset Nat) (k : Nat) : ℚ :=
+  ∑ A ∈ S.powerset, subsetSign A / ((subsetWeight A + k + 1 : Nat) : ℚ)
+
+/-- The real `k`th monomial moment of the finite product profile. -/
+noncomputable def moment (S : Finset Nat) (k : Nat) : ℝ :=
+  ∫ u in (0 : ℝ)..1, qProd S u * u ^ k
+
+@[simp] theorem subsetWeight_empty : subsetWeight ∅ = 0 := by
+  simp [subsetWeight]
+
+@[simp] theorem subsetSign_empty : subsetSign ∅ = 1 := by
+  simp [subsetSign]
+
+@[simp] theorem qProd_empty (u : ℝ) : qProd ∅ u = 1 := by
+  simp [qProd]
+
+@[simp] theorem F_empty : F ∅ = 1 := by
+  simp [F, qProd]
+
+/-- `subsetSign` as a real coefficient is `(-1)^card`. -/
+theorem subsetSign_cast_eq (A : Finset Nat) :
+    (subsetSign A : ℝ) = (-1 : ℝ) ^ A.card := by
+  unfold subsetSign
+  by_cases h : Even A.card
+  · simp [h]
+  · have hodd : Odd A.card := Nat.not_even_iff_odd.mp h
+    simp [h, hodd.neg_one_pow]
+
+/-- Product expansion over the powerset. -/
+theorem qProd_powerset_expand (S : Finset Nat) (u : ℝ) :
+    qProd S u =
+      ∑ A ∈ S.powerset, (subsetSign A : ℝ) * u ^ subsetWeight A := by
+  classical
+  unfold qProd subsetWeight
+  rw [Finset.prod_sub]
+  apply Finset.sum_congr rfl
+  intro A hA
+  rw [subsetSign_cast_eq]
+  have hprod_one : (∏ x ∈ S \ A, (1 : ℝ)) = 1 := by simp
+  simp [hprod_one]
+  exact Finset.prod_pow_eq_pow_sum A id u
+
+private theorem integral_pow_zero_one (n : Nat) :
+    ∫ u in (0 : ℝ)..1, u ^ n = (1 : ℝ) / (n + 1) := by
+  simp [integral_pow (a := (0 : ℝ)) (b := 1) (n := n)]
+
+/-- Semantic correctness of the exact rational finite product integral. -/
+theorem finiteIntegralRat_correct (S : Finset Nat) :
+    (finiteIntegralRat S : ℝ) = F S := by
+  classical
+  unfold finiteIntegralRat F
+  simp_rw [qProd_powerset_expand]
+  rw [intervalIntegral.integral_finset_sum]
+  · simp_rw [Rat.cast_sum]
+    apply Finset.sum_congr rfl
+    intro A hA
+    rw [intervalIntegral.integral_const_mul]
+    rw [integral_pow_zero_one]
+    simp only [Rat.cast_div, Rat.cast_natCast]
+    norm_num
+    rw [div_eq_mul_inv]
+  · intro A hA
+    exact (continuous_const.mul (continuous_id.pow (subsetWeight A))).intervalIntegrable 0 1
+
+/-- Semantic correctness of the exact rational moment formula. -/
+theorem momentRat_correct (S : Finset Nat) (k : Nat) :
+    (momentRat S k : ℝ) = moment S k := by
+  classical
+  unfold momentRat moment
+  simp_rw [qProd_powerset_expand]
+  simp_rw [Finset.sum_mul]
+  rw [intervalIntegral.integral_finset_sum]
+  · simp_rw [Rat.cast_sum]
+    apply Finset.sum_congr rfl
+    intro A hA
+    have hintegrand :
+        (fun u : ℝ => (subsetSign A : ℝ) * u ^ subsetWeight A * u ^ k) =
+          fun u : ℝ => (subsetSign A : ℝ) * u ^ (subsetWeight A + k) := by
+      funext u
+      rw [mul_assoc, ← pow_add]
+    rw [hintegrand]
+    rw [intervalIntegral.integral_const_mul]
+    rw [integral_pow_zero_one]
+    simp only [Rat.cast_div, Rat.cast_natCast]
+    norm_num
+    rw [div_eq_mul_inv]
+  · intro A hA
+    have hc : Continuous fun u : ℝ => (subsetSign A : ℝ) * (u ^ subsetWeight A * u ^ k) :=
+      (continuous_const : Continuous fun _ : ℝ => (subsetSign A : ℝ)).mul
+      ((continuous_id.pow (subsetWeight A)).mul (continuous_id.pow k))
+    simpa [mul_assoc] using hc.intervalIntegrable 0 1
+
+end LeanCert.QProduct

--- a/LeanCert/QProduct/PrimeLambda.lean
+++ b/LeanCert/QProduct/PrimeLambda.lean
@@ -78,15 +78,20 @@ theorem primeLambda_lower_of_forall (lo : ℚ)
 def checkPrimeLambdaUpper (N : Nat) (hi : ℚ) : Bool :=
   decide (primeFRat N ≤ hi)
 
-/-- Golden theorem for prime-limit upper certificates. -/
+/-- Golden theorem for prime-limit upper certificates.
+
+The checker verifies an upper bound for one finite prime truncation. Antitonicity
+then makes the same rational an upper bound for the directed prime limit. -/
 theorem verify_primeLambda_upper (N : Nat) (hi : ℚ)
     (hcheck : checkPrimeLambdaUpper N hi = true) :
     primeLambda ≤ (hi : ℝ) := by
   simp only [checkPrimeLambdaUpper, decide_eq_true_eq] at hcheck
   exact le_trans (primeLambda_le_trunc N) (by exact_mod_cast hcheck)
 
-/-- Combined prime-limit interval theorem. The lower side is supplied as a
-mathematical tail proof; the upper side is checked exactly by computation. -/
+/-- Combined prime-limit interval bridge. The lower side is supplied as a
+mathematical tail proof; the upper side is checked exactly by computation. This
+is intentionally not a purely boolean certificate, because lower bounds for the
+directed limit need a tail argument. -/
 theorem verify_primeLambda_interval_of_forall (N : Nat) (lo hi : ℚ)
     (hlo : ∀ M : Nat, (lo : ℝ) ≤ (primeFRat M : ℝ))
     (hcheck : checkPrimeLambdaUpper N hi = true) :

--- a/LeanCert/QProduct/PrimeLambda.lean
+++ b/LeanCert/QProduct/PrimeLambda.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.QProduct.Stability
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic.IntervalCases
+
+/-!
+# Prime-indexed q-product truncations
+
+This file introduces the finite prime truncations and the directed prime limit as
+an infimum over the truncation values.  The tail-sandwich certificates live on
+top of these definitions.
+-/
+
+namespace LeanCert.QProduct
+
+open scoped BigOperators
+
+private theorem nat_prime_two : Nat.Prime 2 := by native_decide
+private theorem nat_prime_three : Nat.Prime 3 := by native_decide
+private theorem nat_not_prime_zero : ¬ Nat.Prime 0 := by native_decide
+private theorem nat_not_prime_one : ¬ Nat.Prime 1 := by native_decide
+private theorem nat_not_prime_four : ¬ Nat.Prime 4 := by native_decide
+
+/-- Prime exponents up to `N`. -/
+def primesLE (N : Nat) : Finset Nat :=
+  (Finset.range (N + 1)).filter Nat.Prime
+
+/-- Exact rational value of the prime truncation integral. -/
+def primeFRat (N : Nat) : ℚ :=
+  finiteIntegralRat (primesLE N)
+
+/-- Prime q-product directed limit, represented as the infimum of truncations. -/
+noncomputable def primeLambda : ℝ :=
+  sInf (Set.range fun N : Nat => (primeFRat N : ℝ))
+
+theorem primesLE_subset {N M : Nat} (hNM : N ≤ M) :
+    primesLE N ⊆ primesLE M := by
+  intro p hp
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp ⊢
+  exact ⟨Nat.lt_succ_of_le (Nat.le_trans (Nat.lt_succ_iff.mp hp.1) hNM), hp.2⟩
+
+/-- Prime truncation values are antitone in the cutoff. -/
+theorem primeFRat_antitone {N M : Nat} (hNM : N ≤ M) :
+    (primeFRat M : ℝ) ≤ (primeFRat N : ℝ) := by
+  unfold primeFRat
+  rw [finiteIntegralRat_correct, finiteIntegralRat_correct]
+  exact F_antitone (primesLE_subset hNM)
+
+/-- The limit is bounded above by every finite prime truncation. -/
+theorem primeLambda_le_trunc (N : Nat) :
+    primeLambda ≤ (primeFRat N : ℝ) := by
+  unfold primeLambda
+  apply csInf_le
+  · refine ⟨0, ?_⟩
+    rintro x ⟨M, rfl⟩
+    change 0 ≤ (finiteIntegralRat (primesLE M) : ℝ)
+    rw [finiteIntegralRat_correct]
+    exact F_nonneg (primesLE M)
+  · exact ⟨N, rfl⟩
+
+/-- Any rational lower bound valid for every finite prime truncation is valid
+for the directed prime limit. -/
+theorem primeLambda_lower_of_forall (lo : ℚ)
+    (hlo : ∀ N : Nat, (lo : ℝ) ≤ (primeFRat N : ℝ)) :
+    (lo : ℝ) ≤ primeLambda := by
+  unfold primeLambda
+  apply le_csInf
+  · exact Set.range_nonempty _
+  · rintro x ⟨N, rfl⟩
+    exact hlo N
+
+/-- Boolean upper certificate for the prime limit using one truncation. -/
+def checkPrimeLambdaUpper (N : Nat) (hi : ℚ) : Bool :=
+  decide (primeFRat N ≤ hi)
+
+/-- Golden theorem for prime-limit upper certificates. -/
+theorem verify_primeLambda_upper (N : Nat) (hi : ℚ)
+    (hcheck : checkPrimeLambdaUpper N hi = true) :
+    primeLambda ≤ (hi : ℝ) := by
+  simp only [checkPrimeLambdaUpper, decide_eq_true_eq] at hcheck
+  exact le_trans (primeLambda_le_trunc N) (by exact_mod_cast hcheck)
+
+/-- Combined prime-limit interval theorem. The lower side is supplied as a
+mathematical tail proof; the upper side is checked exactly by computation. -/
+theorem verify_primeLambda_interval_of_forall (N : Nat) (lo hi : ℚ)
+    (hlo : ∀ M : Nat, (lo : ℝ) ≤ (primeFRat M : ℝ))
+    (hcheck : checkPrimeLambdaUpper N hi = true) :
+    (lo : ℝ) ≤ primeLambda ∧ primeLambda ≤ (hi : ℝ) :=
+  ⟨primeLambda_lower_of_forall lo hlo, verify_primeLambda_upper N hi hcheck⟩
+
+private theorem primesLE_three :
+    primesLE 3 = ({2, 3} : Finset Nat) := by
+  ext q
+  constructor
+  · intro hq
+    simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hq
+    have hq_le : q ≤ 3 := Nat.lt_succ_iff.mp hq.1
+    have hp : Nat.Prime q := hq.2
+    interval_cases q
+    · exact False.elim (nat_not_prime_zero hp)
+    · exact False.elim (nat_not_prime_one hp)
+    · simp
+    · simp
+  · intro hq
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hq
+    rcases hq with rfl | rfl
+    · simp [primesLE, nat_prime_two]
+    · simp [primesLE, nat_prime_three]
+
+private theorem primesLE_lt_five_subset_three {M : Nat} (hM : M < 5) :
+    primesLE M ⊆ primesLE 3 := by
+  intro q hq
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hq
+  rw [primesLE_three]
+  have hq5 : q < 5 := by omega
+  have hp : Nat.Prime q := hq.2
+  interval_cases q
+  · exact False.elim (nat_not_prime_zero hp)
+  · exact False.elim (nat_not_prime_one hp)
+  · simp
+  · simp
+  · exact False.elim (nat_not_prime_four hp)
+
+private theorem prime_tail_pointwise_three {M : Nat} (hM : 5 ≤ M)
+    {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    qProd (primesLE 3) u - qProd (primesLE M) u ≤ qProd ({3} : Finset Nat) u * u ^ 5 := by
+  classical
+  let A := primesLE M \ primesLE 3
+  have hST : primesLE 3 ⊆ primesLE M := primesLE_subset (by omega)
+  have hbase := qProd_sub_le_commonPrefix_sum (R := primesLE 3) (S := primesLE 3)
+    (T := primesLE M) (by intro q hq; exact hq) hST hu
+  have hodd : ∀ q ∈ A, Odd q := by
+    intro q hq
+    have hq' : q ∈ primesLE M ∧ q ∉ primesLE 3 := by
+      simpa only [A, Finset.mem_sdiff] using hq
+    have hqM' : q < M + 1 ∧ Nat.Prime q := by
+      simpa only [primesLE, Finset.mem_filter, Finset.mem_range] using hq'.1
+    have hp : Nat.Prime q := by
+      exact hqM'.2
+    apply hp.odd_of_ne_two
+    intro h2
+    apply hq'.2
+    rw [h2, primesLE_three]
+    simp
+  have h5 : ∀ q ∈ A, 5 ≤ q := by
+    intro q hq
+    have hq' : q ∈ primesLE M ∧ q ∉ primesLE 3 := by
+      simpa only [A, Finset.mem_sdiff] using hq
+    have hqM' : q < M + 1 ∧ Nat.Prime q := by
+      simpa only [primesLE, Finset.mem_filter, Finset.mem_range] using hq'.1
+    by_contra hlt
+    have hq5 : q < 5 := by omega
+    have hq_mem3 : q ∈ primesLE 3 := by
+      rw [primesLE_three]
+      have hp : Nat.Prime q := hqM'.2
+      interval_cases q
+      · exact False.elim (nat_not_prime_zero hp)
+      · exact False.elim (nat_not_prime_one hp)
+      · simp
+      · simp
+      · exact False.elim (nat_not_prime_four hp)
+    exact hq'.2 hq_mem3
+  have hA_M : ∀ q ∈ A, q < M + 1 := by
+    intro q hq
+    have hq' : q ∈ primesLE M ∧ q ∉ primesLE 3 := by
+      simpa only [A, Finset.mem_sdiff] using hq
+    have hqM' : q < M + 1 ∧ Nat.Prime q := by
+      simpa only [primesLE, Finset.mem_filter, Finset.mem_range] using hq'.1
+    exact hqM'.1
+  have hsum_le := odd_tail_sum_le_geom A M hu hodd h5 hA_M
+  have hgeom := odd_tail_telescope_bound M hu
+  have h1u2_nonneg : 0 ≤ 1 - u ^ 2 := sub_nonneg.mpr (pow_mem_unit_interval hu 2).2
+  have htail : (1 - u ^ 2) * (∑ q ∈ A, u ^ q) ≤ u ^ 5 := by
+    calc
+      (1 - u ^ 2) * (∑ q ∈ A, u ^ q)
+          ≤ (1 - u ^ 2) * (∑ j ∈ Finset.range (M + 1), u ^ (5 + 2 * j)) :=
+            mul_le_mul_of_nonneg_left hsum_le h1u2_nonneg
+      _ ≤ u ^ 5 := hgeom
+  have hq3 : qProd (primesLE 3) u = (1 - u ^ 2) * (1 - u ^ 3) := by
+    rw [primesLE_three]
+    simp [qProd]
+  have hsingle3 : qProd ({3} : Finset Nat) u = 1 - u ^ 3 := by
+    simp [qProd]
+  have hfactor_nonneg : 0 ≤ 1 - u ^ 3 := sub_nonneg.mpr (pow_mem_unit_interval hu 3).2
+  calc
+    qProd (primesLE 3) u - qProd (primesLE M) u
+        ≤ qProd (primesLE 3) u * ∑ q ∈ primesLE M \ primesLE 3, u ^ q := hbase
+    _ = (1 - u ^ 3) * ((1 - u ^ 2) * ∑ q ∈ A, u ^ q) := by
+        simp only [A]
+        rw [hq3]
+        ring
+    _ ≤ (1 - u ^ 3) * u ^ 5 := mul_le_mul_of_nonneg_left htail hfactor_nonneg
+    _ = qProd ({3} : Finset Nat) u * u ^ 5 := by rw [hsingle3]
+
+private theorem qProd_intervalIntegrable (S : Finset Nat) :
+    IntervalIntegrable (fun u => qProd S u) MeasureTheory.volume (0 : ℝ) 1 := by
+  classical
+  unfold qProd
+  apply Continuous.intervalIntegrable
+  exact continuous_finset_prod S fun n hn =>
+    continuous_const.sub (continuous_id.pow n)
+
+/-- The elementary finite odd-tail certificate: every prime truncation is at least `19/36`. -/
+theorem primeFRat_lower_nineteen_thirtysix (M : Nat) :
+    ((19 / 36 : ℚ) : ℝ) ≤ (primeFRat M : ℝ) := by
+  by_cases hM : M < 5
+  · have hsubset : primesLE M ⊆ primesLE 3 := primesLE_lt_five_subset_three hM
+    have hmono : F (primesLE 3) ≤ F (primesLE M) := F_antitone hsubset
+    unfold primeFRat
+    change ((19 / 36 : ℚ) : ℝ) ≤ (finiteIntegralRat (primesLE M) : ℝ)
+    rw [finiteIntegralRat_correct]
+    have hF3 : F (primesLE 3) = ((7 / 12 : ℚ) : ℝ) := by
+      rw [← finiteIntegralRat_correct]
+      have hval : finiteIntegralRat (primesLE 3) = 7 / 12 := by native_decide
+      exact_mod_cast hval
+    have hmono' : ((7 / 12 : ℚ) : ℝ) ≤ F (primesLE M) := by
+      simpa [hF3] using hmono
+    norm_num at hmono' ⊢
+    linarith
+  · have hM5 : 5 ≤ M := by omega
+    have hsub_int :
+        F (primesLE 3) - F (primesLE M) ≤ moment ({3} : Finset Nat) 5 := by
+      unfold F moment
+      have hInt3 := qProd_intervalIntegrable (primesLE 3)
+      have hIntM := qProd_intervalIntegrable (primesLE M)
+      have hIntSub := hInt3.sub hIntM
+      have hIntB : IntervalIntegrable
+          (fun u : ℝ => qProd ({3} : Finset Nat) u * u ^ 5)
+          MeasureTheory.volume (0 : ℝ) 1 := by
+        apply Continuous.intervalIntegrable
+        exact (by
+          classical
+          unfold qProd
+          exact (continuous_finset_prod ({3} : Finset Nat) fun n hn =>
+            continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow 5))
+      have hle := intervalIntegral.integral_mono_on (by norm_num : (0 : ℝ) ≤ 1)
+        hIntSub hIntB (fun u hu => prime_tail_pointwise_three hM5 hu)
+      rwa [intervalIntegral.integral_sub hInt3 hIntM] at hle
+    unfold primeFRat
+    rw [finiteIntegralRat_correct]
+    have hF3 : F (primesLE 3) = ((7 / 12 : ℚ) : ℝ) := by
+      rw [← finiteIntegralRat_correct]
+      have hval : finiteIntegralRat (primesLE 3) = 7 / 12 := by native_decide
+      exact_mod_cast hval
+    have hmom : moment ({3} : Finset Nat) 5 = ((1 / 18 : ℚ) : ℝ) := by
+      rw [← momentRat_correct]
+      have hval : momentRat ({3} : Finset Nat) 5 = 1 / 18 := by native_decide
+      exact_mod_cast hval
+    rw [hF3, hmom] at hsub_int
+    norm_num at hsub_int ⊢
+    linarith
+
+/-- Certified qualitative lower bound for the prime directed limit. -/
+theorem primeLambda_lower_nineteen_thirtysix :
+    ((19 / 36 : ℚ) : ℝ) ≤ primeLambda :=
+  primeLambda_lower_of_forall (19 / 36) primeFRat_lower_nineteen_thirtysix
+
+theorem primeLambda_gt_half : (1 : ℝ) / 2 < primeLambda := by
+  have h := primeLambda_lower_nineteen_thirtysix
+  norm_num at h ⊢
+  linarith
+
+end LeanCert.QProduct

--- a/LeanCert/QProduct/PrimeLambda.lean
+++ b/LeanCert/QProduct/PrimeLambda.lean
@@ -34,6 +34,19 @@ def primesLE (N : Nat) : Finset Nat :=
 def primeFRat (N : Nat) : ℚ :=
   finiteIntegralRat (primesLE N)
 
+/-- Exact rational error integral used in the prime-limit sandwich:
+`∫ u^m ∏_{p ≤ N, p ≠ 2} (1 - u^p) du`. -/
+def primeSandwichErrorRat (N m : Nat) : ℚ :=
+  momentRat ((primesLE N).filter (fun p => p ≠ 2)) m
+
+/-- Exact rational lower endpoint for the prime-limit sandwich. -/
+def primeSandwichLowerRat (N m : Nat) : ℚ :=
+  primeFRat N - primeSandwichErrorRat N m
+
+/-- Pointwise lower-envelope function used in the prime sandwich. -/
+noncomputable def primeSandwichLowerFun (N m : Nat) (u : ℝ) : ℝ :=
+  qProd (primesLE N) u - qProd ((primesLE N).filter (fun p => p ≠ 2)) u * u ^ m
+
 /-- Prime q-product directed limit, represented as the infimum of truncations. -/
 noncomputable def primeLambda : ℝ :=
   sInf (Set.range fun N : Nat => (primeFRat N : ℝ))
@@ -238,11 +251,11 @@ theorem primeFRat_lower_nineteen_thirtysix (M : Nat) :
           (fun u : ℝ => qProd ({3} : Finset Nat) u * u ^ 5)
           MeasureTheory.volume (0 : ℝ) 1 := by
         apply Continuous.intervalIntegrable
-        exact (by
+        exact by
           classical
           unfold qProd
           exact (continuous_finset_prod ({3} : Finset Nat) fun n hn =>
-            continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow 5))
+            continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow 5)
       have hle := intervalIntegral.integral_mono_on (by norm_num : (0 : ℝ) ≤ 1)
         hIntSub hIntB (fun u hu => prime_tail_pointwise_three hM5 hu)
       rwa [intervalIntegral.integral_sub hInt3 hIntM] at hle
@@ -259,6 +272,267 @@ theorem primeFRat_lower_nineteen_thirtysix (M : Nat) :
     rw [hF3, hmom] at hsub_int
     norm_num at hsub_int ⊢
     linarith
+
+theorem prime_odd_of_gt_two {p : Nat} (hp : Nat.Prime p) (hp2 : 2 < p) : Odd p := by
+  rcases Nat.Prime.eq_two_or_odd hp with hp_eq | hp_odd
+  · omega
+  · exact Nat.odd_iff.mpr hp_odd
+
+theorem odd_ge_form {m p : Nat} (hm : Odd m) (hp : Odd p) (hmp : m ≤ p) :
+    ∃ k, p = m + 2 * k := by
+  rcases hm with ⟨a, ha⟩
+  rcases hp with ⟨b, hb⟩
+  refine ⟨b - a, ?_⟩
+  omega
+
+theorem telescope_odd_sum_bound_from {m : Nat} (hm : Odd m) (S : Finset Nat)
+    (hS : ∀ p ∈ S, Odd p ∧ m ≤ p)
+    {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    (1 - u ^ 2) * ∑ p ∈ S, u ^ p ≤ u ^ m := by
+  classical
+  let f : Nat → Nat := fun p => (p - m) / 2
+  have hodd : ∀ p ∈ S, Odd p := fun p hp => (hS p hp).1
+  have hge : ∀ p ∈ S, m ≤ p := fun p hp => (hS p hp).2
+  have hform : ∀ p ∈ S, p = m + 2 * f p := by
+    intro p hp
+    obtain ⟨k, hk⟩ := odd_ge_form hm (hodd p hp) (hge p hp)
+    have hf : f p = k := by
+      change (p - m) / 2 = k
+      omega
+    rw [hf, hk]
+  let K := S.image f
+  have hsum_eq : ∑ p ∈ S, u ^ p = ∑ k ∈ K, u ^ (m + 2 * k) := by
+    unfold K
+    have hrewrite : ∑ p ∈ S, u ^ p = ∑ p ∈ S, u ^ (m + 2 * f p) := by
+      apply Finset.sum_congr rfl
+      intro p hp
+      exact congrArg (fun e => u ^ e) (hform p hp)
+    rw [hrewrite]
+    rw [Finset.sum_image]
+    intro p hp q hq hf
+    have hpform := hform p hp
+    have hqform := hform q hq
+    omega
+  rw [hsum_eq]
+  by_cases hK : K = ∅
+  · simp [hK, pow_nonneg hu.1 m]
+  · obtain ⟨M, hM⟩ := Finset.exists_max_image K id (Finset.nonempty_of_ne_empty hK)
+    let n := M + 1
+    have hK_sub : K ⊆ Finset.range n := by
+      intro k hk
+      simp only [Finset.mem_range]
+      have hkM := hM.2 k hk
+      simp only [id] at hkM
+      exact Nat.lt_add_one_of_le hkM
+    have hsum_le :
+        ∑ k ∈ K, u ^ (m + 2 * k) ≤
+          ∑ k ∈ Finset.range n, u ^ (m + 2 * k) :=
+      Finset.sum_le_sum_of_subset_of_nonneg hK_sub
+        (fun _ _ _ => pow_nonneg hu.1 _)
+    have htel :
+        (1 - u ^ 2) * (∑ k ∈ Finset.range n, u ^ (m + 2 * k)) =
+          u ^ m - u ^ (m + 2 * n) := by
+      induction n with
+      | zero => simp
+      | succ n ih =>
+          rw [Finset.sum_range_succ, mul_add, ih]
+          have h1 :
+              (1 - u ^ 2) * u ^ (m + 2 * n) =
+                u ^ (m + 2 * n) - u ^ (m + 2 * n) * u ^ 2 := by
+            ring
+          rw [h1, ← pow_add]
+          ring_nf
+    have h1u2_nonneg : 0 ≤ 1 - u ^ 2 :=
+      sub_nonneg.mpr (pow_mem_unit_interval hu 2).2
+    calc
+      (1 - u ^ 2) * ∑ k ∈ K, u ^ (m + 2 * k)
+          ≤ (1 - u ^ 2) * ∑ k ∈ Finset.range n, u ^ (m + 2 * k) :=
+            mul_le_mul_of_nonneg_left hsum_le h1u2_nonneg
+      _ = u ^ m - u ^ (m + 2 * n) := htel
+      _ ≤ u ^ m := by
+        have hnonneg : 0 ≤ u ^ (m + 2 * n) := pow_nonneg hu.1 _
+        linarith
+
+theorem primeSandwichLowerFun_pointwise_of_tail_ge {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p)
+    (S : Finset Nat)
+    (hbase : primesLE N ⊆ S) (hS_primes : ∀ p ∈ S, Nat.Prime p)
+    {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    primeSandwichLowerFun N m u ≤ qProd S u := by
+  classical
+  let B := primesLE N
+  let O := B.filter (fun p => p ≠ 2)
+  let T := S \ B
+  let R := qProd O u
+  have hsplit : qProd S u = qProd B u * qProd T u := by
+    unfold qProd T B
+    rw [← Finset.prod_union Finset.disjoint_sdiff]
+    congr 1
+    exact (Finset.union_sdiff_of_subset hbase).symm
+  have hB2 : 2 ∈ B := by
+    simp only [B, primesLE, Finset.mem_filter, Finset.mem_range]
+    exact ⟨by omega, nat_prime_two⟩
+  have hB_eq : B = insert 2 O := by
+    ext p
+    by_cases hp : p = 2
+    · subst hp
+      simp [O, hB2]
+    · simp [O, hp]
+  have hP_eq : qProd B u = (1 - u ^ 2) * R := by
+    rw [hB_eq]
+    unfold R O qProd
+    simp
+  have hR_nonneg : 0 ≤ R := by
+    unfold R
+    exact qProd_nonneg O hu
+  have hmain : (1 - u ^ 2) * (1 - qProd T u) ≤ u ^ m := by
+    have h_weier : 1 - qProd T u ≤ ∑ p ∈ T, u ^ p := by
+      unfold qProd
+      simpa using one_sub_prod_one_sub_le_sum T (fun q => u ^ q)
+        (fun q _hq => (pow_mem_unit_interval hu q).1)
+        (fun q _hq => (pow_mem_unit_interval hu q).2)
+    have h_tail : ∀ p ∈ T, Odd p ∧ m ≤ p := by
+      intro p hp
+      have hpS : p ∈ S := (Finset.mem_sdiff.mp hp).1
+      have hp_notB : p ∉ B := (Finset.mem_sdiff.mp hp).2
+      have hp_prime : Nat.Prime p := hS_primes p hpS
+      have hp_gt : N < p := by
+        by_contra hle
+        push Not at hle
+        have hpB : p ∈ B := by
+          simp only [B, primesLE, Finset.mem_filter, Finset.mem_range]
+          exact ⟨Nat.lt_succ_of_le hle, hp_prime⟩
+        exact hp_notB hpB
+      have hp_odd : Odd p := prime_odd_of_gt_two hp_prime (lt_of_le_of_lt hN hp_gt)
+      exact ⟨hp_odd, htail_ge p hp_prime hp_gt⟩
+    have h_bound :
+        (1 - u ^ 2) * ∑ p ∈ T, u ^ p ≤ u ^ m :=
+      telescope_odd_sum_bound_from hm T h_tail hu
+    have h1u2_nonneg : 0 ≤ 1 - u ^ 2 :=
+      sub_nonneg.mpr (pow_mem_unit_interval hu 2).2
+    exact (mul_le_mul_of_nonneg_left h_weier h1u2_nonneg).trans h_bound
+  unfold primeSandwichLowerFun
+  change qProd B u - R * u ^ m ≤ qProd S u
+  rw [hsplit, hP_eq]
+  have hscalar : (1 - u ^ 2) - u ^ m ≤ (1 - u ^ 2) * qProd T u := by
+    nlinarith [hmain]
+  calc
+    (1 - u ^ 2) * R - R * u ^ m
+        = ((1 - u ^ 2) - u ^ m) * R := by ring
+    _ ≤ ((1 - u ^ 2) * qProd T u) * R :=
+        mul_le_mul_of_nonneg_right hscalar hR_nonneg
+    _ = (1 - u ^ 2) * R * qProd T u := by ring
+
+theorem primeSandwichLowerFun_le_prime_truncation_of_tail_ge {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p)
+    (M : Nat) {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    primeSandwichLowerFun N m u ≤ qProd (primesLE M) u := by
+  classical
+  let S := primesLE M ∪ primesLE N
+  have hpoint : primeSandwichLowerFun N m u ≤ qProd S u := by
+    apply primeSandwichLowerFun_pointwise_of_tail_ge hN hm htail_ge
+    · exact Finset.subset_union_right
+    · intro p hp
+      rcases Finset.mem_union.mp hp with hpM | hpN
+      · exact (by
+          have hpM' : p < M + 1 ∧ Nat.Prime p := by
+            simpa only [primesLE, Finset.mem_filter, Finset.mem_range] using hpM
+          exact hpM'.2)
+      · exact (by
+          have hpN' : p < N + 1 ∧ Nat.Prime p := by
+            simpa only [primesLE, Finset.mem_filter, Finset.mem_range] using hpN
+          exact hpN'.2)
+    · exact hu
+  exact hpoint.trans (qProd_antitone_pointwise Finset.subset_union_left hu)
+
+private theorem primeSandwichLowerFun_intervalIntegrable (N m : Nat) :
+    IntervalIntegrable (fun u => primeSandwichLowerFun N m u)
+      MeasureTheory.volume (0 : ℝ) 1 := by
+  unfold primeSandwichLowerFun
+  apply Continuous.intervalIntegrable
+  exact (by
+    classical
+    exact (continuous_finset_prod (primesLE N) fun n hn =>
+      continuous_const.sub (continuous_id.pow n)).sub
+      ((continuous_finset_prod ((primesLE N).filter (fun p => p ≠ 2)) fun n hn =>
+        continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow m)))
+
+theorem integral_primeSandwichLowerFun_eq_rat (N m : Nat) :
+    (∫ u in (0 : ℝ)..1, primeSandwichLowerFun N m u) =
+      (primeSandwichLowerRat N m : ℝ) := by
+  unfold primeSandwichLowerFun primeSandwichLowerRat primeSandwichErrorRat primeFRat
+  rw [intervalIntegral.integral_sub]
+  · change F (primesLE N) - moment ((primesLE N).filter (fun p => p ≠ 2)) m =
+      (((finiteIntegralRat (primesLE N) - momentRat ((primesLE N).filter (fun p => p ≠ 2)) m) : ℚ) : ℝ)
+    rw [← finiteIntegralRat_correct, ← momentRat_correct]
+    norm_num
+  · exact qProd_intervalIntegrable (primesLE N)
+  · apply Continuous.intervalIntegrable
+    exact (by
+      classical
+      exact (continuous_finset_prod ((primesLE N).filter (fun p => p ≠ 2)) fun n hn =>
+        continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow m))
+
+theorem primeSandwichLowerRat_le_truncation_of_tail_ge {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p)
+    (M : Nat) :
+    (primeSandwichLowerRat N m : ℝ) ≤ (primeFRat M : ℝ) := by
+  have hle :
+      (∫ u in (0 : ℝ)..1, primeSandwichLowerFun N m u) ≤ F (primesLE M) := by
+    unfold F
+    exact intervalIntegral.integral_mono_on (by norm_num : (0 : ℝ) ≤ 1)
+      (primeSandwichLowerFun_intervalIntegrable N m)
+      (qProd_intervalIntegrable (primesLE M))
+      (fun u hu => primeSandwichLowerFun_le_prime_truncation_of_tail_ge hN hm htail_ge M hu)
+  rw [integral_primeSandwichLowerFun_eq_rat] at hle
+  unfold primeFRat
+  rw [finiteIntegralRat_correct]
+  exact hle
+
+theorem primeSandwichLowerRat_le_lambda_of_tail_ge {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p) :
+    (primeSandwichLowerRat N m : ℝ) ≤ primeLambda :=
+  primeLambda_lower_of_forall (primeSandwichLowerRat N m)
+    (primeSandwichLowerRat_le_truncation_of_tail_ge hN hm htail_ge)
+
+/-- Prime product-integral sandwich in exact rational form. -/
+theorem primeLambda_rational_sandwich {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p) :
+    (primeSandwichLowerRat N m : ℝ) ≤ primeLambda ∧
+      primeLambda ≤ (primeFRat N : ℝ) :=
+  ⟨primeSandwichLowerRat_le_lambda_of_tail_ge hN hm htail_ge,
+    primeLambda_le_trunc N⟩
+
+theorem primeLambda_sandwich {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p) :
+    (primeFRat N : ℝ) - (primeSandwichErrorRat N m : ℝ) ≤ primeLambda ∧
+      primeLambda ≤ (primeFRat N : ℝ) := by
+  simpa [primeSandwichLowerRat] using primeLambda_rational_sandwich hN hm htail_ge
+
+theorem primeSandwichErrorRat_three_five :
+    primeSandwichErrorRat 3 5 = 1 / 18 := by
+  native_decide
+
+theorem primeSandwichLowerRat_three_five :
+    primeSandwichLowerRat 3 5 = 19 / 36 := by
+  native_decide
+
+theorem primeSandwichLowerRat_three_five_le_lambda :
+    (primeSandwichLowerRat 3 5 : ℝ) ≤ primeLambda := by
+  apply primeSandwichLowerRat_le_lambda_of_tail_ge (N := 3) (m := 5) (by norm_num) (by decide)
+  intro p hp_prime hp_gt
+  have hp_ge4 : 4 ≤ p := Nat.succ_le_of_lt hp_gt
+  rcases Nat.lt_or_eq_of_le hp_ge4 with hp4 | hp4
+  · exact Nat.succ_le_of_lt hp4
+  · exfalso
+    rw [← hp4] at hp_prime
+    exact nat_not_prime_four hp_prime
 
 /-- Certified qualitative lower bound for the prime directed limit. -/
 theorem primeLambda_lower_nineteen_thirtysix :

--- a/LeanCert/QProduct/Stability.lean
+++ b/LeanCert/QProduct/Stability.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.QProduct.Finite
+import Mathlib.Algebra.Ring.GeomSum
+import Mathlib.Data.Finset.Image
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.Topology.Algebra.Monoid
+
+/-!
+# Stability lemmas for finite q-product integrals
+
+This file proves the elementary order facts used by the directed-limit theory:
+on `[0,1]`, every positive exponent factor `1 - u^n` lies in `[0,1]`, so finite
+products are nonnegative, bounded by one, and antitone in the exponent set.
+-/
+
+namespace LeanCert.QProduct
+
+open scoped BigOperators
+open MeasureTheory
+
+theorem pow_mem_unit_interval {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) (n : Nat) :
+    u ^ n ∈ Set.Icc (0 : ℝ) 1 := by
+  exact ⟨pow_nonneg hu.1 n, pow_le_one₀ hu.1 hu.2⟩
+
+/-- The finite product profile is nonnegative on `[0,1]`. -/
+theorem qProd_nonneg (S : Finset Nat) {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    0 ≤ qProd S u := by
+  classical
+  unfold qProd
+  apply Finset.prod_nonneg
+  intro n hn
+  exact sub_nonneg.mpr (pow_mem_unit_interval hu n).2
+
+/-- The finite product profile is bounded by one on `[0,1]`. -/
+theorem qProd_le_one (S : Finset Nat) {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    qProd S u ≤ 1 := by
+  classical
+  unfold qProd
+  apply Finset.prod_le_one
+  · intro n hn
+    exact sub_nonneg.mpr (pow_mem_unit_interval hu n).2
+  · intro n hn
+    exact sub_le_self 1 (pow_nonneg hu.1 n)
+
+/-- Adding positive exponents can only lower the profile on `[0,1]`. -/
+theorem qProd_antitone_pointwise {S T : Finset Nat}
+    (hST : S ⊆ T)
+    {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    qProd T u ≤ qProd S u := by
+  classical
+  have hsplit :
+      qProd T u = qProd S u * (∏ n ∈ T \ S, (1 - u ^ n)) := by
+    unfold qProd
+    rw [← Finset.prod_sdiff hST]
+    ring
+  rw [hsplit]
+  have hS_nonneg : 0 ≤ qProd S u := qProd_nonneg S hu
+  have htail_le : (∏ n ∈ T \ S, (1 - u ^ n)) ≤ 1 :=
+    qProd_le_one (T \ S) hu
+  have htail_nonneg : 0 ≤ (∏ n ∈ T \ S, (1 - u ^ n)) :=
+    qProd_nonneg (T \ S) hu
+  calc
+    qProd S u * (∏ n ∈ T \ S, (1 - u ^ n))
+        ≤ qProd S u * 1 := mul_le_mul_of_nonneg_left htail_le hS_nonneg
+    _ = qProd S u := mul_one _
+
+/-- Product-integral values are nonnegative. -/
+theorem F_nonneg (S : Finset Nat) : 0 ≤ F S := by
+  unfold F
+  have hInt : IntervalIntegrable (fun u => qProd S u) volume (0 : ℝ) 1 := by
+    classical
+    unfold qProd
+    apply Continuous.intervalIntegrable
+    exact continuous_finset_prod S fun n hn =>
+      continuous_const.sub (continuous_id.pow n)
+  apply intervalIntegral.integral_nonneg (by norm_num : (0 : ℝ) ≤ 1)
+  intro u hu
+  exact qProd_nonneg S hu
+
+/-- Product-integral values are at most one. -/
+theorem F_le_one (S : Finset Nat) : F S ≤ 1 := by
+  unfold F
+  have hInt : IntervalIntegrable (fun u => qProd S u) volume (0 : ℝ) 1 := by
+    classical
+    unfold qProd
+    apply Continuous.intervalIntegrable
+    exact continuous_finset_prod S fun n hn =>
+      continuous_const.sub (continuous_id.pow n)
+  have hConst : IntervalIntegrable (fun _ : ℝ => (1 : ℝ)) volume (0 : ℝ) 1 := by
+    exact continuous_const.intervalIntegrable 0 1
+  have hle := intervalIntegral.integral_mono_on (by norm_num : (0 : ℝ) ≤ 1) hInt hConst
+    (fun u hu => qProd_le_one S hu)
+  simpa using hle
+
+/-- The product-integral invariant is antitone under inclusion. -/
+theorem F_antitone {S T : Finset Nat}
+    (hST : S ⊆ T) :
+    F T ≤ F S := by
+  unfold F
+  have hTInt : IntervalIntegrable (fun u => qProd T u) volume (0 : ℝ) 1 := by
+    classical
+    unfold qProd
+    apply Continuous.intervalIntegrable
+    exact continuous_finset_prod T fun n hn =>
+      continuous_const.sub (continuous_id.pow n)
+  have hSInt : IntervalIntegrable (fun u => qProd S u) volume (0 : ℝ) 1 := by
+    classical
+    unfold qProd
+    apply Continuous.intervalIntegrable
+    exact continuous_finset_prod S fun n hn =>
+      continuous_const.sub (continuous_id.pow n)
+  exact intervalIntegral.integral_mono_on (by norm_num : (0 : ℝ) ≤ 1) hTInt hSInt
+    (fun u hu => qProd_antitone_pointwise hST hu)
+
+/-- Finite Weierstrass product inequality on `[0,1]`:
+`1 - ∏ (1 - x_i) ≤ ∑ x_i`. -/
+theorem one_sub_prod_one_sub_le_sum {ι : Type*} (s : Finset ι) (x : ι → ℝ)
+    (h0 : ∀ i ∈ s, 0 ≤ x i) (h1 : ∀ i ∈ s, x i ≤ 1) :
+    1 - (∏ i ∈ s, (1 - x i)) ≤ ∑ i ∈ s, x i := by
+  classical
+  induction s using Finset.induction_on with
+  | empty =>
+      simp
+  | insert a s ha ih =>
+      have h0s : ∀ i ∈ s, 0 ≤ x i := fun i hi => h0 i (Finset.mem_insert_of_mem hi)
+      have h1s : ∀ i ∈ s, x i ≤ 1 := fun i hi => h1 i (Finset.mem_insert_of_mem hi)
+      have hprod_nonneg : 0 ≤ ∏ i ∈ s, (1 - x i) := by
+        apply Finset.prod_nonneg
+        intro i hi
+        exact sub_nonneg.mpr (h1s i hi)
+      have hprod_le_one : (∏ i ∈ s, (1 - x i)) ≤ 1 := by
+        apply Finset.prod_le_one
+        · intro i hi
+          exact sub_nonneg.mpr (h1s i hi)
+        · intro i hi
+          exact sub_le_self 1 (h0s i hi)
+      have hxa_nonneg : 0 ≤ x a := h0 a (by simp)
+      have hxa_le : x a ≤ 1 := h1 a (by simp)
+      rw [Finset.prod_insert ha, Finset.sum_insert ha]
+      calc
+        1 - ((1 - x a) * ∏ i ∈ s, (1 - x i))
+            = (1 - ∏ i ∈ s, (1 - x i)) +
+              x a * ∏ i ∈ s, (1 - x i) := by ring
+        _ ≤ (∑ i ∈ s, x i) + x a * ∏ i ∈ s, (1 - x i) :=
+              by simpa [add_comm, add_left_comm, add_assoc] using
+                add_le_add_right (ih h0s h1s) (x a * ∏ i ∈ s, (1 - x i))
+        _ ≤ (∑ i ∈ s, x i) + x a := by
+              simpa [add_comm, add_left_comm, add_assoc] using
+                add_le_add_left (mul_le_of_le_one_right hxa_nonneg hprod_le_one)
+                  (∑ i ∈ s, x i)
+        _ = x a + ∑ i ∈ s, x i := by ring
+
+/-- Pointwise common-prefix tail bound. -/
+theorem qProd_sub_le_commonPrefix_sum {R S T : Finset Nat}
+    (hRS : R ⊆ S) (hST : S ⊆ T)
+    {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    qProd S u - qProd T u ≤ qProd R u * ∑ q ∈ T \ S, u ^ q := by
+  classical
+  have hsplitT : qProd T u = qProd S u * (∏ q ∈ T \ S, (1 - u ^ q)) := by
+    unfold qProd
+    rw [← Finset.prod_sdiff hST]
+    ring
+  have hPS_nonneg : 0 ≤ qProd S u := qProd_nonneg S hu
+  have hPR_nonneg : 0 ≤ qProd R u := qProd_nonneg R hu
+  have hPS_le_PR : qProd S u ≤ qProd R u := qProd_antitone_pointwise hRS hu
+  have htail_le :
+      1 - (∏ q ∈ T \ S, (1 - u ^ q)) ≤ ∑ q ∈ T \ S, u ^ q := by
+    apply one_sub_prod_one_sub_le_sum
+    · intro q hq
+      exact (pow_mem_unit_interval hu q).1
+    · intro q hq
+      exact (pow_mem_unit_interval hu q).2
+  have htail_nonneg :
+      0 ≤ 1 - (∏ q ∈ T \ S, (1 - u ^ q)) := by
+    exact sub_nonneg.mpr (qProd_le_one (T \ S) hu)
+  rw [hsplitT]
+  calc
+    qProd S u - qProd S u * (∏ q ∈ T \ S, (1 - u ^ q))
+        = qProd S u * (1 - ∏ q ∈ T \ S, (1 - u ^ q)) := by ring
+    _ ≤ qProd R u * (1 - ∏ q ∈ T \ S, (1 - u ^ q)) :=
+        mul_le_mul_of_nonneg_right hPS_le_PR htail_nonneg
+    _ ≤ qProd R u * ∑ q ∈ T \ S, u ^ q :=
+        mul_le_mul_of_nonneg_left htail_le hPR_nonneg
+
+/-- Odd exponent tails beginning at `5` telescope against the factor `1 - u^2`. -/
+theorem odd_tail_telescope_bound (M : Nat) {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1) :
+    (1 - u ^ 2) * (∑ j ∈ Finset.range (M + 1), u ^ (5 + 2 * j)) ≤ u ^ 5 := by
+  have hsum :
+      (∑ j ∈ Finset.range (M + 1), u ^ (5 + 2 * j)) =
+        u ^ 5 * ∑ j ∈ Finset.range (M + 1), (u ^ 2) ^ j := by
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [pow_add, pow_mul]
+  rw [mul_comm]
+  rw [hsum, mul_assoc, geom_sum_mul_neg]
+  calc
+    u ^ 5 * (1 - (u ^ 2) ^ (M + 1)) ≤ u ^ 5 * 1 := by
+      apply mul_le_mul_of_nonneg_left
+      · have hnonneg : 0 ≤ (u ^ 2) ^ (M + 1) := pow_nonneg (sq_nonneg u) _
+        linarith
+      · exact pow_nonneg hu.1 5
+    _ = u ^ 5 := by ring
+
+/-- Any finite set of odd exponents at least `5` and bounded by `M` is dominated
+by the full odd geometric tail beginning at `5`. -/
+theorem odd_tail_sum_le_geom (A : Finset Nat) (M : Nat)
+    {u : ℝ} (hu : u ∈ Set.Icc (0 : ℝ) 1)
+    (hodd : ∀ q ∈ A, Odd q) (h5 : ∀ q ∈ A, 5 ≤ q) (hM : ∀ q ∈ A, q < M + 1) :
+    ∑ q ∈ A, u ^ q ≤ ∑ j ∈ Finset.range (M + 1), u ^ (5 + 2 * j) := by
+  classical
+  let G : Finset Nat := (Finset.range (M + 1)).image (fun j => 5 + 2 * j)
+  have hsub : A ⊆ G := by
+    intro q hq
+    rcases hodd q hq with ⟨k, hk⟩
+    have hq5 := h5 q hq
+    have hqM := hM q hq
+    subst q
+    refine Finset.mem_image.mpr ?_
+    refine ⟨k - 2, ?_, ?_⟩
+    · simp only [Finset.mem_range]
+      omega
+    · omega
+  have hsum_subset : ∑ q ∈ A, u ^ q ≤ ∑ q ∈ G, u ^ q := by
+    apply Finset.sum_le_sum_of_subset_of_nonneg hsub
+    intro q hqG hqA
+    exact pow_nonneg hu.1 q
+  have hG :
+      (∑ q ∈ G, u ^ q) = ∑ j ∈ Finset.range (M + 1), u ^ (5 + 2 * j) := by
+    unfold G
+    rw [Finset.sum_image]
+    intro a ha b hb h
+    simp only at h
+    omega
+  exact hsum_subset.trans_eq hG
+
+end LeanCert.QProduct

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Numerical computation produces suggestions. LeanCert produces theorems.
 
-LeanCert is a Lean 4 library for certified numerical reasoning: interval bounds, global optimization, root existence/uniqueness, and integration bounds with proof-producing tactics.
+LeanCert is a Lean 4 library for certified numerical reasoning: interval bounds, global optimization, root existence/uniqueness, integration bounds, and exact product-integral certificates with proof-producing tactics.
 
 ## Installation
 
@@ -41,9 +41,13 @@ LeanCert follows a certificate-driven structure:
 2. Computation in interval/taylor engines
 3. Certification through Golden Theorems
 
+It also includes specialized exact-arithmetic certificate modules such as
+`LeanCert.QProduct` for finite q-product/product-integral invariants and
+prime-indexed limit bounds.
+
 ## Checking Mathlib Compatibility
 
-LeanCert currently targets Mathlib aligned with Lean `v4.28.0`.
+LeanCert targets the Lean/mathlib version pinned by `lean-toolchain`.
 
 ```bash
 lake exe check-compat

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -23,6 +23,8 @@ Golden Theorems are defined across multiple files:
 - `Validity/DyadicBounds.lean` - Dyadic arithmetic (fast)
 - `Validity/AffineBounds.lean` - Affine arithmetic (tight bounds)
 - `Validity/Monotonicity.lean` - Monotonicity via automatic differentiation
+- `QProduct/Certificate.lean` - Exact finite q-product integrals
+- `QProduct/PrimeLambda.lean` - Prime-limit q-product certificates
 
 ### Bound Verification
 
@@ -108,6 +110,50 @@ theorem integratePartitionDyadic_correct (e : Expr) (hsupp : ExprSupportedWithIn
     ∫ x in (I.lo : ℝ)..(I.hi : ℝ), Expr.eval (fun _ => x) e ∈
       integratePartitionDyadic e I n hn cfg
 ```
+
+### QProduct Product Integrals
+
+`LeanCert.QProduct` is a specialized exact-arithmetic certificate family for
+finite products
+
+$$
+F(S) = \int_0^1 \prod_{n \in S} (1 - u^n)\,du.
+$$
+
+The finite checker expands the product into a signed subset-sum polynomial and
+integrates exactly over `ℚ`.
+
+| Goal | Theorem | Checker |
+|------|---------|---------|
+| Exact finite interval | `verify_finiteIntegral_interval` | `checkFiniteIntegralInterval` |
+| Finite upper bound | `verify_finiteIntegral_upper` | `checkFiniteIntegralUpper` |
+| Finite lower bound | `verify_finiteIntegral_lower` | `checkFiniteIntegralLower` |
+| Prime-limit upper bound | `verify_primeLambda_upper` | `checkPrimeLambdaUpper` |
+
+```lean
+theorem verify_finiteIntegral_interval (S : Finset Nat) (lo hi : ℚ)
+    (hcheck : checkFiniteIntegralInterval S lo hi = true) :
+    (lo : ℝ) ≤ F S ∧ F S ≤ (hi : ℝ)
+```
+
+```lean
+theorem verify_primeLambda_upper (N : Nat) (hi : ℚ)
+    (hcheck : checkPrimeLambdaUpper N hi = true) :
+    primeLambda ≤ (hi : ℝ)
+```
+
+Prime-limit lower bounds are intentionally hybrid: the finite arithmetic is
+exact, but the lower side needs a mathematical tail proof. The bridge theorem
+is:
+
+```lean
+theorem primeLambda_lower_of_forall (lo : ℚ)
+    (hlo : ∀ N : Nat, (lo : ℝ) ≤ (primeFRat N : ℝ)) :
+    (lo : ℝ) ≤ primeLambda
+```
+
+The initial module includes the formally proved tail certificate
+`primeLambda_gt_half : (1 : ℝ) / 2 < primeLambda`.
 
 ### Monotonicity
 

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -152,6 +152,16 @@ theorem primeLambda_lower_of_forall (lo : ℚ)
     (lo : ℝ) ≤ primeLambda
 ```
 
+The reusable odd-prime tail certificate is:
+
+```lean
+theorem primeLambda_sandwich {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p) :
+    (primeFRat N : ℝ) - (primeSandwichErrorRat N m : ℝ) ≤ primeLambda ∧
+      primeLambda ≤ (primeFRat N : ℝ)
+```
+
 The initial module includes the formally proved tail certificate
 `primeLambda_gt_half : (1 : ℝ) / 2 < primeLambda`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ LeanCert is a Lean 4 library for certified numerical computation and proof-produ
 - Verified interval bounds
 - Proof automation for inequalities and root claims
 - Global optimization and integration certificates
+- Exact q-product/product-integral certificates
 - Dyadic and rational backends for different performance/precision tradeoffs
 
 ## Quick Lean Example
@@ -44,6 +45,7 @@ lake update
 | [Tactics Reference](tactics.md) | Main proving tactics |
 | [Choosing Tactics](choosing-tactics.md) | Pick the right tactic quickly |
 | [End-to-End Example](end-to-end-example.md) | Discovery to theorem workflow |
+| [QProduct Certificates](qproduct.md) | Exact product-integral and prime-limit certificates |
 
 ## Architecture
 

--- a/docs/qproduct.md
+++ b/docs/qproduct.md
@@ -1,0 +1,184 @@
+# QProduct Certificates
+
+`LeanCert.QProduct` certifies finite product-integral invariants of the form
+
+```lean
+F S = ∫ u in (0 : ℝ)..1, ∏ n ∈ S, (1 - u ^ n)
+```
+
+for finite exponent sets `S : Finset Nat`.  The finite checker does not perform
+numerical integration. It expands the product into a signed subset-sum
+polynomial and integrates each monomial exactly over `[0, 1]`.
+
+## Import
+
+```lean
+import LeanCert.QProduct
+```
+
+or, for examples:
+
+```lean
+import LeanCert.Examples.QProduct.Basic
+import LeanCert.Examples.QProduct.PrimeLambda
+```
+
+## Finite Product Integrals
+
+The core definitions are:
+
+```lean
+qProd (S : Finset Nat) (u : ℝ)
+F (S : Finset Nat)
+finiteIntegralRat (S : Finset Nat)
+```
+
+The theorem `finiteIntegralRat_correct` connects the computable rational value
+to the semantic real integral:
+
+```lean
+theorem finiteIntegralRat_correct (S : Finset Nat) :
+    F S = (finiteIntegralRat S : ℝ)
+```
+
+For example, the exact integral for `{2, 3}` is `7 / 12`:
+
+```lean
+import LeanCert.QProduct
+
+open LeanCert.QProduct
+
+example : finiteIntegralRat ({2, 3} : Finset Nat) = 7 / 12 := by
+  native_decide
+
+example : F ({2, 3} : Finset Nat) = ((7 / 12 : ℚ) : ℝ) := by
+  rw [finiteIntegralRat_correct]
+  have h : finiteIntegralRat ({2, 3} : Finset Nat) = 7 / 12 := by
+    native_decide
+  exact_mod_cast h
+```
+
+## Finite Golden Theorems
+
+The finite certificate API follows the usual LeanCert pattern:
+
+```lean
+checkFiniteIntegralInterval
+verify_finiteIntegral_interval
+checkFiniteIntegralUpper
+verify_finiteIntegral_upper
+checkFiniteIntegralLower
+verify_finiteIntegral_lower
+```
+
+The checker is boolean and exact over `ℚ`; the verifier lifts a successful
+check to a real statement about the integral.
+
+```lean
+example :
+    ((7 / 12 : ℚ) : ℝ) ≤ F ({2, 3} : Finset Nat) ∧
+      F ({2, 3} : Finset Nat) ≤ ((7 / 12 : ℚ) : ℝ) := by
+  exact verify_finiteIntegral_interval ({2, 3} : Finset Nat)
+    (7 / 12) (7 / 12) (by native_decide)
+```
+
+## Moments
+
+`momentRat` and `moment` certify weighted integrals:
+
+```lean
+moment S k = ∫ u in (0 : ℝ)..1, qProd S u * u ^ k
+```
+
+The bridge theorem is:
+
+```lean
+theorem momentRat_correct (S : Finset Nat) (k : Nat) :
+    moment S k = (momentRat S k : ℝ)
+```
+
+## Stability Lemmas
+
+`LeanCert.QProduct.Stability` proves the elementary finite inequalities used by
+tail certificates:
+
+```lean
+qProd_nonneg
+qProd_le_one
+F_nonneg
+F_le_one
+F_antitone
+qProd_sub_le_commonPrefix_sum
+odd_tail_telescope_bound
+odd_tail_sum_le_geom
+```
+
+These are not boolean checkers. They are reusable analytic lemmas for building
+certificates from finite truncations and explicit tail estimates.
+
+## Prime-Indexed Limit
+
+`LeanCert.QProduct.PrimeLambda` defines prime truncations and the directed
+prime limit:
+
+```lean
+primesLE (N : Nat)
+primeFRat (N : Nat)
+primeLambda
+```
+
+The upper side is a standard checker-to-theorem bridge:
+
+```lean
+theorem verify_primeLambda_upper (N : Nat) (hi : ℚ)
+    (hcheck : checkPrimeLambdaUpper N hi = true) :
+    primeLambda ≤ (hi : ℝ)
+```
+
+For example:
+
+```lean
+example : primeLambda ≤ ((133 / 240 : ℚ) : ℝ) := by
+  exact verify_primeLambda_upper 7 (133 / 240) (by native_decide)
+```
+
+The lower side of a prime interval needs mathematical tail control.  The helper
+`primeLambda_lower_of_forall` says that any rational lower bound valid for all
+finite prime truncations is also valid for the directed limit:
+
+```lean
+theorem primeLambda_lower_of_forall (lo : ℚ)
+    (hlo : ∀ N : Nat, (lo : ℝ) ≤ (primeFRat N : ℝ)) :
+    (lo : ℝ) ≤ primeLambda
+```
+
+The module includes the elementary odd-tail certificate:
+
+```lean
+theorem primeLambda_lower_nineteen_thirtysix :
+    ((19 / 36 : ℚ) : ℝ) ≤ primeLambda
+
+theorem primeLambda_gt_half :
+    (1 : ℝ) / 2 < primeLambda
+```
+
+So the qualitative bound is available directly:
+
+```lean
+example : (1 : ℝ) / 2 < primeLambda := by
+  exact primeLambda_gt_half
+```
+
+## Current Scope
+
+The implemented framework certifies:
+
+- exact finite q-product integrals by rational arithmetic;
+- exact finite monomial moments;
+- finite interval, upper, and lower certificates;
+- positivity, boundedness, antitonicity, and common-prefix tail bounds;
+- prime truncation upper certificates;
+- the formal lower bound `19 / 36 ≤ primeLambda`, hence `1 / 2 < primeLambda`.
+
+High-precision prime-limit sandwiches and eta-function closed-form benchmarks
+fit the same API shape, but are not part of this initial module.

--- a/docs/qproduct.md
+++ b/docs/qproduct.md
@@ -152,9 +152,28 @@ theorem primeLambda_lower_of_forall (lo : ℚ)
     (lo : ℝ) ≤ primeLambda
 ```
 
+The reusable odd-prime tail theorem is `primeLambda_sandwich`:
+
+```lean
+theorem primeLambda_sandwich {N m : Nat}
+    (hN : 2 ≤ N) (hm : Odd m)
+    (htail_ge : ∀ p, Nat.Prime p → N < p → m ≤ p) :
+    (primeFRat N : ℝ) - (primeSandwichErrorRat N m : ℝ) ≤ primeLambda ∧
+      primeLambda ≤ (primeFRat N : ℝ)
+```
+
+The rational endpoint form is `primeLambda_rational_sandwich`, where
+`primeSandwichLowerRat N m = primeFRat N - primeSandwichErrorRat N m`.
+
 The module includes the elementary odd-tail certificate:
 
 ```lean
+theorem primeSandwichLowerRat_three_five :
+    primeSandwichLowerRat 3 5 = 19 / 36
+
+theorem primeSandwichLowerRat_three_five_le_lambda :
+    (primeSandwichLowerRat 3 5 : ℝ) ≤ primeLambda
+
 theorem primeLambda_lower_nineteen_thirtysix :
     ((19 / 36 : ℚ) : ℝ) ≤ primeLambda
 
@@ -178,6 +197,7 @@ The implemented framework certifies:
 - finite interval, upper, and lower certificates;
 - positivity, boundedness, antitonicity, and common-prefix tail bounds;
 - prime truncation upper certificates;
+- reusable odd-prime tail sandwich certificates;
 - the formal lower bound `19 / 36 ≤ primeLambda`, hence `1 / 2 < primeLambda`.
 
 High-precision prime-limit sandwiches and eta-function closed-form benchmarks


### PR DESCRIPTION
Adds a new LeanCert.QProduct framework for certified finite q-product/product-integral invariants.

  This includes:

  - exact finite product-integral evaluation via signed subset-sum expansion;
  - certified moment integrals;
  - finite interval/upper/lower certificate checkers;
  - stability lemmas for products on [0, 1];
  - common-prefix tail bounds;
  - odd-tail telescope bounds;
  - prime-indexed truncations and directed limit primeLambda;
  - certified qualitative lower bound 1/2 < primeLambda;
  - examples for finite integrals and prime-limit certificates.