### PR TITLE
Add Chebyshev golden theorem API

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -35,6 +35,8 @@ import LeanCert.Engine.ReflectiveSum
 import LeanCert.Engine.FinSumDyadic
 -- v1.3: Witness-based finite sum evaluator (user-provided per-term evaluator)
 import LeanCert.Engine.WitnessSum
+import LeanCert.Engine.ChebyshevPsi
+import LeanCert.Engine.ChebyshevTheta
 
 -- Global Optimization
 import LeanCert.Engine.Optimization.Box
@@ -268,6 +270,59 @@ export LeanCert.Engine.SearchAPI (
   isNegativeOn
   getLowerBound
   getUpperBound
+)
+
+-- Re-export Chebyshev certificate APIs
+export LeanCert.Engine.ChebyshevPsi (
+  vonMangoldtUB
+  psiUB
+  checkPsiLeMulWith
+  checkAllPsiLeMulWith
+  checkPsiBound
+  allPsiBoundsHold
+  psi_le_psiUB
+  psi_le_of_checkPsiLeMulWith
+  psi_le_mul_real_of_checkPsiLeMulWith
+  checkAllPsiLeMulWith_implies_checkPsiLeMulWith
+  allPsiBoundsHold_implies_checkPsiBound
+  verify_psi_le_mul
+  verify_psi_le_mul_real
+  verify_all_psi_le_mul
+  verify_all_psi_le_mul_real
+  verify_psi_bound
+  verify_all_psi_bound
+)
+
+export LeanCert.Engine.ChebyshevTheta (
+  logPrimeUB
+  logPrimeLB
+  thetaUB
+  thetaLB
+  checkThetaLeMulWith
+  checkAllThetaLeMulWith
+  checkThetaAbsError
+  checkAllThetaAbsError
+  checkThetaRelError
+  checkAllThetaRelError
+  checkThetaRelErrorReal
+  checkAllThetaRelErrorReal
+  theta_le_thetaUB
+  thetaLB_le_theta
+  theta_le_of_checkThetaLeMulWith
+  abs_theta_sub_le_of_checkThetaAbsError
+  abs_theta_sub_le_mul_of_checkThetaRelError
+  abs_theta_sub_le_mul_of_checkThetaRelErrorReal
+  checkAllThetaLeMulWith_implies_checkThetaLeMulWith
+  checkAllThetaAbsError_implies_checkThetaAbsError
+  checkAllThetaRelError_implies_checkThetaRelError
+  checkAllThetaRelErrorReal_implies
+  verify_theta_le_mul
+  verify_theta_abs_error
+  verify_theta_rel_error
+  verify_theta_rel_error_real
+  verify_all_theta_le_mul
+  verify_all_theta_abs_error
+  verify_all_theta_rel_error
 )
 
 -- Re-export QProduct API

--- a/LeanCert/Engine/Chebyshev/Psi.lean
+++ b/LeanCert/Engine/Chebyshev/Psi.lean
@@ -229,4 +229,71 @@ theorem allPsiBoundsHold_implies_checkPsiBound
   simpa [allPsiBoundsHold, checkPsiBound] using
     (checkAllPsiLeMulWith_implies_checkPsiLeMulWith bound (111 / 100) depth h N hN hNb)
 
