### PR TITLE
Improve interval_decide on closed exp-sqrt goals

### DIFF
--- a/LeanCert/Tactic/IntervalAuto/PointIneq.lean
+++ b/LeanCert/Tactic/IntervalAuto/PointIneq.lean
@@ -166,9 +166,6 @@ def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr) (taylorDep
     let ast ← reify funcExpr
     trace[interval_decide] "ast reified"
 
-    let supportProof ← mkSupportedCoreProof ast
-    trace[interval_decide] "supportProof generated"
-
     -- Helper: try to close the goal given a proof term for the bound
     let tryCloseWith (proofStx : TSyntax `term) : TacticM Bool := do
       -- Approach 1: Direct simp + exact
@@ -317,6 +314,9 @@ def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr) (taylorDep
     catch e =>
       trace[interval_decide] "Dyadic backend failed: {e.toMessageData}"
 
+    let supportProof ← mkSupportedCoreProof ast
+    trace[interval_decide] "supportProof generated"
+
     let cfgExpr ← mkAppM ``EvalConfig.mk #[toExpr taylorDepth]
 
     let zeroRat : ℚ := 0
@@ -419,6 +419,11 @@ def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
   let c : ℚ ←
     if !hasFreeVars then
       trace[interval_decide] "No free variables, trying closed expression path"
+      try
+        proveClosedExpressionBound goal goalType taylorDepth
+        return
+      catch e =>
+        trace[interval_decide] "Closed expression path on original goal failed: {e.toMessageData}"
       let mut currentGoal := goal
       let mut currentGoalType := goalType
       try

--- a/LeanCert/Test/test_exp_bounds.lean
+++ b/LeanCert/Test/test_exp_bounds.lean
@@ -17,3 +17,8 @@ example : ∀ x ∈ Set.Icc 0 1, Real.exp x ≤ 2.71828183 := by
 -- Very tight (e ≈ 2.718281828...)
 example : ∀ x ∈ Set.Icc 0 1, Real.exp x ≤ 2.718281829 := by
   interval_bound
+
+-- Regression: closed point inequalities should be certified before `norm_num`
+-- rewrites decimal square roots into quotient forms such as `√3 / √2`.
+example : (2.5 : ℝ) ≤ 9.2211 * Real.exp (-0.8476 * Real.sqrt 1.5) := by
+  interval_decide


### PR DESCRIPTION
 ## Summary
  - try the closed-expression certificate path before `norm_num` normalization
  - avoid rewriting decimal square roots like `sqrt 1.5` into quotient forms before dyadic certification
  - defer core-support proof until after the dyadic-with-inv backend gets a chance
  - add regression coverage for the PNT-style `exp (-c * sqrt q)` point inequality