+/-! ### Golden theorem aliases -/
+
+/-- Golden theorem: a successful `checkPsiLeMulWith` certificate proves
+`ψ(N) ≤ slope * N`. -/
+theorem verify_psi_le_mul (N depth : Nat) (slope : Rat)
+    (hcheck : checkPsiLeMulWith N slope depth = true) :
+    psi (N : Real) ≤ (slope : Real) * N :=
+  psi_le_of_checkPsiLeMulWith N depth slope hcheck
+
+/-- Golden theorem, real-variable form: a successful checker at `⌊x⌋₊`
+proves `ψ(x) ≤ slope * x`. -/
+theorem verify_psi_le_mul_real
+    (x : Real) (slope : Rat) (depth : Nat)
+    (hslope : 0 ≤ slope) (hx : 0 < x)
+    (hcheck : checkPsiLeMulWith (Nat.floor x) slope depth = true) :
+    psi x ≤ (slope : Real) * x :=
+  psi_le_mul_real_of_checkPsiLeMulWith x slope depth hslope hx hcheck
+
+/-- Golden theorem for the incremental checker over all natural inputs up to
+`bound`. -/
+theorem verify_all_psi_le_mul
+    (bound depth : Nat) (slope : Rat)
+    (hcheck : checkAllPsiLeMulWith bound slope depth = true) :
+    ∀ N : Nat, 0 < N → N ≤ bound →
+      psi (N : Real) ≤ (slope : Real) * N := by
+  intro N hN hNb
+  exact verify_psi_le_mul N depth slope
+    (checkAllPsiLeMulWith_implies_checkPsiLeMulWith bound slope depth hcheck N hN hNb)
+
+/-- Golden theorem for the incremental checker over all real inputs
+`0 < x ≤ bound`. The `⌊x⌋₊ = 0` case is discharged by `ψ(x) = 0`. -/
+theorem verify_all_psi_le_mul_real
+    (bound depth : Nat) (slope : Rat)
+    (hslope : 0 ≤ slope)
+    (hcheck : checkAllPsiLeMulWith bound slope depth = true) :
+    ∀ x : Real, 0 < x → x ≤ (bound : Real) →
+      psi x ≤ (slope : Real) * x := by
+  intro x hx hxb
+  rw [Chebyshev.psi_eq_psi_coe_floor x]
+  have hnn : (0 : Real) ≤ x := le_of_lt hx
+  have hfloor_le : Nat.floor x ≤ bound := Nat.floor_le_of_le hxb
+  rcases Nat.eq_zero_or_pos (Nat.floor x) with hfloor0 | hfloor_pos
+  · rw [hfloor0]
+    have hpsi0 : psi (0 : Real) = 0 :=
+      Chebyshev.psi_eq_zero_of_lt_two (by norm_num : (0 : Real) < 2)
+    rw [show ((0 : Nat) : Real) = 0 by norm_num, hpsi0]
+    exact mul_nonneg (by exact_mod_cast hslope) (le_of_lt hx)
+  · exact (verify_all_psi_le_mul bound depth slope hcheck
+      (Nat.floor x) hfloor_pos hfloor_le).trans
+      (mul_le_mul_of_nonneg_left (Nat.floor_le hnn) (by exact_mod_cast hslope))
+
+/-- Backwards-compatible Golden theorem for the legacy `1.11` checker. -/
+theorem verify_psi_bound (N depth : Nat)
+    (hcheck : checkPsiBound N depth = true) :
+    psi (N : Real) ≤ 111 / 100 * N :=
+  psi_le_of_checkPsiBound N depth hcheck
+
+/-- Backwards-compatible Golden theorem for the legacy incremental `1.11`
+checker. -/
+theorem verify_all_psi_bound
+    (bound depth : Nat) (hcheck : allPsiBoundsHold bound depth = true) :
+    ∀ N : Nat, 0 < N → N ≤ bound →
+      psi (N : Real) ≤ 111 / 100 * N := by
+  intro N hN hNb
+  exact verify_psi_bound N depth
+    (allPsiBoundsHold_implies_checkPsiBound bound depth hcheck N hN hNb)
+
 end LeanCert.Engine.ChebyshevPsi

--- a/LeanCert/Engine/Chebyshev/Theta.lean
+++ b/LeanCert/Engine/Chebyshev/Theta.lean
@@ -633,4 +633,69 @@ theorem checkAllThetaRelErrorReal_implies
   go_true_implies_checkAllThetaRelErrorReal start limit bound depth 1 (by omega) 0 0
     (by simp [thetaUB]) (by simp [thetaLB]) h N (by omega) hN_start hNb
 
+/-! ### Golden theorem aliases -/
+
+/-- Golden theorem: a successful `checkThetaLeMulWith` certificate proves
+`θ(N) ≤ slope * N`. -/
+theorem verify_theta_le_mul (N depth : Nat) (slope : Rat)
+    (hcheck : checkThetaLeMulWith N slope depth = true) :
+    theta (N : Real) ≤ (slope : Real) * N :=
+  theta_le_of_checkThetaLeMulWith N depth slope hcheck
+
+/-- Golden theorem for absolute-error certificates at one natural input. -/
+theorem verify_theta_abs_error (N depth : Nat) (bound : Rat)
+    (hcheck : checkThetaAbsError N bound depth = true) :
+    |theta (N : Real) - N| ≤ (bound : Real) :=
+  abs_theta_sub_le_of_checkThetaAbsError N depth bound hcheck
+
+/-- Golden theorem for relative-error certificates at one natural input. -/
+theorem verify_theta_rel_error (N depth : Nat) (bound : Rat)
+    (hcheck : checkThetaRelError N bound depth = true) :
+    |theta (N : Real) - N| ≤ (bound : Real) * N :=
+  abs_theta_sub_le_mul_of_checkThetaRelError N depth bound hcheck
+
+/-- Golden theorem for strengthened real-variable relative-error certificates
+on a single unit interval `[N, N+1)`. -/
+theorem verify_theta_rel_error_real (N depth : Nat) (bound : Rat)
+    (hbound : 0 ≤ bound) (hbound1 : bound ≤ 1)
+    (hcheck : checkThetaRelErrorReal N bound depth = true)
+    (x : Real) (hxlo : (N : Real) ≤ x) (hxhi : x < (N : Real) + 1) :
+    |theta x - x| ≤ (bound : Real) * x :=
+  abs_theta_sub_le_mul_of_checkThetaRelErrorReal N depth bound hbound hbound1 hcheck
+    x hxlo hxhi
+
+/-- Golden theorem for the incremental upper-bound checker over all natural
+inputs up to `bound`. -/
+theorem verify_all_theta_le_mul
+    (bound depth : Nat) (slope : Rat)
+    (hcheck : checkAllThetaLeMulWith bound slope depth = true) :
+    ∀ N : Nat, 0 < N → N ≤ bound →
+      theta (N : Real) ≤ (slope : Real) * N := by
+  intro N hN hNb
+  exact verify_theta_le_mul N depth slope
+    (checkAllThetaLeMulWith_implies_checkThetaLeMulWith bound slope depth hcheck N hN hNb)
+
+/-- Golden theorem for the incremental absolute-error checker over all natural
+inputs up to `limit`. -/
+theorem verify_all_theta_abs_error
+    (limit depth : Nat) (bound : Rat)
+    (hcheck : checkAllThetaAbsError limit bound depth = true) :
+    ∀ N : Nat, 0 < N → N ≤ limit →
+      |theta (N : Real) - N| ≤ (bound : Real) := by
+  intro N hN hNb
+  exact verify_theta_abs_error N depth bound
+    (checkAllThetaAbsError_implies_checkThetaAbsError limit bound depth hcheck N hN hNb)
+
+/-- Golden theorem for the incremental relative-error checker over all natural
+inputs in `[start, limit]`. -/
+theorem verify_all_theta_rel_error
+    (start limit depth : Nat) (bound : Rat)
+    (hcheck : checkAllThetaRelError start limit bound depth = true) :
+    ∀ N : Nat, 0 < N → start ≤ N → N ≤ limit →
+      |theta (N : Real) - N| ≤ (bound : Real) * N := by
+  intro N hN hN_start hNb
+  exact verify_theta_rel_error N depth bound
+    (checkAllThetaRelError_implies_checkThetaRelError start limit bound depth hcheck
+      N hN hN_start hNb)
+
 end LeanCert.Engine.ChebyshevTheta

--- a/LeanCert/Examples.lean
+++ b/LeanCert/Examples.lean
@@ -7,6 +7,7 @@ import LeanCert.Examples.GlobalOptimization
 import LeanCert.Examples.EdgeCases
 import LeanCert.Examples.NeuralNet
 import LeanCert.Examples.Showcase
+import LeanCert.Examples.Chebyshev
 import LeanCert.Examples.QProduct.Basic
 import LeanCert.Examples.QProduct.PrimeLambda
 import LeanCert.Examples.ML.Distillation

--- a/LeanCert/Examples/Chebyshev.lean
+++ b/LeanCert/Examples/Chebyshev.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.Engine.ChebyshevPsi
+import LeanCert.Engine.ChebyshevTheta
+
+/-!
+# Chebyshev certificate examples
+-/
+
+open Chebyshev (psi theta)
+open LeanCert.Engine.ChebyshevPsi
+open LeanCert.Engine.ChebyshevTheta
+
+namespace LeanCert.Examples.Chebyshev
+
+example :
+    psi (10 : ℝ) ≤ (3 : ℝ) * 10 := by
+  exact verify_psi_le_mul 10 20 3 (by native_decide)
+
+example :
+    ∀ N : Nat, 0 < N → N ≤ 20 →
+      psi (N : ℝ) ≤ (3 : ℝ) * N := by
+  exact verify_all_psi_le_mul 20 20 3 (by native_decide)
+
+example :
+    theta (10 : ℝ) ≤ (3 : ℝ) * 10 := by
+  exact verify_theta_le_mul 10 20 3 (by native_decide)
+
+example :
+    ∀ N : Nat, 0 < N → 2 ≤ N → N ≤ 20 →
+      |theta (N : ℝ) - N| ≤ ((9 / 10 : ℚ) : ℝ) * N := by
+  exact verify_all_theta_rel_error 2 20 20 (9 / 10) (by native_decide)
+
+end LeanCert.Examples.Chebyshev

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Numerical computation produces suggestions. LeanCert produces theorems.
 
-LeanCert is a Lean 4 library for certified numerical reasoning: interval bounds, global optimization, root existence/uniqueness, integration bounds, and exact product-integral certificates with proof-producing tactics.
+LeanCert is a Lean 4 library for certified numerical reasoning: interval bounds, global optimization, root existence/uniqueness, integration bounds, Chebyshev function certificates, and exact product-integral certificates with proof-producing tactics.
 
 ## Installation
 
@@ -42,8 +42,9 @@ LeanCert follows a certificate-driven structure:
 3. Certification through Golden Theorems
 
 It also includes specialized exact-arithmetic certificate modules such as
-`LeanCert.QProduct` for finite q-product/product-integral invariants and
-prime-indexed limit bounds.
+`LeanCert.Engine.ChebyshevPsi`/`LeanCert.Engine.ChebyshevTheta` for finite
+Chebyshev function bounds, and `LeanCert.QProduct` for finite
+q-product/product-integral invariants and prime-indexed limit bounds.
 
 ## Checking Mathlib Compatibility
 

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -23,6 +23,8 @@ Golden Theorems are defined across multiple files:
 - `Validity/DyadicBounds.lean` - Dyadic arithmetic (fast)
 - `Validity/AffineBounds.lean` - Affine arithmetic (tight bounds)
 - `Validity/Monotonicity.lean` - Monotonicity via automatic differentiation
+- `Engine/Chebyshev/Psi.lean` - Chebyshev `ψ` finite-range certificates
+- `Engine/Chebyshev/Theta.lean` - Chebyshev `θ` finite-range certificates
 - `QProduct/Certificate.lean` - Exact finite q-product integrals
 - `QProduct/PrimeLambda.lean` - Prime-limit q-product certificates
 
@@ -164,6 +166,45 @@ theorem primeLambda_sandwich {N m : Nat}
 
 The initial module includes the formally proved tail certificate
 `primeLambda_gt_half : (1 : ℝ) / 2 < primeLambda`.
+
+### Chebyshev Certificates
+
+The Chebyshev engines expose specialized finite-range Golden Theorems for
+number-theoretic functions.
+
+For `ψ`, the checker bounds a computable rational envelope `psiUB`:
+
+| Goal | Theorem | Checker |
+|------|---------|---------|
+| One natural input | `verify_psi_le_mul` | `checkPsiLeMulWith` |
+| All natural inputs up to `bound` | `verify_all_psi_le_mul` | `checkAllPsiLeMulWith` |
+| All real inputs up to `bound` | `verify_all_psi_le_mul_real` | `checkAllPsiLeMulWith` |
+
+```lean
+theorem verify_all_psi_le_mul
+    (bound depth : Nat) (slope : ℚ)
+    (hcheck : checkAllPsiLeMulWith bound slope depth = true) :
+    ∀ N : Nat, 0 < N → N ≤ bound →
+      Chebyshev.psi (N : ℝ) ≤ (slope : ℝ) * N
+```
+
+For `θ`, the checker supports upper, absolute-error, and relative-error bounds:
+
+| Goal | Theorem | Checker |
+|------|---------|---------|
+| Upper bound | `verify_theta_le_mul` | `checkThetaLeMulWith` |
+| Absolute error | `verify_theta_abs_error` | `checkThetaAbsError` |
+| Relative error | `verify_theta_rel_error` | `checkThetaRelError` |
+| Range relative error | `verify_all_theta_rel_error` | `checkAllThetaRelError` |
+| Unit-interval real relative error | `verify_theta_rel_error_real` | `checkThetaRelErrorReal` |
+
+```lean
+theorem verify_all_theta_rel_error
+    (start limit depth : Nat) (bound : ℚ)
+    (hcheck : checkAllThetaRelError start limit bound depth = true) :
+    ∀ N : Nat, 0 < N → start ≤ N → N ≤ limit →
+      |Chebyshev.theta (N : ℝ) - N| ≤ (bound : ℝ) * N
+```
 
 ### Monotonicity
 

--- a/docs/chebyshev.md
+++ b/docs/chebyshev.md
@@ -1,0 +1,129 @@
+# Chebyshev Certificates
+
+LeanCert includes specialized certificate engines for finite Chebyshev function
+bounds. These engines use computable rational upper/lower envelopes for
+logarithmic summands, then expose Golden Theorems that turn successful boolean
+checks into real-number bounds.
+
+## Imports
+
+```lean
+import LeanCert.Engine.ChebyshevPsi
+import LeanCert.Engine.ChebyshevTheta
+```
+
+or use the aggregate import:
+
+```lean
+import LeanCert
+```
+
+## Psi Bounds
+
+`LeanCert.Engine.ChebyshevPsi` certifies upper bounds for the second Chebyshev
+function `ψ`.
+
+Core checkers:
+
+```lean
+checkPsiLeMulWith (N : Nat) (slope : ℚ) (depth : Nat)
+checkAllPsiLeMulWith (bound : Nat) (slope : ℚ) (depth : Nat)
+```
+
+Golden Theorems:
+
+```lean
+theorem verify_psi_le_mul (N depth : Nat) (slope : ℚ)
+    (hcheck : checkPsiLeMulWith N slope depth = true) :
+    Chebyshev.psi (N : ℝ) ≤ (slope : ℝ) * N
+
+theorem verify_all_psi_le_mul
+    (bound depth : Nat) (slope : ℚ)
+    (hcheck : checkAllPsiLeMulWith bound slope depth = true) :
+    ∀ N : Nat, 0 < N → N ≤ bound →
+      Chebyshev.psi (N : ℝ) ≤ (slope : ℝ) * N
+```
+
+Real-variable form:
+
+```lean
+theorem verify_all_psi_le_mul_real
+    (bound depth : Nat) (slope : ℚ)
+    (hslope : 0 ≤ slope)
+    (hcheck : checkAllPsiLeMulWith bound slope depth = true) :
+    ∀ x : ℝ, 0 < x → x ≤ (bound : ℝ) →
+      Chebyshev.psi x ≤ (slope : ℝ) * x
+```
+
+## Theta Bounds
+
+`LeanCert.Engine.ChebyshevTheta` certifies upper, absolute-error, and
+relative-error bounds for the first Chebyshev function `θ`.
+
+Core checkers:
+
+```lean
+checkThetaLeMulWith
+checkAllThetaLeMulWith
+checkThetaAbsError
+checkAllThetaAbsError
+checkThetaRelError
+checkAllThetaRelError
+checkThetaRelErrorReal
+checkAllThetaRelErrorReal
+```
+
+Golden Theorems:
+
+```lean
+theorem verify_theta_le_mul (N depth : Nat) (slope : ℚ)
+    (hcheck : checkThetaLeMulWith N slope depth = true) :
+    Chebyshev.theta (N : ℝ) ≤ (slope : ℝ) * N
+
+theorem verify_theta_abs_error (N depth : Nat) (bound : ℚ)
+    (hcheck : checkThetaAbsError N bound depth = true) :
+    |Chebyshev.theta (N : ℝ) - N| ≤ (bound : ℝ)
+
+theorem verify_theta_rel_error (N depth : Nat) (bound : ℚ)
+    (hcheck : checkThetaRelError N bound depth = true) :
+    |Chebyshev.theta (N : ℝ) - N| ≤ (bound : ℝ) * N
+```
+
+Range checkers have corresponding range Golden Theorems:
+
+```lean
+theorem verify_all_theta_le_mul
+theorem verify_all_theta_abs_error
+theorem verify_all_theta_rel_error
+```
+
+For real `x ∈ [N, N+1)`, use the strengthened interval certificate:
+
+```lean
+theorem verify_theta_rel_error_real (N depth : Nat) (bound : ℚ)
+    (hbound : 0 ≤ bound) (hbound1 : bound ≤ 1)
+    (hcheck : checkThetaRelErrorReal N bound depth = true)
+    (x : ℝ) (hxlo : (N : ℝ) ≤ x) (hxhi : x < (N : ℝ) + 1) :
+    |Chebyshev.theta x - x| ≤ (bound : ℝ) * x
+```
+
+## Example
+
+```lean
+import LeanCert.Engine.ChebyshevPsi
+
+open Chebyshev (psi)
+open LeanCert.Engine.ChebyshevPsi
+
+example :
+    ∀ N : Nat, 0 < N → N ≤ 20 →
+      psi (N : ℝ) ≤ (3 : ℝ) * N := by
+  exact verify_all_psi_le_mul 20 20 3 (by native_decide)
+```
+
+## Notes
+
+The older theorem names such as `psi_le_of_checkPsiLeMulWith` and
+`abs_theta_sub_le_mul_of_checkThetaRelError` remain available. The `verify_*`
+names are thin public aliases matching the rest of LeanCert's Golden Theorem
+style.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ LeanCert is a Lean 4 library for certified numerical computation and proof-produ
 - Verified interval bounds
 - Proof automation for inequalities and root claims
 - Global optimization and integration certificates
+- Chebyshev function certificates
 - Exact q-product/product-integral certificates
 - Dyadic and rational backends for different performance/precision tradeoffs
 
@@ -45,6 +46,7 @@ lake update
 | [Tactics Reference](tactics.md) | Main proving tactics |
 | [Choosing Tactics](choosing-tactics.md) | Pick the right tactic quickly |
 | [End-to-End Example](end-to-end-example.md) | Discovery to theorem workflow |
+| [Chebyshev Certificates](chebyshev.md) | Certified `ψ` and `θ` finite-range bounds |
 | [QProduct Certificates](qproduct.md) | Exact product-integral and prime-limit certificates |
 
 ## Architecture


### PR DESCRIPTION
Adds public verify_* Golden Theorem wrappers for the Chebyshev ψ and θ certificate engines.

  This PR does not change the underlying checker logic. It exposes the existing checker-to-theorem bridges through a consistent LeanCert-style API.

  Adds:

  - verify_psi_le_mul
  - verify_psi_le_mul_real
  - verify_all_psi_le_mul
  - verify_all_psi_le_mul_real
  - verify_psi_bound
  - verify_all_psi_bound
  - verify_theta_le_mul
  - verify_theta_abs_error
  - verify_theta_rel_error
  - verify_theta_rel_error_real
  - verify_all_theta_le_mul
  - verify_all_theta_abs_error
  - verify_all_theta_rel_error

  Also adds:

  - Chebyshev API re-exports from LeanCert.lean
  - LeanCert/Examples/Chebyshev.lean
  - docs/chebyshev.md
  - Golden Theorems documentation updates
