### PR TITLE
Feature/abel euler mertens certificates

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -11,6 +11,7 @@ import LeanCert.Core.IntervalReal
 import LeanCert.Core.IntervalRealEndpoints
 import LeanCert.Core.Taylor
 import LeanCert.Core.DerivativeIntervals
+import LeanCert.Cert.Interval
 -- v1.1: Dyadic arithmetic (high-performance alternative to Rat)
 import LeanCert.Core.Dyadic
 import LeanCert.Core.IntervalDyadic
@@ -124,6 +125,16 @@ export LeanCert.Core (Expr)
 
 -- Re-export interval types
 export LeanCert.Core (IntervalRat)
+
+-- Re-export small certificate combinators
+export LeanCert.Cert (
+  checkRatInterval
+  checkRatUpper
+  checkRatLower
+  verify_rat_interval
+  verify_rat_upper
+  verify_rat_lower
+)
 
 -- v1.1: Re-export Dyadic types (high-performance arithmetic)
 export LeanCert.Core (Dyadic IntervalDyadic)
@@ -420,6 +431,8 @@ export LeanCert.ANT (
   abelBoundUpperRat
   abelBoundLowerRat_le_transform
   transform_le_abelBoundUpperRat
+  abelTransformOfPrefix_le_abelBoundUpperRat
+  abelTransformOfPrefix_ge_abelBoundLowerRat
   checkAbelBoundInterval
   verify_abelBound_interval
   productLowerRat
@@ -438,6 +451,8 @@ export LeanCert.ANT (
   verify_logProduct_interval
   finiteProduct_eq_exp_finiteLogProduct
   verify_product_interval_of_log_interval
+  verify_product_lower_of_log_lower
+  verify_product_upper_of_log_upper
   oneMinusInvRat
   onePlusInvRat
   primeEulerOneMinusInv

--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -463,6 +463,37 @@ export LeanCert.ANT (
   checkPrimeEulerOnePlusInvInterval
   verify_primeEulerOneMinusInv_interval
   verify_primeEulerOnePlusInv_interval
+  finiteDirichletSum
+  intervalMulLowerRat
+  intervalMulUpperRat
+  finiteDirichletSumLowerRat
+  finiteDirichletSumUpperRat
+  finiteDirichletSumLowerRat_le
+  finiteDirichletSum_le_upperRat
+  checkDirichletSumInterval
+  checkDirichletSumLower
+  checkDirichletSumUpper
+  verify_dirichletSum_interval
+  verify_dirichletSum_lower
+  verify_dirichletSum_upper
+  naturalsIcc
+  harmonicSum
+  harmonicSumRat
+  primeHarmonicSum
+  primeHarmonicSumRat
+  logPrimeOverPrimeSum
+  logPrimeOverPrimeLowerRat
+  logPrimeOverPrimeUpperRat
+  harmonicSum_eq_rat
+  primeHarmonicSum_eq_rat
+  checkHarmonicSumInterval
+  checkPrimeHarmonicSumInterval
+  checkLogPrimeOverPrimeSumInterval
+  logPrimeOverPrimeLowerRat_le
+  logPrimeOverPrime_le_upperRat
+  verify_harmonicSum_interval
+  verify_primeHarmonicSum_interval
+  verify_logPrimeOverPrimeSum_interval
   mertensLogSum
   thetaIncrement
   invNatRat

--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -59,6 +59,9 @@ import LeanCert.Engine.SearchAPI
 -- Q-product product-integral certificates
 import LeanCert.QProduct
 
+-- Analytic number theory certificate machinery
+import LeanCert.ANT
+
 -- Meta (metaprogramming utilities)
 import LeanCert.Meta.ProveContinuous
 import LeanCert.Meta.ProveSupported
@@ -381,6 +384,54 @@ export LeanCert.QProduct (
   primeFRat_lower_nineteen_thirtysix
   primeLambda_lower_nineteen_thirtysix
   primeLambda_gt_half
+)
+
+-- Re-export ANT certificate API
+export LeanCert.ANT (
+  StepFn
+  stepLowerRat
+  stepUpperRat
+  stepSum
+  stepLowerRat_le_stepSum
+  stepSum_le_stepUpperRat
+  checkStepSumInterval
+  checkStepSumLower
+  checkStepSumUpper
+  verify_stepSum_interval
+  verify_stepSum_lower
+  verify_stepSum_upper
+  prefixSum
+  prefixSumRat
+  abelTransformRat
+  weightedSumRat
+  weightedSumRat_eq_abelTransformRat
+  checkAbelInterval
+  checkAbelUpper
+  checkAbelLower
+  verify_abel_interval
+  verify_abel_upper
+  verify_abel_lower
+  productLowerRat
+  productUpperRat
+  finiteProduct
+  productLowerRat_le_finiteProduct
+  finiteProduct_le_productUpperRat
+  checkEulerProductInterval
+  verify_eulerProduct_interval
+  finiteLogProduct
+  logProductLowerRat
+  logProductUpperRat
+  logProductLowerRat_le_finiteLogProduct
+  finiteLogProduct_le_logProductUpperRat
+  checkLogProductInterval
+  verify_logProduct_interval
+  mertensLogSum
+  mertensLogSumLowerRat
+  mertensLogSumUpperRat
+  mertensLogSumLowerRat_le
+  mertensLogSum_le_mertensLogSumUpperRat
+  checkMertensLogSumInterval
+  verify_mertensLogSum_interval
 )
 
 /-! ### Convenience abbreviations -/

--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -404,13 +404,24 @@ export LeanCert.ANT (
   prefixSumRat
   abelTransformRat
   weightedSumRat
+  weightedSum
+  abelTransformOfPrefix
   weightedSumRat_eq_abelTransformRat
+  weightedSum_eq_abelTransformOfPrefix
   checkAbelInterval
   checkAbelUpper
   checkAbelLower
   verify_abel_interval
   verify_abel_upper
   verify_abel_lower
+  coeffLowerRat
+  coeffUpperRat
+  abelBoundLowerRat
+  abelBoundUpperRat
+  abelBoundLowerRat_le_transform
+  transform_le_abelBoundUpperRat
+  checkAbelBoundInterval
+  verify_abelBound_interval
   productLowerRat
   productUpperRat
   finiteProduct
@@ -425,7 +436,29 @@ export LeanCert.ANT (
   finiteLogProduct_le_logProductUpperRat
   checkLogProductInterval
   verify_logProduct_interval
+  finiteProduct_eq_exp_finiteLogProduct
+  verify_product_interval_of_log_interval
+  oneMinusInvRat
+  onePlusInvRat
+  primeEulerOneMinusInv
+  primeEulerOneMinusInvRat
+  primeEulerOnePlusInv
+  primeEulerOnePlusInvRat
+  checkPrimeEulerOneMinusInvInterval
+  checkPrimeEulerOnePlusInvInterval
+  verify_primeEulerOneMinusInv_interval
+  verify_primeEulerOnePlusInv_interval
   mertensLogSum
+  thetaIncrement
+  invNatRat
+  thetaPrefixLowerRat
+  thetaPrefixUpperRat
+  mertensAbelSum
+  thetaPrefixLowerRat_le_prefix
+  prefix_le_thetaPrefixUpperRat
+  thetaPrefix_envelope
+  checkMertensAbelInterval
+  verify_mertensAbel_interval
   mertensLogSumLowerRat
   mertensLogSumUpperRat
   mertensLogSumLowerRat_le

--- a/LeanCert/ANT.lean
+++ b/LeanCert/ANT.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT.Step
+import LeanCert.ANT.Abel
+import LeanCert.ANT.EulerProduct
+import LeanCert.ANT.Mertens
+
+/-!
+# Analytic number theory certificate machinery
+
+Reusable finite certificate bridges for arithmetic step sums, Abel/partial
+summation transforms, finite Euler products, and Mertens-style prime sums.
+-/

--- a/LeanCert/ANT.lean
+++ b/LeanCert/ANT.lean
@@ -6,6 +6,7 @@ Authors: LeanCert Contributors
 import LeanCert.ANT.Step
 import LeanCert.ANT.Abel
 import LeanCert.ANT.EulerProduct
+import LeanCert.ANT.PrimeEuler
 import LeanCert.ANT.Mertens
 
 /-!

--- a/LeanCert/ANT.lean
+++ b/LeanCert/ANT.lean
@@ -7,6 +7,7 @@ import LeanCert.ANT.Step
 import LeanCert.ANT.Abel
 import LeanCert.ANT.EulerProduct
 import LeanCert.ANT.PrimeEuler
+import LeanCert.ANT.Dirichlet
 import LeanCert.ANT.Mertens
 
 /-!

--- a/LeanCert/ANT/Abel.lean
+++ b/LeanCert/ANT/Abel.lean
@@ -78,15 +78,15 @@ theorem weightedSumRat_eq_abelTransformRat {a f : Nat → ℚ} {m n : Nat}
 
 /-- Exact rational Abel interval checker. -/
 def checkAbelInterval (a f : Nat → ℚ) (m n : Nat) (lo hi : ℚ) : Bool :=
-  decide (lo ≤ abelTransformRat a f m n) && decide (abelTransformRat a f m n ≤ hi)
+  LeanCert.Cert.checkRatInterval (abelTransformRat a f m n) (abelTransformRat a f m n) lo hi
 
 /-- Exact rational Abel upper checker. -/
 def checkAbelUpper (a f : Nat → ℚ) (m n : Nat) (hi : ℚ) : Bool :=
-  decide (abelTransformRat a f m n ≤ hi)
+  LeanCert.Cert.checkRatUpper (abelTransformRat a f m n) hi
 
 /-- Exact rational Abel lower checker. -/
 def checkAbelLower (a f : Nat → ℚ) (m n : Nat) (lo : ℚ) : Bool :=
-  decide (lo ≤ abelTransformRat a f m n)
+  LeanCert.Cert.checkRatLower (abelTransformRat a f m n) lo
 
 /-- Golden theorem for exact finite Abel interval certificates. -/
 theorem verify_abel_interval (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (lo hi : ℚ)
@@ -95,7 +95,7 @@ theorem verify_abel_interval (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (lo h
       (weightedSumRat a f m n : ℝ) ≤ (hi : ℝ) := by
   simp only [checkAbelInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
   rw [weightedSumRat_eq_abelTransformRat hmn]
-  exact ⟨by exact_mod_cast hcheck.1, by exact_mod_cast hcheck.2⟩
+  exact LeanCert.Cert.verify_rat_interval le_rfl le_rfl hcheck
 
 /-- Golden theorem for exact finite Abel upper certificates. -/
 theorem verify_abel_upper (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (hi : ℚ)
@@ -103,7 +103,7 @@ theorem verify_abel_upper (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (hi : �
     (weightedSumRat a f m n : ℝ) ≤ (hi : ℝ) := by
   simp only [checkAbelUpper, decide_eq_true_eq] at hcheck
   rw [weightedSumRat_eq_abelTransformRat hmn]
-  exact_mod_cast hcheck
+  exact LeanCert.Cert.verify_rat_upper le_rfl hcheck
 
 /-- Golden theorem for exact finite Abel lower certificates. -/
 theorem verify_abel_lower (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (lo : ℚ)
@@ -111,7 +111,7 @@ theorem verify_abel_lower (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (lo : �
     (lo : ℝ) ≤ (weightedSumRat a f m n : ℝ) := by
   simp only [checkAbelLower, decide_eq_true_eq] at hcheck
   rw [weightedSumRat_eq_abelTransformRat hmn]
-  exact_mod_cast hcheck
+  exact LeanCert.Cert.verify_rat_lower le_rfl hcheck
 
 /-! ### Bounded Abel certificates -/
 
@@ -193,10 +193,24 @@ theorem transform_le_abelBoundUpperRat
       (hA (i + 1)).1 (hA (i + 1)).2
     convert hterm using 1 <;> simp [Nat.add_comm] <;> ring_nf
 
+/-- Alias with the semantic object first in the name. -/
+theorem abelTransformOfPrefix_le_abelBoundUpperRat
+    (f ALo AHi : Nat → ℚ) (A : Nat → ℝ) (m n : Nat)
+    (hA : ∀ k, (ALo k : ℝ) ≤ A k ∧ A k ≤ (AHi k : ℝ)) :
+    abelTransformOfPrefix f A m n ≤ (abelBoundUpperRat f ALo AHi m n : ℝ) :=
+  transform_le_abelBoundUpperRat f ALo AHi A m n hA
+
+/-- Alias with the semantic object first in the name. -/
+theorem abelTransformOfPrefix_ge_abelBoundLowerRat
+    (f ALo AHi : Nat → ℚ) (A : Nat → ℝ) (m n : Nat)
+    (hA : ∀ k, (ALo k : ℝ) ≤ A k ∧ A k ≤ (AHi k : ℝ)) :
+    (abelBoundLowerRat f ALo AHi m n : ℝ) ≤ abelTransformOfPrefix f A m n :=
+  abelBoundLowerRat_le_transform f ALo AHi A m n hA
+
 /-- Boolean interval checker for Abel bounds from prefix envelopes. -/
 def checkAbelBoundInterval (f ALo AHi : Nat → ℚ) (m n : Nat) (lo hi : ℚ) : Bool :=
-  decide (lo ≤ abelBoundLowerRat f ALo AHi m n) &&
-    decide (abelBoundUpperRat f ALo AHi m n ≤ hi)
+  LeanCert.Cert.checkRatInterval (abelBoundLowerRat f ALo AHi m n)
+    (abelBoundUpperRat f ALo AHi m n) lo hi
 
 /-- Golden theorem for bounded Abel certificates. -/
 theorem verify_abelBound_interval
@@ -205,13 +219,10 @@ theorem verify_abelBound_interval
     (lo hi : ℚ)
     (hcheck : checkAbelBoundInterval f ALo AHi m n lo hi = true) :
     (lo : ℝ) ≤ weightedSum a f m n ∧ weightedSum a f m n ≤ (hi : ℝ) := by
-  simp only [checkAbelBoundInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
   rw [weightedSum_eq_abelTransformOfPrefix hmn]
-  have hlo : (lo : ℝ) ≤ (abelBoundLowerRat f ALo AHi m n : ℝ) := by
-    exact_mod_cast hcheck.1
-  have hhi : (abelBoundUpperRat f ALo AHi m n : ℝ) ≤ (hi : ℝ) := by
-    exact_mod_cast hcheck.2
-  exact ⟨hlo.trans (abelBoundLowerRat_le_transform f ALo AHi (prefixSum a) m n hA),
-    (transform_le_abelBoundUpperRat f ALo AHi (prefixSum a) m n hA).trans hhi⟩
+  exact LeanCert.Cert.verify_rat_interval
+    (abelBoundLowerRat_le_transform f ALo AHi (prefixSum a) m n hA)
+    (transform_le_abelBoundUpperRat f ALo AHi (prefixSum a) m n hA)
+    hcheck
 
 end LeanCert.ANT

--- a/LeanCert/ANT/Abel.lean
+++ b/LeanCert/ANT/Abel.lean
@@ -18,6 +18,9 @@ namespace LeanCert.ANT
 
 open scoped BigOperators
 
+set_option linter.unusedSimpArgs false
+set_option linter.unnecessarySeqFocus false
+
 /-- Prefix sum `∑ i < n, a i`. -/
 noncomputable def prefixSum (a : Nat → ℝ) (n : Nat) : ℝ :=
   ∑ i ∈ Finset.range n, a i
@@ -37,10 +40,30 @@ def abelTransformRat (a f : Nat → ℚ) (m n : Nat) : ℚ :=
 def weightedSumRat (a f : Nat → ℚ) (m n : Nat) : ℚ :=
   ∑ i ∈ Finset.Ico m n, f i * a i
 
+/-- Direct real weighted sum on `[m, n)`, with rational weights. -/
+noncomputable def weightedSum (a : Nat → ℝ) (f : Nat → ℚ) (m n : Nat) : ℝ :=
+  ∑ i ∈ Finset.Ico m n, (f i : ℝ) * a i
+
+/-- Abel transform written against an arbitrary real prefix function `A`. -/
+noncomputable def abelTransformOfPrefix (f : Nat → ℚ) (A : Nat → ℝ) (m n : Nat) : ℝ :=
+  (f (n - 1) : ℝ) * A n -
+    (f m : ℝ) * A m -
+      ∑ i ∈ Finset.Ico m (n - 1),
+        ((f (i + 1) - f i : ℚ) : ℝ) * A (i + 1)
+
 theorem prefixSumRat_cast (a : Nat → ℚ) (n : Nat) :
     (prefixSumRat a n : ℝ) = prefixSum (fun i => (a i : ℝ)) n := by
   unfold prefixSumRat prefixSum
   rw [Rat.cast_sum]
+
+/-- Abel's finite summation-by-parts identity for real summands and rational weights. -/
+theorem weightedSum_eq_abelTransformOfPrefix {a : Nat → ℝ} {f : Nat → ℚ} {m n : Nat}
+    (hmn : m < n) :
+    weightedSum a f m n = abelTransformOfPrefix f (prefixSum a) m n := by
+  unfold weightedSum abelTransformOfPrefix
+  have h := Finset.sum_Ico_by_parts (R := ℝ) (M := ℝ)
+    (fun i => (f i : ℝ)) a hmn
+  simpa [prefixSum, smul_eq_mul, mul_comm, mul_left_comm, mul_assoc] using h
 
 /-- Abel's finite summation-by-parts identity, in the rational evaluator form. -/
 theorem weightedSumRat_eq_abelTransformRat {a f : Nat → ℚ} {m n : Nat}
@@ -89,5 +112,106 @@ theorem verify_abel_lower (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (lo : �
   simp only [checkAbelLower, decide_eq_true_eq] at hcheck
   rw [weightedSumRat_eq_abelTransformRat hmn]
   exact_mod_cast hcheck
+
+/-! ### Bounded Abel certificates -/
+
+/-- Lower contribution of `c * A` when `A ∈ [lo, hi]`. -/
+def coeffLowerRat (c lo hi : ℚ) : ℚ :=
+  if 0 ≤ c then c * lo else c * hi
+
+/-- Upper contribution of `c * A` when `A ∈ [lo, hi]`. -/
+def coeffUpperRat (c lo hi : ℚ) : ℚ :=
+  if 0 ≤ c then c * hi else c * lo
+
+private theorem coeffLowerRat_le_mul {c lo hi : ℚ} {A : ℝ}
+    (hlo : (lo : ℝ) ≤ A) (hhi : A ≤ (hi : ℝ)) :
+    (coeffLowerRat c lo hi : ℝ) ≤ (c : ℝ) * A := by
+  unfold coeffLowerRat
+  by_cases hc : 0 ≤ c
+  · simp [hc]
+    exact mul_le_mul_of_nonneg_left hlo (by exact_mod_cast hc)
+  · simp [hc]
+    have hc_nonpos : (c : ℝ) ≤ 0 := by exact_mod_cast le_of_not_ge hc
+    exact mul_le_mul_of_nonpos_left hhi hc_nonpos
+
+private theorem mul_le_coeffUpperRat {c lo hi : ℚ} {A : ℝ}
+    (hlo : (lo : ℝ) ≤ A) (hhi : A ≤ (hi : ℝ)) :
+    (c : ℝ) * A ≤ (coeffUpperRat c lo hi : ℝ) := by
+  unfold coeffUpperRat
+  by_cases hc : 0 ≤ c
+  · simp [hc]
+    exact mul_le_mul_of_nonneg_left hhi (by exact_mod_cast hc)
+  · simp [hc]
+    have hc_nonpos : (c : ℝ) ≤ 0 := by exact_mod_cast le_of_not_ge hc
+    exact mul_le_mul_of_nonpos_left hlo hc_nonpos
+
+/-- Lower bound for the Abel transform from prefix envelopes. -/
+def abelBoundLowerRat (f ALo AHi : Nat → ℚ) (m n : Nat) : ℚ :=
+  coeffLowerRat (f (n - 1)) (ALo n) (AHi n) +
+    coeffLowerRat (-(f m)) (ALo m) (AHi m) +
+      ∑ i ∈ Finset.Ico m (n - 1),
+        coeffLowerRat (-(f (i + 1) - f i)) (ALo (i + 1)) (AHi (i + 1))
+
+/-- Upper bound for the Abel transform from prefix envelopes. -/
+def abelBoundUpperRat (f ALo AHi : Nat → ℚ) (m n : Nat) : ℚ :=
+  coeffUpperRat (f (n - 1)) (ALo n) (AHi n) +
+    coeffUpperRat (-(f m)) (ALo m) (AHi m) +
+      ∑ i ∈ Finset.Ico m (n - 1),
+        coeffUpperRat (-(f (i + 1) - f i)) (ALo (i + 1)) (AHi (i + 1))
+
+theorem abelBoundLowerRat_le_transform
+    (f ALo AHi : Nat → ℚ) (A : Nat → ℝ) (m n : Nat)
+    (hA : ∀ k, (ALo k : ℝ) ≤ A k ∧ A k ≤ (AHi k : ℝ)) :
+    (abelBoundLowerRat f ALo AHi m n : ℝ) ≤ abelTransformOfPrefix f A m n := by
+  unfold abelBoundLowerRat abelTransformOfPrefix
+  rw [Rat.cast_add, Rat.cast_add, Rat.cast_sum]
+  apply add_le_add
+  · apply add_le_add
+    · exact coeffLowerRat_le_mul (hA n).1 (hA n).2
+    · simpa using coeffLowerRat_le_mul (c := -(f m)) (hA m).1 (hA m).2
+  · rw [← Finset.sum_neg_distrib]
+    apply Finset.sum_le_sum
+    intro i hi
+    have hterm := coeffLowerRat_le_mul (c := -(f (i + 1) - f i))
+      (hA (i + 1)).1 (hA (i + 1)).2
+    convert hterm using 1 <;> simp [Nat.add_comm] <;> ring_nf
+
+theorem transform_le_abelBoundUpperRat
+    (f ALo AHi : Nat → ℚ) (A : Nat → ℝ) (m n : Nat)
+    (hA : ∀ k, (ALo k : ℝ) ≤ A k ∧ A k ≤ (AHi k : ℝ)) :
+    abelTransformOfPrefix f A m n ≤ (abelBoundUpperRat f ALo AHi m n : ℝ) := by
+  unfold abelBoundUpperRat abelTransformOfPrefix
+  rw [Rat.cast_add, Rat.cast_add, Rat.cast_sum]
+  apply add_le_add
+  · apply add_le_add
+    · exact mul_le_coeffUpperRat (hA n).1 (hA n).2
+    · simpa using mul_le_coeffUpperRat (c := -(f m)) (hA m).1 (hA m).2
+  · rw [← Finset.sum_neg_distrib]
+    apply Finset.sum_le_sum
+    intro i hi
+    have hterm := mul_le_coeffUpperRat (c := -(f (i + 1) - f i))
+      (hA (i + 1)).1 (hA (i + 1)).2
+    convert hterm using 1 <;> simp [Nat.add_comm] <;> ring_nf
+
+/-- Boolean interval checker for Abel bounds from prefix envelopes. -/
+def checkAbelBoundInterval (f ALo AHi : Nat → ℚ) (m n : Nat) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ abelBoundLowerRat f ALo AHi m n) &&
+    decide (abelBoundUpperRat f ALo AHi m n ≤ hi)
+
+/-- Golden theorem for bounded Abel certificates. -/
+theorem verify_abelBound_interval
+    (a : Nat → ℝ) (f ALo AHi : Nat → ℚ) {m n : Nat} (hmn : m < n)
+    (hA : ∀ k, (ALo k : ℝ) ≤ prefixSum a k ∧ prefixSum a k ≤ (AHi k : ℝ))
+    (lo hi : ℚ)
+    (hcheck : checkAbelBoundInterval f ALo AHi m n lo hi = true) :
+    (lo : ℝ) ≤ weightedSum a f m n ∧ weightedSum a f m n ≤ (hi : ℝ) := by
+  simp only [checkAbelBoundInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rw [weightedSum_eq_abelTransformOfPrefix hmn]
+  have hlo : (lo : ℝ) ≤ (abelBoundLowerRat f ALo AHi m n : ℝ) := by
+    exact_mod_cast hcheck.1
+  have hhi : (abelBoundUpperRat f ALo AHi m n : ℝ) ≤ (hi : ℝ) := by
+    exact_mod_cast hcheck.2
+  exact ⟨hlo.trans (abelBoundLowerRat_le_transform f ALo AHi (prefixSum a) m n hA),
+    (transform_le_abelBoundUpperRat f ALo AHi (prefixSum a) m n hA).trans hhi⟩
 
 end LeanCert.ANT

--- a/LeanCert/ANT/Abel.lean
+++ b/LeanCert/ANT/Abel.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT.Step
+import Mathlib.Algebra.BigOperators.Module
+
+/-!
+# Abel / partial-summation certificates
+
+The first layer is the exact finite Abel transform.  It is deliberately discrete:
+continuous Stieltjes-integral refinements can be built on top of this identity
+without changing finite certificate data.
+-/
+
+namespace LeanCert.ANT
+
+open scoped BigOperators
+
+/-- Prefix sum `∑ i < n, a i`. -/
+noncomputable def prefixSum (a : Nat → ℝ) (n : Nat) : ℝ :=
+  ∑ i ∈ Finset.range n, a i
+
+/-- Rational prefix sum `∑ i < n, a i`. -/
+def prefixSumRat (a : Nat → ℚ) (n : Nat) : ℚ :=
+  ∑ i ∈ Finset.range n, a i
+
+/-- Rational finite Abel transform on `[m, n)`. -/
+def abelTransformRat (a f : Nat → ℚ) (m n : Nat) : ℚ :=
+  f (n - 1) * prefixSumRat a n -
+    f m * prefixSumRat a m -
+      ∑ i ∈ Finset.Ico m (n - 1),
+        (f (i + 1) - f i) * prefixSumRat a (i + 1)
+
+/-- Direct rational weighted sum on `[m, n)`. -/
+def weightedSumRat (a f : Nat → ℚ) (m n : Nat) : ℚ :=
+  ∑ i ∈ Finset.Ico m n, f i * a i
+
+theorem prefixSumRat_cast (a : Nat → ℚ) (n : Nat) :
+    (prefixSumRat a n : ℝ) = prefixSum (fun i => (a i : ℝ)) n := by
+  unfold prefixSumRat prefixSum
+  rw [Rat.cast_sum]
+
+/-- Abel's finite summation-by-parts identity, in the rational evaluator form. -/
+theorem weightedSumRat_eq_abelTransformRat {a f : Nat → ℚ} {m n : Nat}
+    (hmn : m < n) :
+    (weightedSumRat a f m n : ℝ) = (abelTransformRat a f m n : ℝ) := by
+  unfold weightedSumRat abelTransformRat prefixSumRat
+  rw [Rat.cast_sum, Rat.cast_sub, Rat.cast_sub, Rat.cast_mul, Rat.cast_mul, Rat.cast_sum]
+  simp only [Rat.cast_mul]
+  have h := Finset.sum_Ico_by_parts (R := ℝ) (M := ℝ)
+    (fun i => (f i : ℝ)) (fun i => (a i : ℝ)) hmn
+  simpa [prefixSum, smul_eq_mul, mul_comm, mul_left_comm, mul_assoc] using h
+
+/-- Exact rational Abel interval checker. -/
+def checkAbelInterval (a f : Nat → ℚ) (m n : Nat) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ abelTransformRat a f m n) && decide (abelTransformRat a f m n ≤ hi)
+
+/-- Exact rational Abel upper checker. -/
+def checkAbelUpper (a f : Nat → ℚ) (m n : Nat) (hi : ℚ) : Bool :=
+  decide (abelTransformRat a f m n ≤ hi)
+
+/-- Exact rational Abel lower checker. -/
+def checkAbelLower (a f : Nat → ℚ) (m n : Nat) (lo : ℚ) : Bool :=
+  decide (lo ≤ abelTransformRat a f m n)
+
+/-- Golden theorem for exact finite Abel interval certificates. -/
+theorem verify_abel_interval (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (lo hi : ℚ)
+    (hcheck : checkAbelInterval a f m n lo hi = true) :
+    (lo : ℝ) ≤ (weightedSumRat a f m n : ℝ) ∧
+      (weightedSumRat a f m n : ℝ) ≤ (hi : ℝ) := by
+  simp only [checkAbelInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rw [weightedSumRat_eq_abelTransformRat hmn]
+  exact ⟨by exact_mod_cast hcheck.1, by exact_mod_cast hcheck.2⟩
+
+/-- Golden theorem for exact finite Abel upper certificates. -/
+theorem verify_abel_upper (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (hi : ℚ)
+    (hcheck : checkAbelUpper a f m n hi = true) :
+    (weightedSumRat a f m n : ℝ) ≤ (hi : ℝ) := by
+  simp only [checkAbelUpper, decide_eq_true_eq] at hcheck
+  rw [weightedSumRat_eq_abelTransformRat hmn]
+  exact_mod_cast hcheck
+
+/-- Golden theorem for exact finite Abel lower certificates. -/
+theorem verify_abel_lower (a f : Nat → ℚ) {m n : Nat} (hmn : m < n) (lo : ℚ)
+    (hcheck : checkAbelLower a f m n lo = true) :
+    (lo : ℝ) ≤ (weightedSumRat a f m n : ℝ) := by
+  simp only [checkAbelLower, decide_eq_true_eq] at hcheck
+  rw [weightedSumRat_eq_abelTransformRat hmn]
+  exact_mod_cast hcheck
+
+end LeanCert.ANT

--- a/LeanCert/ANT/Dirichlet.lean
+++ b/LeanCert/ANT/Dirichlet.lean
@@ -1,0 +1,293 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT.PrimeEuler
+import LeanCert.Engine.ChebyshevTheta
+
+/-!
+# Certified finite Dirichlet-series truncations
+
+This module certifies finite sums of the form
+
+`∑ n ∈ S, a n * w n`
+
+from rational interval enclosures for the coefficients `a n` and weights `w n`.
+The multiplication envelope is sign-aware, so the API works for signed
+coefficients such as Möbius-like data as well as nonnegative prime weights.
+-/
+
+namespace LeanCert.ANT
+
+open scoped BigOperators
+open LeanCert.Engine.ChebyshevTheta
+
+/-- Semantic finite Dirichlet-style weighted sum. -/
+noncomputable def finiteDirichletSum
+    (S : Finset Nat) (a w : Nat → ℝ) : ℝ :=
+  ∑ n ∈ S, a n * w n
+
+/-- Lower endpoint for multiplying a signed coefficient interval by a nonnegative weight interval. -/
+def intervalMulLowerRat (aLo _aHi wLo wHi : ℚ) : ℚ :=
+  if 0 ≤ aLo then aLo * wLo else aLo * wHi
+
+/-- Upper endpoint for multiplying a signed coefficient interval by a nonnegative weight interval. -/
+def intervalMulUpperRat (_aLo aHi wLo wHi : ℚ) : ℚ :=
+  if 0 ≤ aHi then aHi * wHi else aHi * wLo
+
+private theorem intervalMulLowerRat_le_mul {a w : ℝ} {aLo aHi wLo wHi : ℚ}
+    (ha : (aLo : ℝ) ≤ a ∧ a ≤ (aHi : ℝ))
+    (hw_nonneg : 0 ≤ wLo)
+    (hw : (wLo : ℝ) ≤ w ∧ w ≤ (wHi : ℝ)) :
+    (intervalMulLowerRat aLo aHi wLo wHi : ℝ) ≤ a * w := by
+  unfold intervalMulLowerRat
+  by_cases haLo_nonneg : 0 ≤ aLo
+  · simp [haLo_nonneg]
+    have hLo_nonneg : 0 ≤ (aLo : ℝ) := by exact_mod_cast haLo_nonneg
+    have hwLo_nonneg : 0 ≤ (wLo : ℝ) := by exact_mod_cast hw_nonneg
+    exact (mul_le_mul_of_nonneg_right ha.1 hwLo_nonneg).trans
+      (mul_le_mul_of_nonneg_left hw.1 (hLo_nonneg.trans ha.1))
+  · simp [haLo_nonneg]
+    have haLo_nonpos : (aLo : ℝ) ≤ 0 := by exact_mod_cast le_of_not_ge haLo_nonneg
+    have hw_nonneg_real : 0 ≤ w := (by exact_mod_cast hw_nonneg : (0 : ℝ) ≤ wLo).trans hw.1
+    exact (mul_le_mul_of_nonpos_left hw.2 haLo_nonpos).trans
+      (mul_le_mul_of_nonneg_right ha.1 hw_nonneg_real)
+
+private theorem mul_le_intervalMulUpperRat {a w : ℝ} {aLo aHi wLo wHi : ℚ}
+    (ha : (aLo : ℝ) ≤ a ∧ a ≤ (aHi : ℝ))
+    (hw_nonneg : 0 ≤ wLo)
+    (hw : (wLo : ℝ) ≤ w ∧ w ≤ (wHi : ℝ)) :
+    a * w ≤ (intervalMulUpperRat aLo aHi wLo wHi : ℝ) := by
+  unfold intervalMulUpperRat
+  by_cases haHi_nonneg : 0 ≤ aHi
+  · simp [haHi_nonneg]
+    have hHi_nonneg : 0 ≤ (aHi : ℝ) := by exact_mod_cast haHi_nonneg
+    have hw_nonneg_real : 0 ≤ w := (by exact_mod_cast hw_nonneg : (0 : ℝ) ≤ wLo).trans hw.1
+    exact (mul_le_mul_of_nonneg_right ha.2 hw_nonneg_real).trans
+      (mul_le_mul_of_nonneg_left hw.2 hHi_nonneg)
+  · simp [haHi_nonneg]
+    have haHi_nonpos : (aHi : ℝ) ≤ 0 := by exact_mod_cast le_of_not_ge haHi_nonneg
+    have hw_nonneg_real : 0 ≤ w := (by exact_mod_cast hw_nonneg : (0 : ℝ) ≤ wLo).trans hw.1
+    exact (mul_le_mul_of_nonneg_right ha.2 hw_nonneg_real).trans
+      (mul_le_mul_of_nonpos_left hw.1 haHi_nonpos)
+
+/-- Rational lower endpoint for a finite Dirichlet sum. -/
+def finiteDirichletSumLowerRat
+    (S : Finset Nat) (aLo aHi wLo wHi : Nat → ℚ) : ℚ :=
+  ∑ n ∈ S, intervalMulLowerRat (aLo n) (aHi n) (wLo n) (wHi n)
+
+/-- Rational upper endpoint for a finite Dirichlet sum. -/
+def finiteDirichletSumUpperRat
+    (S : Finset Nat) (aLo aHi wLo wHi : Nat → ℚ) : ℚ :=
+  ∑ n ∈ S, intervalMulUpperRat (aLo n) (aHi n) (wLo n) (wHi n)
+
+theorem finiteDirichletSumLowerRat_le
+    (S : Finset Nat) (a w : Nat → ℝ) (aLo aHi wLo wHi : Nat → ℚ)
+    (ha : ∀ n ∈ S, (aLo n : ℝ) ≤ a n ∧ a n ≤ (aHi n : ℝ))
+    (hw_nonneg : ∀ n ∈ S, 0 ≤ wLo n)
+    (hw : ∀ n ∈ S, (wLo n : ℝ) ≤ w n ∧ w n ≤ (wHi n : ℝ)) :
+    (finiteDirichletSumLowerRat S aLo aHi wLo wHi : ℝ) ≤ finiteDirichletSum S a w := by
+  unfold finiteDirichletSumLowerRat finiteDirichletSum
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro n hn
+  exact intervalMulLowerRat_le_mul (ha n hn) (hw_nonneg n hn) (hw n hn)
+
+theorem finiteDirichletSum_le_upperRat
+    (S : Finset Nat) (a w : Nat → ℝ) (aLo aHi wLo wHi : Nat → ℚ)
+    (ha : ∀ n ∈ S, (aLo n : ℝ) ≤ a n ∧ a n ≤ (aHi n : ℝ))
+    (hw_nonneg : ∀ n ∈ S, 0 ≤ wLo n)
+    (hw : ∀ n ∈ S, (wLo n : ℝ) ≤ w n ∧ w n ≤ (wHi n : ℝ)) :
+    finiteDirichletSum S a w ≤ (finiteDirichletSumUpperRat S aLo aHi wLo wHi : ℝ) := by
+  unfold finiteDirichletSumUpperRat finiteDirichletSum
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro n hn
+  exact mul_le_intervalMulUpperRat (ha n hn) (hw_nonneg n hn) (hw n hn)
+
+/-- Boolean interval checker for finite Dirichlet sums. -/
+def checkDirichletSumInterval
+    (S : Finset Nat) (aLo aHi wLo wHi : Nat → ℚ) (lo hi : ℚ) : Bool :=
+  LeanCert.Cert.checkRatInterval
+    (finiteDirichletSumLowerRat S aLo aHi wLo wHi)
+    (finiteDirichletSumUpperRat S aLo aHi wLo wHi) lo hi
+
+/-- Boolean lower checker for finite Dirichlet sums. -/
+def checkDirichletSumLower
+    (S : Finset Nat) (aLo aHi wLo wHi : Nat → ℚ) (lo : ℚ) : Bool :=
+  LeanCert.Cert.checkRatLower
+    (finiteDirichletSumLowerRat S aLo aHi wLo wHi) lo
+
+/-- Boolean upper checker for finite Dirichlet sums. -/
+def checkDirichletSumUpper
+    (S : Finset Nat) (aLo aHi wLo wHi : Nat → ℚ) (hi : ℚ) : Bool :=
+  LeanCert.Cert.checkRatUpper
+    (finiteDirichletSumUpperRat S aLo aHi wLo wHi) hi
+
+/-- Golden theorem for finite Dirichlet-sum interval certificates. -/
+theorem verify_dirichletSum_interval
+    (S : Finset Nat) (a w : Nat → ℝ) (aLo aHi wLo wHi : Nat → ℚ)
+    (ha : ∀ n ∈ S, (aLo n : ℝ) ≤ a n ∧ a n ≤ (aHi n : ℝ))
+    (hw_nonneg : ∀ n ∈ S, 0 ≤ wLo n)
+    (hw : ∀ n ∈ S, (wLo n : ℝ) ≤ w n ∧ w n ≤ (wHi n : ℝ))
+    (lo hi : ℚ)
+    (hcheck : checkDirichletSumInterval S aLo aHi wLo wHi lo hi = true) :
+    (lo : ℝ) ≤ finiteDirichletSum S a w ∧ finiteDirichletSum S a w ≤ (hi : ℝ) := by
+  exact LeanCert.Cert.verify_rat_interval
+    (finiteDirichletSumLowerRat_le S a w aLo aHi wLo wHi ha hw_nonneg hw)
+    (finiteDirichletSum_le_upperRat S a w aLo aHi wLo wHi ha hw_nonneg hw)
+    hcheck
+
+/-- Golden theorem for finite Dirichlet-sum lower certificates. -/
+theorem verify_dirichletSum_lower
+    (S : Finset Nat) (a w : Nat → ℝ) (aLo aHi wLo wHi : Nat → ℚ)
+    (ha : ∀ n ∈ S, (aLo n : ℝ) ≤ a n ∧ a n ≤ (aHi n : ℝ))
+    (hw_nonneg : ∀ n ∈ S, 0 ≤ wLo n)
+    (hw : ∀ n ∈ S, (wLo n : ℝ) ≤ w n ∧ w n ≤ (wHi n : ℝ))
+    (lo : ℚ)
+    (hcheck : checkDirichletSumLower S aLo aHi wLo wHi lo = true) :
+    (lo : ℝ) ≤ finiteDirichletSum S a w := by
+  exact LeanCert.Cert.verify_rat_lower
+    (finiteDirichletSumLowerRat_le S a w aLo aHi wLo wHi ha hw_nonneg hw)
+    hcheck
+
+/-- Golden theorem for finite Dirichlet-sum upper certificates. -/
+theorem verify_dirichletSum_upper
+    (S : Finset Nat) (a w : Nat → ℝ) (aLo aHi wLo wHi : Nat → ℚ)
+    (ha : ∀ n ∈ S, (aLo n : ℝ) ≤ a n ∧ a n ≤ (aHi n : ℝ))
+    (hw_nonneg : ∀ n ∈ S, 0 ≤ wLo n)
+    (hw : ∀ n ∈ S, (wLo n : ℝ) ≤ w n ∧ w n ≤ (wHi n : ℝ))
+    (hi : ℚ)
+    (hcheck : checkDirichletSumUpper S aLo aHi wLo wHi hi = true) :
+    finiteDirichletSum S a w ≤ (hi : ℝ) := by
+  exact LeanCert.Cert.verify_rat_upper
+    (finiteDirichletSum_le_upperRat S a w aLo aHi wLo wHi ha hw_nonneg hw)
+    hcheck
+
+/-! ### Common finite Dirichlet truncation presets -/
+
+/-- Natural numbers `1 ≤ n ≤ N`. -/
+def naturalsIcc (N : Nat) : Finset Nat :=
+  Finset.Icc 1 N
+
+/-- Harmonic truncation `∑_{1 ≤ n ≤ N} 1/n`. -/
+noncomputable def harmonicSum (N : Nat) : ℝ :=
+  finiteDirichletSum (naturalsIcc N) (fun _ => (1 : ℝ)) fun n => 1 / (n : ℝ)
+
+/-- Exact rational harmonic truncation. -/
+def harmonicSumRat (N : Nat) : ℚ :=
+  ∑ n ∈ naturalsIcc N, 1 / (n : ℚ)
+
+/-- Prime harmonic truncation `∑_{p ≤ N} 1/p`. -/
+noncomputable def primeHarmonicSum (N : Nat) : ℝ :=
+  finiteDirichletSum (primesLE N) (fun _ => (1 : ℝ)) fun p => 1 / (p : ℝ)
+
+/-- Exact rational prime harmonic truncation. -/
+def primeHarmonicSumRat (N : Nat) : ℚ :=
+  ∑ p ∈ primesLE N, 1 / (p : ℚ)
+
+/-- Prime logarithmic Dirichlet truncation `∑_{p ≤ N} log p / p`. -/
+noncomputable def logPrimeOverPrimeSum (N : Nat) : ℝ :=
+  finiteDirichletSum (primesLE N) (fun p => Real.log p) fun p => 1 / (p : ℝ)
+
+/-- Lower endpoint for `∑_{p ≤ N} log p / p`. -/
+def logPrimeOverPrimeLowerRat (N depth : Nat) : ℚ :=
+  ∑ p ∈ primesLE N, logPrimeLB p depth / (p : ℚ)
+
+/-- Upper endpoint for `∑_{p ≤ N} log p / p`. -/
+def logPrimeOverPrimeUpperRat (N depth : Nat) : ℚ :=
+  ∑ p ∈ primesLE N, logPrimeUB p depth / (p : ℚ)
+
+private theorem invNatRat_interval_of_pos {n : Nat} (hn : 0 < n) :
+    ((1 / (n : ℚ) : ℚ) : ℝ) ≤ 1 / (n : ℝ) ∧
+      1 / (n : ℝ) ≤ ((1 / (n : ℚ) : ℚ) : ℝ) := by
+  have hnq : (n : ℚ) ≠ 0 := by exact_mod_cast hn.ne'
+  norm_num [Rat.cast_div, hnq]
+
+theorem harmonicSum_eq_rat (N : Nat) :
+    harmonicSum N = (harmonicSumRat N : ℝ) := by
+  unfold harmonicSum harmonicSumRat finiteDirichletSum naturalsIcc
+  rw [Rat.cast_sum]
+  apply Finset.sum_congr rfl
+  intro n hn
+  have hn_pos : 0 < n := by
+    simp only [Finset.mem_Icc] at hn
+    exact hn.1
+  have hnq : (n : ℚ) ≠ 0 := by exact_mod_cast hn_pos.ne'
+  norm_num [Rat.cast_div, hnq]
+
+theorem primeHarmonicSum_eq_rat (N : Nat) :
+    primeHarmonicSum N = (primeHarmonicSumRat N : ℝ) := by
+  unfold primeHarmonicSum primeHarmonicSumRat finiteDirichletSum
+  rw [Rat.cast_sum]
+  apply Finset.sum_congr rfl
+  intro p hp
+  have hp' := hp
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
+  have hp_pos : 0 < p := hp'.2.pos
+  have hpq : (p : ℚ) ≠ 0 := by exact_mod_cast hp_pos.ne'
+  norm_num [Rat.cast_div, hpq]
+
+/-- Boolean interval checker for harmonic truncations. -/
+def checkHarmonicSumInterval (N : Nat) (lo hi : ℚ) : Bool :=
+  LeanCert.Cert.checkRatInterval (harmonicSumRat N) (harmonicSumRat N) lo hi
+
+/-- Boolean interval checker for prime harmonic truncations. -/
+def checkPrimeHarmonicSumInterval (N : Nat) (lo hi : ℚ) : Bool :=
+  LeanCert.Cert.checkRatInterval (primeHarmonicSumRat N) (primeHarmonicSumRat N) lo hi
+
+/-- Boolean interval checker for `∑_{p ≤ N} log p / p`. -/
+def checkLogPrimeOverPrimeSumInterval (N depth : Nat) (lo hi : ℚ) : Bool :=
+  LeanCert.Cert.checkRatInterval (logPrimeOverPrimeLowerRat N depth)
+    (logPrimeOverPrimeUpperRat N depth) lo hi
+
+theorem logPrimeOverPrimeLowerRat_le (N depth : Nat) :
+    (logPrimeOverPrimeLowerRat N depth : ℝ) ≤ logPrimeOverPrimeSum N := by
+  unfold logPrimeOverPrimeLowerRat logPrimeOverPrimeSum finiteDirichletSum
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro p hp
+  have hp' := hp
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
+  have hlog := logPrimeLB_le_log_prime p depth
+  have hpos : (0 : ℝ) ≤ 1 / (p : ℝ) := by positivity
+  simp [hp'.2] at hlog
+  have h := mul_le_mul_of_nonneg_right hlog hpos
+  have hpq : (p : ℚ) ≠ 0 := by exact_mod_cast hp'.2.pos.ne'
+  simpa [Rat.cast_div, hpq, mul_div_assoc] using h
+
+theorem logPrimeOverPrime_le_upperRat (N depth : Nat) :
+    logPrimeOverPrimeSum N ≤ (logPrimeOverPrimeUpperRat N depth : ℝ) := by
+  unfold logPrimeOverPrimeUpperRat logPrimeOverPrimeSum finiteDirichletSum
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro p hp
+  have hp' := hp
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
+  have hlog := log_prime_le_logPrimeUB p depth
+  have hpos : (0 : ℝ) ≤ 1 / (p : ℝ) := by positivity
+  simp [hp'.2] at hlog
+  have h := mul_le_mul_of_nonneg_right hlog hpos
+  have hpq : (p : ℚ) ≠ 0 := by exact_mod_cast hp'.2.pos.ne'
+  simpa [Rat.cast_div, hpq, mul_div_assoc] using h
+
+theorem verify_harmonicSum_interval (N : Nat) (lo hi : ℚ)
+    (hcheck : checkHarmonicSumInterval N lo hi = true) :
+    (lo : ℝ) ≤ harmonicSum N ∧ harmonicSum N ≤ (hi : ℝ) := by
+  rw [harmonicSum_eq_rat N]
+  exact LeanCert.Cert.verify_rat_interval le_rfl le_rfl hcheck
+
+theorem verify_primeHarmonicSum_interval (N : Nat) (lo hi : ℚ)
+    (hcheck : checkPrimeHarmonicSumInterval N lo hi = true) :
+    (lo : ℝ) ≤ primeHarmonicSum N ∧ primeHarmonicSum N ≤ (hi : ℝ) := by
+  rw [primeHarmonicSum_eq_rat N]
+  exact LeanCert.Cert.verify_rat_interval le_rfl le_rfl hcheck
+
+theorem verify_logPrimeOverPrimeSum_interval (N depth : Nat) (lo hi : ℚ)
+    (hcheck : checkLogPrimeOverPrimeSumInterval N depth lo hi = true) :
+    (lo : ℝ) ≤ logPrimeOverPrimeSum N ∧ logPrimeOverPrimeSum N ≤ (hi : ℝ) := by
+  exact LeanCert.Cert.verify_rat_interval (logPrimeOverPrimeLowerRat_le N depth)
+    (logPrimeOverPrime_le_upperRat N depth) hcheck
+
+end LeanCert.ANT

--- a/LeanCert/ANT/EulerProduct.lean
+++ b/LeanCert/ANT/EulerProduct.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT.Step
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Tactic
+
+/-!
+# Finite Euler-product and log-product certificates
+
+This module certifies finite products by rational factor envelopes and finite
+log-products by rational logarithm envelopes.
+-/
+
+namespace LeanCert.ANT
+
+open scoped BigOperators
+
+/-- Prime numbers up to `N`. -/
+def primesLE (N : Nat) : Finset Nat :=
+  (Finset.range (N + 1)).filter Nat.Prime
+
+/-- Rational lower endpoint of a finite product certificate. -/
+def productLowerRat (S : Finset Nat) (lo : Nat → ℚ) : ℚ :=
+  ∏ n ∈ S, lo n
+
+/-- Rational upper endpoint of a finite product certificate. -/
+def productUpperRat (S : Finset Nat) (hi : Nat → ℚ) : ℚ :=
+  ∏ n ∈ S, hi n
+
+/-- Semantic finite product. -/
+noncomputable def finiteProduct (S : Finset Nat) (g : Nat → ℝ) : ℝ :=
+  ∏ n ∈ S, g n
+
+/-- Lower product certificate from pointwise nonnegative factor envelopes. -/
+theorem productLowerRat_le_finiteProduct
+    (S : Finset Nat) (g : Nat → ℝ) (lo : Nat → ℚ)
+    (hlo_nonneg : ∀ n ∈ S, 0 ≤ lo n)
+    (hlo : ∀ n ∈ S, (lo n : ℝ) ≤ g n) :
+    (productLowerRat S lo : ℝ) ≤ finiteProduct S g := by
+  unfold productLowerRat finiteProduct
+  rw [Rat.cast_prod]
+  exact Finset.prod_le_prod (fun n hn => by exact_mod_cast hlo_nonneg n hn) hlo
+
+/-- Upper product certificate from pointwise nonnegative factor envelopes. -/
+theorem finiteProduct_le_productUpperRat
+    (S : Finset Nat) (g : Nat → ℝ) (lo hi : Nat → ℚ)
+    (hlo_nonneg : ∀ n ∈ S, 0 ≤ lo n)
+    (hlo : ∀ n ∈ S, (lo n : ℝ) ≤ g n)
+    (hhi : ∀ n ∈ S, g n ≤ (hi n : ℝ)) :
+    finiteProduct S g ≤ (productUpperRat S hi : ℝ) := by
+  unfold productUpperRat finiteProduct
+  rw [Rat.cast_prod]
+  exact Finset.prod_le_prod
+    (fun n hn => by
+      have hlo0 : (0 : ℝ) ≤ (lo n : ℝ) := by exact_mod_cast hlo_nonneg n hn
+      exact hlo0.trans (hlo n hn))
+    hhi
+
+/-- Boolean interval checker for finite product certificates. -/
+def checkEulerProductInterval (S : Finset Nat) (lo hi : Nat → ℚ)
+    (targetLo targetHi : ℚ) : Bool :=
+  decide (targetLo ≤ productLowerRat S lo) &&
+    decide (productUpperRat S hi ≤ targetHi)
+
+/-- Golden theorem for finite Euler-product interval certificates. -/
+theorem verify_eulerProduct_interval
+    (S : Finset Nat) (g : Nat → ℝ) (lo hi : Nat → ℚ)
+    (hlo_nonneg : ∀ n ∈ S, 0 ≤ lo n)
+    (hlo : ∀ n ∈ S, (lo n : ℝ) ≤ g n)
+    (hhi : ∀ n ∈ S, g n ≤ (hi n : ℝ))
+    (targetLo targetHi : ℚ)
+    (hcheck : checkEulerProductInterval S lo hi targetLo targetHi = true) :
+    (targetLo : ℝ) ≤ finiteProduct S g ∧ finiteProduct S g ≤ (targetHi : ℝ) := by
+  simp only [checkEulerProductInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  have htargetLo : (targetLo : ℝ) ≤ (productLowerRat S lo : ℝ) := by
+    exact_mod_cast hcheck.1
+  have htargetHi : (productUpperRat S hi : ℝ) ≤ (targetHi : ℝ) := by
+    exact_mod_cast hcheck.2
+  exact ⟨htargetLo.trans (productLowerRat_le_finiteProduct S g lo hlo_nonneg hlo),
+    (finiteProduct_le_productUpperRat S g lo hi hlo_nonneg hlo hhi).trans
+      htargetHi⟩
+
+/-- Semantic finite log-product, represented as a sum of logs. -/
+noncomputable def finiteLogProduct (S : Finset Nat) (g : Nat → ℝ) : ℝ :=
+  ∑ n ∈ S, Real.log (g n)
+
+/-- Rational lower endpoint of a finite log-product certificate. -/
+def logProductLowerRat (S : Finset Nat) (lo : Nat → ℚ) : ℚ :=
+  ∑ n ∈ S, lo n
+
+/-- Rational upper endpoint of a finite log-product certificate. -/
+def logProductUpperRat (S : Finset Nat) (hi : Nat → ℚ) : ℚ :=
+  ∑ n ∈ S, hi n
+
+/-- Lower log-product certificate from pointwise logarithm envelopes. -/
+theorem logProductLowerRat_le_finiteLogProduct
+    (S : Finset Nat) (g : Nat → ℝ) (lo : Nat → ℚ)
+    (hlo : ∀ n ∈ S, (lo n : ℝ) ≤ Real.log (g n)) :
+    (logProductLowerRat S lo : ℝ) ≤ finiteLogProduct S g := by
+  unfold logProductLowerRat finiteLogProduct
+  rw [Rat.cast_sum]
+  exact Finset.sum_le_sum hlo
+
+/-- Upper log-product certificate from pointwise logarithm envelopes. -/
+theorem finiteLogProduct_le_logProductUpperRat
+    (S : Finset Nat) (g : Nat → ℝ) (hi : Nat → ℚ)
+    (hhi : ∀ n ∈ S, Real.log (g n) ≤ (hi n : ℝ)) :
+    finiteLogProduct S g ≤ (logProductUpperRat S hi : ℝ) := by
+  unfold logProductUpperRat finiteLogProduct
+  rw [Rat.cast_sum]
+  exact Finset.sum_le_sum hhi
+
+/-- Boolean interval checker for finite log-product certificates. -/
+def checkLogProductInterval (S : Finset Nat) (lo hi : Nat → ℚ)
+    (targetLo targetHi : ℚ) : Bool :=
+  decide (targetLo ≤ logProductLowerRat S lo) &&
+    decide (logProductUpperRat S hi ≤ targetHi)
+
+/-- Golden theorem for finite log-product interval certificates. -/
+theorem verify_logProduct_interval
+    (S : Finset Nat) (g : Nat → ℝ) (lo hi : Nat → ℚ)
+    (hlo : ∀ n ∈ S, (lo n : ℝ) ≤ Real.log (g n))
+    (hhi : ∀ n ∈ S, Real.log (g n) ≤ (hi n : ℝ))
+    (targetLo targetHi : ℚ)
+    (hcheck : checkLogProductInterval S lo hi targetLo targetHi = true) :
+    (targetLo : ℝ) ≤ finiteLogProduct S g ∧
+      finiteLogProduct S g ≤ (targetHi : ℝ) := by
+  simp only [checkLogProductInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  have htargetLo : (targetLo : ℝ) ≤ (logProductLowerRat S lo : ℝ) := by
+    exact_mod_cast hcheck.1
+  have htargetHi : (logProductUpperRat S hi : ℝ) ≤ (targetHi : ℝ) := by
+    exact_mod_cast hcheck.2
+  exact ⟨htargetLo.trans (logProductLowerRat_le_finiteLogProduct S g lo hlo),
+    (finiteLogProduct_le_logProductUpperRat S g hi hhi).trans htargetHi⟩
+
+end LeanCert.ANT

--- a/LeanCert/ANT/EulerProduct.lean
+++ b/LeanCert/ANT/EulerProduct.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
 import LeanCert.ANT.Step
+import LeanCert.Cert.Interval
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Tactic
@@ -63,8 +64,8 @@ theorem finiteProduct_le_productUpperRat
 /-- Boolean interval checker for finite product certificates. -/
 def checkEulerProductInterval (S : Finset Nat) (lo hi : Nat → ℚ)
     (targetLo targetHi : ℚ) : Bool :=
-  decide (targetLo ≤ productLowerRat S lo) &&
-    decide (productUpperRat S hi ≤ targetHi)
+  LeanCert.Cert.checkRatInterval (productLowerRat S lo) (productUpperRat S hi)
+    targetLo targetHi
 
 /-- Golden theorem for finite Euler-product interval certificates. -/
 theorem verify_eulerProduct_interval
@@ -75,14 +76,10 @@ theorem verify_eulerProduct_interval
     (targetLo targetHi : ℚ)
     (hcheck : checkEulerProductInterval S lo hi targetLo targetHi = true) :
     (targetLo : ℝ) ≤ finiteProduct S g ∧ finiteProduct S g ≤ (targetHi : ℝ) := by
-  simp only [checkEulerProductInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
-  have htargetLo : (targetLo : ℝ) ≤ (productLowerRat S lo : ℝ) := by
-    exact_mod_cast hcheck.1
-  have htargetHi : (productUpperRat S hi : ℝ) ≤ (targetHi : ℝ) := by
-    exact_mod_cast hcheck.2
-  exact ⟨htargetLo.trans (productLowerRat_le_finiteProduct S g lo hlo_nonneg hlo),
-    (finiteProduct_le_productUpperRat S g lo hi hlo_nonneg hlo hhi).trans
-      htargetHi⟩
+  exact LeanCert.Cert.verify_rat_interval
+    (productLowerRat_le_finiteProduct S g lo hlo_nonneg hlo)
+    (finiteProduct_le_productUpperRat S g lo hi hlo_nonneg hlo hhi)
+    hcheck
 
 /-- Semantic finite log-product, represented as a sum of logs. -/
 noncomputable def finiteLogProduct (S : Finset Nat) (g : Nat → ℝ) : ℝ :=
@@ -117,8 +114,8 @@ theorem finiteLogProduct_le_logProductUpperRat
 /-- Boolean interval checker for finite log-product certificates. -/
 def checkLogProductInterval (S : Finset Nat) (lo hi : Nat → ℚ)
     (targetLo targetHi : ℚ) : Bool :=
-  decide (targetLo ≤ logProductLowerRat S lo) &&
-    decide (logProductUpperRat S hi ≤ targetHi)
+  LeanCert.Cert.checkRatInterval (logProductLowerRat S lo) (logProductUpperRat S hi)
+    targetLo targetHi
 
 /-- Golden theorem for finite log-product interval certificates. -/
 theorem verify_logProduct_interval
@@ -129,13 +126,10 @@ theorem verify_logProduct_interval
     (hcheck : checkLogProductInterval S lo hi targetLo targetHi = true) :
     (targetLo : ℝ) ≤ finiteLogProduct S g ∧
       finiteLogProduct S g ≤ (targetHi : ℝ) := by
-  simp only [checkLogProductInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
-  have htargetLo : (targetLo : ℝ) ≤ (logProductLowerRat S lo : ℝ) := by
-    exact_mod_cast hcheck.1
-  have htargetHi : (logProductUpperRat S hi : ℝ) ≤ (targetHi : ℝ) := by
-    exact_mod_cast hcheck.2
-  exact ⟨htargetLo.trans (logProductLowerRat_le_finiteLogProduct S g lo hlo),
-    (finiteLogProduct_le_logProductUpperRat S g hi hhi).trans htargetHi⟩
+  exact LeanCert.Cert.verify_rat_interval
+    (logProductLowerRat_le_finiteLogProduct S g lo hlo)
+    (finiteLogProduct_le_logProductUpperRat S g hi hhi)
+    hcheck
 
 /-- Positive finite products are exponentials of their finite log-products. -/
 theorem finiteProduct_eq_exp_finiteLogProduct
@@ -163,107 +157,22 @@ theorem verify_product_interval_of_log_interval
   rw [finiteProduct_eq_exp_finiteLogProduct S g hpos]
   exact ⟨Real.exp_le_exp.mpr hlog.1, Real.exp_le_exp.mpr hlog.2⟩
 
-/-! ### Prime Euler-product presets -/
+/-- Convert a certified log-product lower bound into an exponential product lower bound. -/
+theorem verify_product_lower_of_log_lower
+    (S : Finset Nat) (g : Nat → ℝ) (lo : ℚ)
+    (hpos : ∀ n ∈ S, 0 < g n)
+    (hlog : (lo : ℝ) ≤ finiteLogProduct S g) :
+    Real.exp (lo : ℝ) ≤ finiteProduct S g := by
+  rw [finiteProduct_eq_exp_finiteLogProduct S g hpos]
+  exact Real.exp_le_exp.mpr hlog
 
-/-- Rational factor `1 - 1/n`. -/
-def oneMinusInvRat (n : Nat) : ℚ :=
-  1 - 1 / (n : ℚ)
-
-/-- Rational factor `1 + 1/n`. -/
-def onePlusInvRat (n : Nat) : ℚ :=
-  1 + 1 / (n : ℚ)
-
-/-- Finite prime product `∏_{p ≤ N} (1 - 1/p)`. -/
-noncomputable def primeEulerOneMinusInv (N : Nat) : ℝ :=
-  finiteProduct (primesLE N) fun p => (1 : ℝ) - 1 / (p : ℝ)
-
-/-- Exact rational value of `∏_{p ≤ N} (1 - 1/p)`. -/
-def primeEulerOneMinusInvRat (N : Nat) : ℚ :=
-  productLowerRat (primesLE N) oneMinusInvRat
-
-/-- Finite prime product `∏_{p ≤ N} (1 + 1/p)`. -/
-noncomputable def primeEulerOnePlusInv (N : Nat) : ℝ :=
-  finiteProduct (primesLE N) fun p => (1 : ℝ) + 1 / (p : ℝ)
-
-/-- Exact rational value of `∏_{p ≤ N} (1 + 1/p)`. -/
-def primeEulerOnePlusInvRat (N : Nat) : ℚ :=
-  productLowerRat (primesLE N) onePlusInvRat
-
-private theorem prime_of_mem_primesLE {N p : Nat} (hp : p ∈ primesLE N) :
-    Nat.Prime p := by
-  have hp' := hp
-  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
-  exact hp'.2
-
-private theorem oneMinusInvRat_nonneg_of_prime {p : Nat} (hp : Nat.Prime p) :
-    0 ≤ oneMinusInvRat p := by
-  unfold oneMinusInvRat
-  have hp_pos : (0 : ℚ) < p := by exact_mod_cast hp.pos
-  have hp_one : (1 : ℚ) ≤ p := by exact_mod_cast hp.one_le
-  have hinv' : (1 : ℚ) / p ≤ (p : ℚ) / p :=
-    div_le_div_of_nonneg_right hp_one (le_of_lt hp_pos)
-  have hinv : (1 / (p : ℚ)) ≤ 1 := by
-    simpa [div_self (ne_of_gt hp_pos)] using hinv'
-  linarith
-
-private theorem oneMinusInvRat_cast_eq {p : Nat} (hp : Nat.Prime p) :
-    (oneMinusInvRat p : ℝ) = (1 : ℝ) - 1 / (p : ℝ) := by
-  unfold oneMinusInvRat
-  have hp_ne : (p : ℚ) ≠ 0 := by exact_mod_cast hp.pos.ne'
-  norm_num [Rat.cast_div, hp_ne]
-
-private theorem onePlusInvRat_cast_eq {p : Nat} (hp : Nat.Prime p) :
-    (onePlusInvRat p : ℝ) = (1 : ℝ) + 1 / (p : ℝ) := by
-  unfold onePlusInvRat
-  have hp_ne : (p : ℚ) ≠ 0 := by exact_mod_cast hp.pos.ne'
-  norm_num [Rat.cast_div, hp_ne]
-
-/-- Boolean interval checker for `∏_{p ≤ N} (1 - 1/p)`. -/
-def checkPrimeEulerOneMinusInvInterval (N : Nat) (lo hi : ℚ) : Bool :=
-  decide (lo ≤ primeEulerOneMinusInvRat N) &&
-    decide (primeEulerOneMinusInvRat N ≤ hi)
-
-/-- Boolean interval checker for `∏_{p ≤ N} (1 + 1/p)`. -/
-def checkPrimeEulerOnePlusInvInterval (N : Nat) (lo hi : ℚ) : Bool :=
-  decide (lo ≤ primeEulerOnePlusInvRat N) &&
-    decide (primeEulerOnePlusInvRat N ≤ hi)
-
-/-- Golden theorem for finite prime products `∏_{p ≤ N} (1 - 1/p)`. -/
-theorem verify_primeEulerOneMinusInv_interval (N : Nat) (lo hi : ℚ)
-    (hcheck : checkPrimeEulerOneMinusInvInterval N lo hi = true) :
-    (lo : ℝ) ≤ primeEulerOneMinusInv N ∧
-      primeEulerOneMinusInv N ≤ (hi : ℝ) := by
-  unfold checkPrimeEulerOneMinusInvInterval at hcheck
-  simp only [Bool.and_eq_true, decide_eq_true_eq] at hcheck
-  unfold primeEulerOneMinusInvRat at hcheck
-  have hprod := verify_eulerProduct_interval (primesLE N)
-    (fun p => (1 : ℝ) - 1 / (p : ℝ)) oneMinusInvRat oneMinusInvRat
-    (fun p hp => oneMinusInvRat_nonneg_of_prime (prime_of_mem_primesLE hp))
-    (fun p hp => by rw [oneMinusInvRat_cast_eq (prime_of_mem_primesLE hp)])
-    (fun p hp => by rw [oneMinusInvRat_cast_eq (prime_of_mem_primesLE hp)])
-    lo hi
-  have hgeneric :
-      checkEulerProductInterval (primesLE N) oneMinusInvRat oneMinusInvRat lo hi = true := by
-    simpa [checkEulerProductInterval, productUpperRat, productLowerRat] using hcheck
-  simpa [primeEulerOneMinusInv] using hprod hgeneric
-
-/-- Golden theorem for finite prime products `∏_{p ≤ N} (1 + 1/p)`. -/
-theorem verify_primeEulerOnePlusInv_interval (N : Nat) (lo hi : ℚ)
-    (hcheck : checkPrimeEulerOnePlusInvInterval N lo hi = true) :
-    (lo : ℝ) ≤ primeEulerOnePlusInv N ∧
-      primeEulerOnePlusInv N ≤ (hi : ℝ) := by
-  unfold checkPrimeEulerOnePlusInvInterval at hcheck
-  simp only [Bool.and_eq_true, decide_eq_true_eq] at hcheck
-  unfold primeEulerOnePlusInvRat at hcheck
-  have hprod := verify_eulerProduct_interval (primesLE N)
-    (fun p => (1 : ℝ) + 1 / (p : ℝ)) onePlusInvRat onePlusInvRat
-    (fun p hp => by unfold onePlusInvRat; positivity)
-    (fun p hp => by rw [onePlusInvRat_cast_eq (prime_of_mem_primesLE hp)])
-    (fun p hp => by rw [onePlusInvRat_cast_eq (prime_of_mem_primesLE hp)])
-    lo hi
-  have hgeneric :
-      checkEulerProductInterval (primesLE N) onePlusInvRat onePlusInvRat lo hi = true := by
-    simpa [checkEulerProductInterval, productUpperRat, productLowerRat] using hcheck
-  simpa [primeEulerOnePlusInv] using hprod hgeneric
+/-- Convert a certified log-product upper bound into an exponential product upper bound. -/
+theorem verify_product_upper_of_log_upper
+    (S : Finset Nat) (g : Nat → ℝ) (hi : ℚ)
+    (hpos : ∀ n ∈ S, 0 < g n)
+    (hlog : finiteLogProduct S g ≤ (hi : ℝ)) :
+    finiteProduct S g ≤ Real.exp (hi : ℝ) := by
+  rw [finiteProduct_eq_exp_finiteLogProduct S g hpos]
+  exact Real.exp_le_exp.mpr hlog
 
 end LeanCert.ANT

--- a/LeanCert/ANT/EulerProduct.lean
+++ b/LeanCert/ANT/EulerProduct.lean
@@ -137,4 +137,133 @@ theorem verify_logProduct_interval
   exact ⟨htargetLo.trans (logProductLowerRat_le_finiteLogProduct S g lo hlo),
     (finiteLogProduct_le_logProductUpperRat S g hi hhi).trans htargetHi⟩
 
+/-- Positive finite products are exponentials of their finite log-products. -/
+theorem finiteProduct_eq_exp_finiteLogProduct
+    (S : Finset Nat) (g : Nat → ℝ)
+    (hpos : ∀ n ∈ S, 0 < g n) :
+    finiteProduct S g = Real.exp (finiteLogProduct S g) := by
+  unfold finiteProduct finiteLogProduct
+  have hprod_pos : 0 < ∏ n ∈ S, g n := Finset.prod_pos hpos
+  have hlog : Real.log (∏ n ∈ S, g n) = ∑ n ∈ S, Real.log (g n) := by
+    rw [Real.log_prod]
+    intro n hn
+    exact ne_of_gt (hpos n hn)
+  calc
+    ∏ n ∈ S, g n = Real.exp (Real.log (∏ n ∈ S, g n)) := by
+      rw [Real.exp_log hprod_pos]
+    _ = Real.exp (∑ n ∈ S, Real.log (g n)) := by rw [hlog]
+
+/-- Convert a certified log-product interval into an exponential product interval. -/
+theorem verify_product_interval_of_log_interval
+    (S : Finset Nat) (g : Nat → ℝ) (lo hi : ℚ)
+    (hpos : ∀ n ∈ S, 0 < g n)
+    (hlog : (lo : ℝ) ≤ finiteLogProduct S g ∧ finiteLogProduct S g ≤ (hi : ℝ)) :
+    Real.exp (lo : ℝ) ≤ finiteProduct S g ∧
+      finiteProduct S g ≤ Real.exp (hi : ℝ) := by
+  rw [finiteProduct_eq_exp_finiteLogProduct S g hpos]
+  exact ⟨Real.exp_le_exp.mpr hlog.1, Real.exp_le_exp.mpr hlog.2⟩
+
+/-! ### Prime Euler-product presets -/
+
+/-- Rational factor `1 - 1/n`. -/
+def oneMinusInvRat (n : Nat) : ℚ :=
+  1 - 1 / (n : ℚ)
+
+/-- Rational factor `1 + 1/n`. -/
+def onePlusInvRat (n : Nat) : ℚ :=
+  1 + 1 / (n : ℚ)
+
+/-- Finite prime product `∏_{p ≤ N} (1 - 1/p)`. -/
+noncomputable def primeEulerOneMinusInv (N : Nat) : ℝ :=
+  finiteProduct (primesLE N) fun p => (1 : ℝ) - 1 / (p : ℝ)
+
+/-- Exact rational value of `∏_{p ≤ N} (1 - 1/p)`. -/
+def primeEulerOneMinusInvRat (N : Nat) : ℚ :=
+  productLowerRat (primesLE N) oneMinusInvRat
+
+/-- Finite prime product `∏_{p ≤ N} (1 + 1/p)`. -/
+noncomputable def primeEulerOnePlusInv (N : Nat) : ℝ :=
+  finiteProduct (primesLE N) fun p => (1 : ℝ) + 1 / (p : ℝ)
+
+/-- Exact rational value of `∏_{p ≤ N} (1 + 1/p)`. -/
+def primeEulerOnePlusInvRat (N : Nat) : ℚ :=
+  productLowerRat (primesLE N) onePlusInvRat
+
+private theorem prime_of_mem_primesLE {N p : Nat} (hp : p ∈ primesLE N) :
+    Nat.Prime p := by
+  have hp' := hp
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
+  exact hp'.2
+
+private theorem oneMinusInvRat_nonneg_of_prime {p : Nat} (hp : Nat.Prime p) :
+    0 ≤ oneMinusInvRat p := by
+  unfold oneMinusInvRat
+  have hp_pos : (0 : ℚ) < p := by exact_mod_cast hp.pos
+  have hp_one : (1 : ℚ) ≤ p := by exact_mod_cast hp.one_le
+  have hinv' : (1 : ℚ) / p ≤ (p : ℚ) / p :=
+    div_le_div_of_nonneg_right hp_one (le_of_lt hp_pos)
+  have hinv : (1 / (p : ℚ)) ≤ 1 := by
+    simpa [div_self (ne_of_gt hp_pos)] using hinv'
+  linarith
+
+private theorem oneMinusInvRat_cast_eq {p : Nat} (hp : Nat.Prime p) :
+    (oneMinusInvRat p : ℝ) = (1 : ℝ) - 1 / (p : ℝ) := by
+  unfold oneMinusInvRat
+  have hp_ne : (p : ℚ) ≠ 0 := by exact_mod_cast hp.pos.ne'
+  norm_num [Rat.cast_div, hp_ne]
+
+private theorem onePlusInvRat_cast_eq {p : Nat} (hp : Nat.Prime p) :
+    (onePlusInvRat p : ℝ) = (1 : ℝ) + 1 / (p : ℝ) := by
+  unfold onePlusInvRat
+  have hp_ne : (p : ℚ) ≠ 0 := by exact_mod_cast hp.pos.ne'
+  norm_num [Rat.cast_div, hp_ne]
+
+/-- Boolean interval checker for `∏_{p ≤ N} (1 - 1/p)`. -/
+def checkPrimeEulerOneMinusInvInterval (N : Nat) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ primeEulerOneMinusInvRat N) &&
+    decide (primeEulerOneMinusInvRat N ≤ hi)
+
+/-- Boolean interval checker for `∏_{p ≤ N} (1 + 1/p)`. -/
+def checkPrimeEulerOnePlusInvInterval (N : Nat) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ primeEulerOnePlusInvRat N) &&
+    decide (primeEulerOnePlusInvRat N ≤ hi)
+
+/-- Golden theorem for finite prime products `∏_{p ≤ N} (1 - 1/p)`. -/
+theorem verify_primeEulerOneMinusInv_interval (N : Nat) (lo hi : ℚ)
+    (hcheck : checkPrimeEulerOneMinusInvInterval N lo hi = true) :
+    (lo : ℝ) ≤ primeEulerOneMinusInv N ∧
+      primeEulerOneMinusInv N ≤ (hi : ℝ) := by
+  unfold checkPrimeEulerOneMinusInvInterval at hcheck
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  unfold primeEulerOneMinusInvRat at hcheck
+  have hprod := verify_eulerProduct_interval (primesLE N)
+    (fun p => (1 : ℝ) - 1 / (p : ℝ)) oneMinusInvRat oneMinusInvRat
+    (fun p hp => oneMinusInvRat_nonneg_of_prime (prime_of_mem_primesLE hp))
+    (fun p hp => by rw [oneMinusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    (fun p hp => by rw [oneMinusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    lo hi
+  have hgeneric :
+      checkEulerProductInterval (primesLE N) oneMinusInvRat oneMinusInvRat lo hi = true := by
+    simpa [checkEulerProductInterval, productUpperRat, productLowerRat] using hcheck
+  simpa [primeEulerOneMinusInv] using hprod hgeneric
+
+/-- Golden theorem for finite prime products `∏_{p ≤ N} (1 + 1/p)`. -/
+theorem verify_primeEulerOnePlusInv_interval (N : Nat) (lo hi : ℚ)
+    (hcheck : checkPrimeEulerOnePlusInvInterval N lo hi = true) :
+    (lo : ℝ) ≤ primeEulerOnePlusInv N ∧
+      primeEulerOnePlusInv N ≤ (hi : ℝ) := by
+  unfold checkPrimeEulerOnePlusInvInterval at hcheck
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  unfold primeEulerOnePlusInvRat at hcheck
+  have hprod := verify_eulerProduct_interval (primesLE N)
+    (fun p => (1 : ℝ) + 1 / (p : ℝ)) onePlusInvRat onePlusInvRat
+    (fun p hp => by unfold onePlusInvRat; positivity)
+    (fun p hp => by rw [onePlusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    (fun p hp => by rw [onePlusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    lo hi
+  have hgeneric :
+      checkEulerProductInterval (primesLE N) onePlusInvRat onePlusInvRat lo hi = true := by
+    simpa [checkEulerProductInterval, productUpperRat, productLowerRat] using hcheck
+  simpa [primeEulerOnePlusInv] using hprod hgeneric
+
 end LeanCert.ANT

--- a/LeanCert/ANT/Mertens.lean
+++ b/LeanCert/ANT/Mertens.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 LeanCert Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
+import LeanCert.ANT.Abel
 import LeanCert.ANT.EulerProduct
 import LeanCert.Engine.ChebyshevTheta
 
@@ -22,6 +23,26 @@ open LeanCert.Engine.ChebyshevTheta
 noncomputable def mertensLogSum (N : Nat) : ℝ :=
   ∑ p ∈ primesLE N, Real.log p / (p : ℝ)
 
+/-- Prime logarithm increment used by the Abel bridge. -/
+noncomputable def thetaIncrement (n : Nat) : ℝ :=
+  if n.Prime then Real.log n else 0
+
+/-- Rational weight `1/n`. -/
+def invNatRat (n : Nat) : ℚ :=
+  1 / (n : ℚ)
+
+/-- Lower prefix envelope for `thetaIncrement`. -/
+def thetaPrefixLowerRat (depth k : Nat) : ℚ :=
+  ∑ n ∈ Finset.range k, logPrimeLB n depth
+
+/-- Upper prefix envelope for `thetaIncrement`. -/
+def thetaPrefixUpperRat (depth k : Nat) : ℚ :=
+  ∑ n ∈ Finset.range k, logPrimeUB n depth
+
+/-- The Abel-side weighted sum for `∑_{p ≤ N} log p / p`. -/
+noncomputable def mertensAbelSum (N : Nat) : ℝ :=
+  weightedSum thetaIncrement invNatRat 2 (N + 1)
+
 /-- Rational lower endpoint for `∑_{p ≤ N} log p / p`. -/
 def mertensLogSumLowerRat (N depth : Nat) : ℚ :=
   ∑ p ∈ primesLE N, logPrimeLB p depth / (p : ℚ)
@@ -34,6 +55,43 @@ private theorem prime_pos_of_mem_primesLE {N p : Nat} (hp : p ∈ primesLE N) :
     0 < p := by
   simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp
   exact hp.2.pos
+
+theorem thetaPrefixLowerRat_le_prefix (depth k : Nat) :
+    (thetaPrefixLowerRat depth k : ℝ) ≤ prefixSum thetaIncrement k := by
+  unfold thetaPrefixLowerRat prefixSum thetaIncrement
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro n hn
+  exact logPrimeLB_le_log_prime n depth
+
+theorem prefix_le_thetaPrefixUpperRat (depth k : Nat) :
+    prefixSum thetaIncrement k ≤ (thetaPrefixUpperRat depth k : ℝ) := by
+  unfold thetaPrefixUpperRat prefixSum thetaIncrement
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro n hn
+  exact log_prime_le_logPrimeUB n depth
+
+theorem thetaPrefix_envelope (depth : Nat) :
+    ∀ k, (thetaPrefixLowerRat depth k : ℝ) ≤ prefixSum thetaIncrement k ∧
+      prefixSum thetaIncrement k ≤ (thetaPrefixUpperRat depth k : ℝ) := by
+  intro k
+  exact ⟨thetaPrefixLowerRat_le_prefix depth k, prefix_le_thetaPrefixUpperRat depth k⟩
+
+/-- Abel-bound checker for the Mertens log sum. -/
+def checkMertensAbelInterval (N depth : Nat) (lo hi : ℚ) : Bool :=
+  checkAbelBoundInterval invNatRat (thetaPrefixLowerRat depth)
+    (thetaPrefixUpperRat depth) 2 (N + 1) lo hi
+
+/-- Golden theorem for the Abel-certified Mertens weighted sum. -/
+theorem verify_mertensAbel_interval {N depth : Nat} (hN : 2 < N + 1) (lo hi : ℚ)
+    (hcheck : checkMertensAbelInterval N depth lo hi = true) :
+    (lo : ℝ) ≤ mertensAbelSum N ∧ mertensAbelSum N ≤ (hi : ℝ) := by
+  unfold checkMertensAbelInterval at hcheck
+  unfold mertensAbelSum
+  exact verify_abelBound_interval thetaIncrement invNatRat
+    (thetaPrefixLowerRat depth) (thetaPrefixUpperRat depth) hN
+    (thetaPrefix_envelope depth) lo hi hcheck
 
 /-- Lower correctness for the finite Mertens log-sum certificate. -/
 theorem mertensLogSumLowerRat_le (N depth : Nat) :

--- a/LeanCert/ANT/Mertens.lean
+++ b/LeanCert/ANT/Mertens.lean
@@ -131,19 +131,14 @@ theorem mertensLogSum_le_mertensLogSumUpperRat (N depth : Nat) :
 
 /-- Boolean interval checker for finite Mertens log sums. -/
 def checkMertensLogSumInterval (N depth : Nat) (lo hi : ℚ) : Bool :=
-  decide (lo ≤ mertensLogSumLowerRat N depth) &&
-    decide (mertensLogSumUpperRat N depth ≤ hi)
+  LeanCert.Cert.checkRatInterval (mertensLogSumLowerRat N depth)
+    (mertensLogSumUpperRat N depth) lo hi
 
 /-- Golden theorem for finite Mertens log-sum certificates. -/
 theorem verify_mertensLogSum_interval (N depth : Nat) (lo hi : ℚ)
     (hcheck : checkMertensLogSumInterval N depth lo hi = true) :
     (lo : ℝ) ≤ mertensLogSum N ∧ mertensLogSum N ≤ (hi : ℝ) := by
-  simp only [checkMertensLogSumInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
-  have hlo : (lo : ℝ) ≤ (mertensLogSumLowerRat N depth : ℝ) := by
-    exact_mod_cast hcheck.1
-  have hhi : (mertensLogSumUpperRat N depth : ℝ) ≤ (hi : ℝ) := by
-    exact_mod_cast hcheck.2
-  exact ⟨hlo.trans (mertensLogSumLowerRat_le N depth),
-    (mertensLogSum_le_mertensLogSumUpperRat N depth).trans hhi⟩
+  exact LeanCert.Cert.verify_rat_interval (mertensLogSumLowerRat_le N depth)
+    (mertensLogSum_le_mertensLogSumUpperRat N depth) hcheck
 
 end LeanCert.ANT

--- a/LeanCert/ANT/Mertens.lean
+++ b/LeanCert/ANT/Mertens.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT.EulerProduct
+import LeanCert.Engine.ChebyshevTheta
+
+/-!
+# Finite Mertens-style certificates
+
+This module connects the existing Chebyshev theta log enclosures to finite
+prime-weighted sums that occur in Mertens/Euler-product arguments.
+-/
+
+namespace LeanCert.ANT
+
+open scoped BigOperators
+open LeanCert.Engine.ChebyshevTheta
+
+/-- Semantic finite Mertens log sum `∑_{p ≤ N} log p / p`. -/
+noncomputable def mertensLogSum (N : Nat) : ℝ :=
+  ∑ p ∈ primesLE N, Real.log p / (p : ℝ)
+
+/-- Rational lower endpoint for `∑_{p ≤ N} log p / p`. -/
+def mertensLogSumLowerRat (N depth : Nat) : ℚ :=
+  ∑ p ∈ primesLE N, logPrimeLB p depth / (p : ℚ)
+
+/-- Rational upper endpoint for `∑_{p ≤ N} log p / p`. -/
+def mertensLogSumUpperRat (N depth : Nat) : ℚ :=
+  ∑ p ∈ primesLE N, logPrimeUB p depth / (p : ℚ)
+
+private theorem prime_pos_of_mem_primesLE {N p : Nat} (hp : p ∈ primesLE N) :
+    0 < p := by
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp
+  exact hp.2.pos
+
+/-- Lower correctness for the finite Mertens log-sum certificate. -/
+theorem mertensLogSumLowerRat_le (N depth : Nat) :
+    (mertensLogSumLowerRat N depth : ℝ) ≤ mertensLogSum N := by
+  unfold mertensLogSumLowerRat mertensLogSum
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro p hp
+  have hlog := logPrimeLB_le_log_prime p depth
+  have hpPrime : Nat.Prime p := by
+    have hp' := hp
+    simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
+    exact hp'.2
+  have hp_pos_real : (0 : ℝ) < p := by exact_mod_cast hpPrime.pos
+  have hp_pos_rat : (0 : ℚ) < p := by exact_mod_cast hpPrime.pos
+  simp [hpPrime] at hlog
+  have hdiv := div_le_div_of_nonneg_right hlog (le_of_lt hp_pos_real)
+  simpa [Rat.cast_div, ne_of_gt hp_pos_rat, div_eq_mul_inv] using hdiv
+
+/-- Upper correctness for the finite Mertens log-sum certificate. -/
+theorem mertensLogSum_le_mertensLogSumUpperRat (N depth : Nat) :
+    mertensLogSum N ≤ (mertensLogSumUpperRat N depth : ℝ) := by
+  unfold mertensLogSumUpperRat mertensLogSum
+  rw [Rat.cast_sum]
+  apply Finset.sum_le_sum
+  intro p hp
+  have hlog := log_prime_le_logPrimeUB p depth
+  have hpPrime : Nat.Prime p := by
+    have hp' := hp
+    simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
+    exact hp'.2
+  have hp_pos_real : (0 : ℝ) < p := by exact_mod_cast hpPrime.pos
+  have hp_pos_rat : (0 : ℚ) < p := by exact_mod_cast hpPrime.pos
+  simp [hpPrime] at hlog
+  have hdiv := div_le_div_of_nonneg_right hlog (le_of_lt hp_pos_real)
+  simpa [Rat.cast_div, ne_of_gt hp_pos_rat, div_eq_mul_inv] using hdiv
+
+/-- Boolean interval checker for finite Mertens log sums. -/
+def checkMertensLogSumInterval (N depth : Nat) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ mertensLogSumLowerRat N depth) &&
+    decide (mertensLogSumUpperRat N depth ≤ hi)
+
+/-- Golden theorem for finite Mertens log-sum certificates. -/
+theorem verify_mertensLogSum_interval (N depth : Nat) (lo hi : ℚ)
+    (hcheck : checkMertensLogSumInterval N depth lo hi = true) :
+    (lo : ℝ) ≤ mertensLogSum N ∧ mertensLogSum N ≤ (hi : ℝ) := by
+  simp only [checkMertensLogSumInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  have hlo : (lo : ℝ) ≤ (mertensLogSumLowerRat N depth : ℝ) := by
+    exact_mod_cast hcheck.1
+  have hhi : (mertensLogSumUpperRat N depth : ℝ) ≤ (hi : ℝ) := by
+    exact_mod_cast hcheck.2
+  exact ⟨hlo.trans (mertensLogSumLowerRat_le N depth),
+    (mertensLogSum_le_mertensLogSumUpperRat N depth).trans hhi⟩
+
+end LeanCert.ANT

--- a/LeanCert/ANT/PrimeEuler.lean
+++ b/LeanCert/ANT/PrimeEuler.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT.EulerProduct
+
+/-!
+# Prime Euler-product presets
+
+This file keeps arithmetic presets separate from the generic finite
+Euler-product certificate machinery.
+-/
+
+namespace LeanCert.ANT
+
+open scoped BigOperators
+
+/-- Rational factor `1 - 1/n`. -/
+def oneMinusInvRat (n : Nat) : ℚ :=
+  1 - 1 / (n : ℚ)
+
+/-- Rational factor `1 + 1/n`. -/
+def onePlusInvRat (n : Nat) : ℚ :=
+  1 + 1 / (n : ℚ)
+
+/-- Finite prime product `∏_{p ≤ N} (1 - 1/p)`. -/
+noncomputable def primeEulerOneMinusInv (N : Nat) : ℝ :=
+  finiteProduct (primesLE N) fun p => (1 : ℝ) - 1 / (p : ℝ)
+
+/-- Exact rational value of `∏_{p ≤ N} (1 - 1/p)`. -/
+def primeEulerOneMinusInvRat (N : Nat) : ℚ :=
+  productLowerRat (primesLE N) oneMinusInvRat
+
+/-- Finite prime product `∏_{p ≤ N} (1 + 1/p)`. -/
+noncomputable def primeEulerOnePlusInv (N : Nat) : ℝ :=
+  finiteProduct (primesLE N) fun p => (1 : ℝ) + 1 / (p : ℝ)
+
+/-- Exact rational value of `∏_{p ≤ N} (1 + 1/p)`. -/
+def primeEulerOnePlusInvRat (N : Nat) : ℚ :=
+  productLowerRat (primesLE N) onePlusInvRat
+
+private theorem prime_of_mem_primesLE {N p : Nat} (hp : p ∈ primesLE N) :
+    Nat.Prime p := by
+  have hp' := hp
+  simp only [primesLE, Finset.mem_filter, Finset.mem_range] at hp'
+  exact hp'.2
+
+private theorem oneMinusInvRat_nonneg_of_prime {p : Nat} (hp : Nat.Prime p) :
+    0 ≤ oneMinusInvRat p := by
+  unfold oneMinusInvRat
+  have hp_pos : (0 : ℚ) < p := by exact_mod_cast hp.pos
+  have hp_one : (1 : ℚ) ≤ p := by exact_mod_cast hp.one_le
+  have hinv' : (1 : ℚ) / p ≤ (p : ℚ) / p :=
+    div_le_div_of_nonneg_right hp_one (le_of_lt hp_pos)
+  have hinv : (1 / (p : ℚ)) ≤ 1 := by
+    simpa [div_self (ne_of_gt hp_pos)] using hinv'
+  linarith
+
+private theorem oneMinusInvRat_cast_eq {p : Nat} (hp : Nat.Prime p) :
+    (oneMinusInvRat p : ℝ) = (1 : ℝ) - 1 / (p : ℝ) := by
+  unfold oneMinusInvRat
+  have hp_ne : (p : ℚ) ≠ 0 := by exact_mod_cast hp.pos.ne'
+  norm_num [Rat.cast_div, hp_ne]
+
+private theorem onePlusInvRat_cast_eq {p : Nat} (hp : Nat.Prime p) :
+    (onePlusInvRat p : ℝ) = (1 : ℝ) + 1 / (p : ℝ) := by
+  unfold onePlusInvRat
+  have hp_ne : (p : ℚ) ≠ 0 := by exact_mod_cast hp.pos.ne'
+  norm_num [Rat.cast_div, hp_ne]
+
+/-- Boolean interval checker for `∏_{p ≤ N} (1 - 1/p)`. -/
+def checkPrimeEulerOneMinusInvInterval (N : Nat) (lo hi : ℚ) : Bool :=
+  LeanCert.Cert.checkRatInterval (primeEulerOneMinusInvRat N)
+    (primeEulerOneMinusInvRat N) lo hi
+
+/-- Boolean interval checker for `∏_{p ≤ N} (1 + 1/p)`. -/
+def checkPrimeEulerOnePlusInvInterval (N : Nat) (lo hi : ℚ) : Bool :=
+  LeanCert.Cert.checkRatInterval (primeEulerOnePlusInvRat N)
+    (primeEulerOnePlusInvRat N) lo hi
+
+/-- Golden theorem for finite prime products `∏_{p ≤ N} (1 - 1/p)`. -/
+theorem verify_primeEulerOneMinusInv_interval (N : Nat) (lo hi : ℚ)
+    (hcheck : checkPrimeEulerOneMinusInvInterval N lo hi = true) :
+    (lo : ℝ) ≤ primeEulerOneMinusInv N ∧
+      primeEulerOneMinusInv N ≤ (hi : ℝ) := by
+  unfold checkPrimeEulerOneMinusInvInterval primeEulerOneMinusInvRat at hcheck
+  have hprod := verify_eulerProduct_interval (primesLE N)
+    (fun p => (1 : ℝ) - 1 / (p : ℝ)) oneMinusInvRat oneMinusInvRat
+    (fun p hp => oneMinusInvRat_nonneg_of_prime (prime_of_mem_primesLE hp))
+    (fun p hp => by rw [oneMinusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    (fun p hp => by rw [oneMinusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    lo hi
+  have hgeneric :
+      checkEulerProductInterval (primesLE N) oneMinusInvRat oneMinusInvRat lo hi = true := by
+    simpa [checkEulerProductInterval, productUpperRat, productLowerRat] using hcheck
+  simpa [primeEulerOneMinusInv] using hprod hgeneric
+
+/-- Golden theorem for finite prime products `∏_{p ≤ N} (1 + 1/p)`. -/
+theorem verify_primeEulerOnePlusInv_interval (N : Nat) (lo hi : ℚ)
+    (hcheck : checkPrimeEulerOnePlusInvInterval N lo hi = true) :
+    (lo : ℝ) ≤ primeEulerOnePlusInv N ∧
+      primeEulerOnePlusInv N ≤ (hi : ℝ) := by
+  unfold checkPrimeEulerOnePlusInvInterval primeEulerOnePlusInvRat at hcheck
+  have hprod := verify_eulerProduct_interval (primesLE N)
+    (fun p => (1 : ℝ) + 1 / (p : ℝ)) onePlusInvRat onePlusInvRat
+    (fun p hp => by unfold onePlusInvRat; positivity)
+    (fun p hp => by rw [onePlusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    (fun p hp => by rw [onePlusInvRat_cast_eq (prime_of_mem_primesLE hp)])
+    lo hi
+  have hgeneric :
+      checkEulerProductInterval (primesLE N) onePlusInvRat onePlusInvRat lo hi = true := by
+    simpa [checkEulerProductInterval, productUpperRat, productLowerRat] using hcheck
+  simpa [primeEulerOnePlusInv] using hprod hgeneric
+
+end LeanCert.ANT

--- a/LeanCert/ANT/Step.lean
+++ b/LeanCert/ANT/Step.lean
@@ -6,6 +6,7 @@ Authors: LeanCert Contributors
 import Mathlib.Data.Rat.Cast.Order
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Tactic
+import LeanCert.Cert.Interval
 
 /-!
 # Finite step-sum certificates
@@ -60,40 +61,33 @@ theorem stepSum_le_stepUpperRat (S : StepFn) (m N : Nat) :
 
 /-- Boolean interval checker for a finite step sum. -/
 def checkStepSumInterval (S : StepFn) (m N : Nat) (lo hi : ℚ) : Bool :=
-  decide (lo ≤ stepLowerRat S m N) && decide (stepUpperRat S m N ≤ hi)
+  LeanCert.Cert.checkRatInterval (stepLowerRat S m N) (stepUpperRat S m N) lo hi
 
 /-- Boolean lower-bound checker for a finite step sum. -/
 def checkStepSumLower (S : StepFn) (m N : Nat) (lo : ℚ) : Bool :=
-  decide (lo ≤ stepLowerRat S m N)
+  LeanCert.Cert.checkRatLower (stepLowerRat S m N) lo
 
 /-- Boolean upper-bound checker for a finite step sum. -/
 def checkStepSumUpper (S : StepFn) (m N : Nat) (hi : ℚ) : Bool :=
-  decide (stepUpperRat S m N ≤ hi)
+  LeanCert.Cert.checkRatUpper (stepUpperRat S m N) hi
 
 /-- Golden theorem for finite step-sum interval certificates. -/
 theorem verify_stepSum_interval (S : StepFn) (m N : Nat) (lo hi : ℚ)
     (hcheck : checkStepSumInterval S m N lo hi = true) :
     (lo : ℝ) ≤ stepSum S m N ∧ stepSum S m N ≤ (hi : ℝ) := by
-  simp only [checkStepSumInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
-  have hlo : (lo : ℝ) ≤ (stepLowerRat S m N : ℝ) := by exact_mod_cast hcheck.1
-  have hhi : (stepUpperRat S m N : ℝ) ≤ (hi : ℝ) := by exact_mod_cast hcheck.2
-  exact ⟨hlo.trans (stepLowerRat_le_stepSum S m N),
-    (stepSum_le_stepUpperRat S m N).trans hhi⟩
+  exact LeanCert.Cert.verify_rat_interval (stepLowerRat_le_stepSum S m N)
+    (stepSum_le_stepUpperRat S m N) hcheck
 
 /-- Golden theorem for finite step-sum lower certificates. -/
 theorem verify_stepSum_lower (S : StepFn) (m N : Nat) (lo : ℚ)
     (hcheck : checkStepSumLower S m N lo = true) :
     (lo : ℝ) ≤ stepSum S m N := by
-  simp only [checkStepSumLower, decide_eq_true_eq] at hcheck
-  have hlo : (lo : ℝ) ≤ (stepLowerRat S m N : ℝ) := by exact_mod_cast hcheck
-  exact hlo.trans (stepLowerRat_le_stepSum S m N)
+  exact LeanCert.Cert.verify_rat_lower (stepLowerRat_le_stepSum S m N) hcheck
 
 /-- Golden theorem for finite step-sum upper certificates. -/
 theorem verify_stepSum_upper (S : StepFn) (m N : Nat) (hi : ℚ)
     (hcheck : checkStepSumUpper S m N hi = true) :
     stepSum S m N ≤ (hi : ℝ) := by
-  simp only [checkStepSumUpper, decide_eq_true_eq] at hcheck
-  have hhi : (stepUpperRat S m N : ℝ) ≤ (hi : ℝ) := by exact_mod_cast hcheck
-  exact (stepSum_le_stepUpperRat S m N).trans hhi
+  exact LeanCert.Cert.verify_rat_upper (stepSum_le_stepUpperRat S m N) hcheck
 
 end LeanCert.ANT

--- a/LeanCert/ANT/Step.lean
+++ b/LeanCert/ANT/Step.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Mathlib.Data.Rat.Cast.Order
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+/-!
+# Finite step-sum certificates
+
+This module provides the small reusable layer needed by arithmetic step
+functions: a semantic real-valued sequence together with computable rational
+lower and upper envelopes.
+-/
+
+namespace LeanCert.ANT
+
+open scoped BigOperators
+
+/-- A real-valued sequence with rational pointwise lower and upper envelopes. -/
+structure StepFn where
+  /-- Semantic value. -/
+  value : Nat → ℝ
+  /-- Computable rational lower envelope. -/
+  lowerRat : Nat → ℚ
+  /-- Computable rational upper envelope. -/
+  upperRat : Nat → ℚ
+  /-- Lower-envelope correctness. -/
+  lower_correct : ∀ n, (lowerRat n : ℝ) ≤ value n
+  /-- Upper-envelope correctness. -/
+  upper_correct : ∀ n, value n ≤ (upperRat n : ℝ)
+
+/-- Exact rational lower sum over a finite integer interval. -/
+def stepLowerRat (S : StepFn) (m N : Nat) : ℚ :=
+  ∑ n ∈ Finset.Icc m N, S.lowerRat n
+
+/-- Exact rational upper sum over a finite integer interval. -/
+def stepUpperRat (S : StepFn) (m N : Nat) : ℚ :=
+  ∑ n ∈ Finset.Icc m N, S.upperRat n
+
+/-- Semantic finite step sum. -/
+noncomputable def stepSum (S : StepFn) (m N : Nat) : ℝ :=
+  ∑ n ∈ Finset.Icc m N, S.value n
+
+/-- A finite step sum is bounded below by the sum of the lower envelopes. -/
+theorem stepLowerRat_le_stepSum (S : StepFn) (m N : Nat) :
+    (stepLowerRat S m N : ℝ) ≤ stepSum S m N := by
+  unfold stepLowerRat stepSum
+  rw [Rat.cast_sum]
+  exact Finset.sum_le_sum fun n _ => S.lower_correct n
+
+/-- A finite step sum is bounded above by the sum of the upper envelopes. -/
+theorem stepSum_le_stepUpperRat (S : StepFn) (m N : Nat) :
+    stepSum S m N ≤ (stepUpperRat S m N : ℝ) := by
+  unfold stepUpperRat stepSum
+  rw [Rat.cast_sum]
+  exact Finset.sum_le_sum fun n _ => S.upper_correct n
+
+/-- Boolean interval checker for a finite step sum. -/
+def checkStepSumInterval (S : StepFn) (m N : Nat) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ stepLowerRat S m N) && decide (stepUpperRat S m N ≤ hi)
+
+/-- Boolean lower-bound checker for a finite step sum. -/
+def checkStepSumLower (S : StepFn) (m N : Nat) (lo : ℚ) : Bool :=
+  decide (lo ≤ stepLowerRat S m N)
+
+/-- Boolean upper-bound checker for a finite step sum. -/
+def checkStepSumUpper (S : StepFn) (m N : Nat) (hi : ℚ) : Bool :=
+  decide (stepUpperRat S m N ≤ hi)
+
+/-- Golden theorem for finite step-sum interval certificates. -/
+theorem verify_stepSum_interval (S : StepFn) (m N : Nat) (lo hi : ℚ)
+    (hcheck : checkStepSumInterval S m N lo hi = true) :
+    (lo : ℝ) ≤ stepSum S m N ∧ stepSum S m N ≤ (hi : ℝ) := by
+  simp only [checkStepSumInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  have hlo : (lo : ℝ) ≤ (stepLowerRat S m N : ℝ) := by exact_mod_cast hcheck.1
+  have hhi : (stepUpperRat S m N : ℝ) ≤ (hi : ℝ) := by exact_mod_cast hcheck.2
+  exact ⟨hlo.trans (stepLowerRat_le_stepSum S m N),
+    (stepSum_le_stepUpperRat S m N).trans hhi⟩
+
+/-- Golden theorem for finite step-sum lower certificates. -/
+theorem verify_stepSum_lower (S : StepFn) (m N : Nat) (lo : ℚ)
+    (hcheck : checkStepSumLower S m N lo = true) :
+    (lo : ℝ) ≤ stepSum S m N := by
+  simp only [checkStepSumLower, decide_eq_true_eq] at hcheck
+  have hlo : (lo : ℝ) ≤ (stepLowerRat S m N : ℝ) := by exact_mod_cast hcheck
+  exact hlo.trans (stepLowerRat_le_stepSum S m N)
+
+/-- Golden theorem for finite step-sum upper certificates. -/
+theorem verify_stepSum_upper (S : StepFn) (m N : Nat) (hi : ℚ)
+    (hcheck : checkStepSumUpper S m N hi = true) :
+    stepSum S m N ≤ (hi : ℝ) := by
+  simp only [checkStepSumUpper, decide_eq_true_eq] at hcheck
+  have hhi : (stepUpperRat S m N : ℝ) ≤ (hi : ℝ) := by exact_mod_cast hcheck
+  exact (stepSum_le_stepUpperRat S m N).trans hhi
+
+end LeanCert.ANT

--- a/LeanCert/Cert/Interval.lean
+++ b/LeanCert/Cert/Interval.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Mathlib.Data.Rat.Cast.Order
+import Mathlib.Data.Real.Basic
+
+/-!
+# Small rational interval certificate combinators
+
+These helpers factor the common LeanCert pattern:
+
+* a computable rational lower endpoint;
+* a computable rational upper endpoint;
+* semantic lower/upper correctness proofs;
+* a boolean endpoint check.
+-/
+
+namespace LeanCert.Cert
+
+/-- Boolean checker for rational interval endpoints. -/
+def checkRatInterval (lower upper lo hi : ℚ) : Bool :=
+  decide (lo ≤ lower) && decide (upper ≤ hi)
+
+/-- Boolean checker for a rational upper endpoint. -/
+def checkRatUpper (upper hi : ℚ) : Bool :=
+  decide (upper ≤ hi)
+
+/-- Boolean checker for a rational lower endpoint. -/
+def checkRatLower (lower lo : ℚ) : Bool :=
+  decide (lo ≤ lower)
+
+/-- Generic Golden Theorem for rational interval endpoints. -/
+theorem verify_rat_interval {value : ℝ} {lower upper lo hi : ℚ}
+    (hlower : (lower : ℝ) ≤ value)
+    (hupper : value ≤ (upper : ℝ))
+    (hcheck : checkRatInterval lower upper lo hi = true) :
+    (lo : ℝ) ≤ value ∧ value ≤ (hi : ℝ) := by
+  simp only [checkRatInterval, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  have hlo : (lo : ℝ) ≤ (lower : ℝ) := by exact_mod_cast hcheck.1
+  have hhi : (upper : ℝ) ≤ (hi : ℝ) := by exact_mod_cast hcheck.2
+  exact ⟨hlo.trans hlower, hupper.trans hhi⟩
+
+/-- Generic Golden Theorem for rational upper endpoints. -/
+theorem verify_rat_upper {value : ℝ} {upper hi : ℚ}
+    (hupper : value ≤ (upper : ℝ))
+    (hcheck : checkRatUpper upper hi = true) :
+    value ≤ (hi : ℝ) := by
+  simp only [checkRatUpper, decide_eq_true_eq] at hcheck
+  have hhi : (upper : ℝ) ≤ (hi : ℝ) := by exact_mod_cast hcheck
+  exact hupper.trans hhi
+
+/-- Generic Golden Theorem for rational lower endpoints. -/
+theorem verify_rat_lower {value : ℝ} {lower lo : ℚ}
+    (hlower : (lower : ℝ) ≤ value)
+    (hcheck : checkRatLower lower lo = true) :
+    (lo : ℝ) ≤ value := by
+  simp only [checkRatLower, decide_eq_true_eq] at hcheck
+  have hlo : (lo : ℝ) ≤ (lower : ℝ) := by exact_mod_cast hcheck
+  exact hlo.trans hlower
+
+end LeanCert.Cert

--- a/LeanCert/Examples.lean
+++ b/LeanCert/Examples.lean
@@ -8,6 +8,7 @@ import LeanCert.Examples.EdgeCases
 import LeanCert.Examples.NeuralNet
 import LeanCert.Examples.Showcase
 import LeanCert.Examples.Chebyshev
+import LeanCert.Examples.ANT.Basic
 import LeanCert.Examples.QProduct.Basic
 import LeanCert.Examples.QProduct.PrimeLambda
 import LeanCert.Examples.ML.Distillation

--- a/LeanCert/Examples/ANT/Basic.lean
+++ b/LeanCert/Examples/ANT/Basic.lean
@@ -74,4 +74,40 @@ example :
   exact verify_mertensAbel_interval (N := 5) (depth := 20) (by norm_num) 0 3
     (by native_decide)
 
+example :
+    ((11 / 6 : ℚ) : ℝ) ≤ harmonicSum 3 ∧ harmonicSum 3 ≤ ((11 / 6 : ℚ) : ℝ) := by
+  exact verify_harmonicSum_interval 3 (11 / 6) (11 / 6) (by native_decide)
+
+example :
+    ((31 / 30 : ℚ) : ℝ) ≤ primeHarmonicSum 5 ∧
+      primeHarmonicSum 5 ≤ ((31 / 30 : ℚ) : ℝ) := by
+  exact verify_primeHarmonicSum_interval 5 (31 / 30) (31 / 30) (by native_decide)
+
+example :
+    ((0 : ℚ) : ℝ) ≤ logPrimeOverPrimeSum 5 ∧
+      logPrimeOverPrimeSum 5 ≤ ((3 : ℚ) : ℝ) := by
+  exact verify_logPrimeOverPrimeSum_interval 5 20 0 3 (by native_decide)
+
+def signedToyCoeff (n : Nat) : ℝ :=
+  if n = 1 then (-1 : ℝ) else 2
+
+example :
+    ((0 : ℚ) : ℝ) ≤ finiteDirichletSum ({1, 2} : Finset Nat) signedToyCoeff
+      (fun n => 1 / (n : ℝ)) ∧
+      finiteDirichletSum ({1, 2} : Finset Nat) signedToyCoeff
+        (fun n => 1 / (n : ℝ)) ≤ ((0 : ℚ) : ℝ) := by
+  apply verify_dirichletSum_interval
+      ({1, 2} : Finset Nat) signedToyCoeff (fun n => 1 / (n : ℝ))
+      (fun n => if n = 1 then (-1 : ℚ) else 2)
+      (fun n => if n = 1 then (-1 : ℚ) else 2)
+      (fun n => 1 / (n : ℚ))
+      (fun n => 1 / (n : ℚ))
+  · intro n hn
+    fin_cases hn <;> simp [signedToyCoeff]
+  · intro n hn
+    fin_cases hn <;> norm_num
+  · intro n hn
+    fin_cases hn <;> norm_num
+  · native_decide
+
 end LeanCert.Examples.ANT

--- a/LeanCert/Examples/ANT/Basic.lean
+++ b/LeanCert/Examples/ANT/Basic.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT
+
+/-!
+# ANT certificate examples
+-/
+
+namespace LeanCert.Examples.ANT
+
+open LeanCert.ANT
+
+def toyStep : StepFn where
+  value := fun n => (n : ℝ)
+  lowerRat := fun n => (n : ℚ)
+  upperRat := fun n => (n : ℚ)
+  lower_correct := by intro n; norm_num
+  upper_correct := by intro n; norm_num
+
+example : ((6 : ℚ) : ℝ) ≤ stepSum toyStep 1 3 ∧ stepSum toyStep 1 3 ≤ ((6 : ℚ) : ℝ) := by
+  exact verify_stepSum_interval toyStep 1 3 6 6 (by native_decide)
+
+def toyA (n : Nat) : ℚ := if n = 1 then 2 else if n = 2 then 3 else 0
+def toyF (n : Nat) : ℚ := n
+
+example :
+    ((8 : ℚ) : ℝ) ≤ (weightedSumRat toyA toyF 1 3 : ℝ) ∧
+      (weightedSumRat toyA toyF 1 3 : ℝ) ≤ ((8 : ℚ) : ℝ) := by
+  exact verify_abel_interval toyA toyF (by norm_num : 1 < 3) 8 8 (by native_decide)
+
+example :
+    ((1 / 4 : ℚ) : ℝ) ≤ finiteProduct ({2, 3} : Finset Nat) (fun n => (1 : ℝ) - 1 / n) ∧
+      finiteProduct ({2, 3} : Finset Nat) (fun n => (1 : ℝ) - 1 / n) ≤
+        ((1 / 3 : ℚ) : ℝ) := by
+  apply verify_eulerProduct_interval
+      ({2, 3} : Finset Nat) (fun n => (1 : ℝ) - 1 / n)
+      (fun n => if n = 2 then (1 / 2 : ℚ) else if n = 3 then (2 / 3 : ℚ) else 0)
+      (fun n => if n = 2 then (1 / 2 : ℚ) else if n = 3 then (2 / 3 : ℚ) else 1)
+  · intro n hn
+    fin_cases hn <;> norm_num
+  · intro n hn
+    fin_cases hn <;> norm_num
+  · intro n hn
+    fin_cases hn <;> norm_num
+  · native_decide
+
+example :
+    ((0 : ℚ) : ℝ) ≤ mertensLogSum 5 ∧ mertensLogSum 5 ≤ ((3 : ℚ) : ℝ) := by
+  exact verify_mertensLogSum_interval 5 20 0 3 (by native_decide)
+
+end LeanCert.Examples.ANT

--- a/LeanCert/Examples/ANT/Basic.lean
+++ b/LeanCert/Examples/ANT/Basic.lean
@@ -48,7 +48,30 @@ example :
   · native_decide
 
 example :
+    ((1 / 4 : ℚ) : ℝ) ≤ primeEulerOneMinusInv 5 ∧
+      primeEulerOneMinusInv 5 ≤ ((1 / 3 : ℚ) : ℝ) := by
+  exact verify_primeEulerOneMinusInv_interval 5 (1 / 4) (1 / 3) (by native_decide)
+
+example :
+    ((2 : ℚ) : ℝ) ≤ primeEulerOnePlusInv 5 ∧
+      primeEulerOnePlusInv 5 ≤ ((3 : ℚ) : ℝ) := by
+  exact verify_primeEulerOnePlusInv_interval 5 2 3 (by native_decide)
+
+example :
+    Real.exp ((0 : ℚ) : ℝ) ≤ finiteProduct ({2, 3} : Finset Nat) (fun _ => (1 : ℝ)) ∧
+      finiteProduct ({2, 3} : Finset Nat) (fun _ => (1 : ℝ)) ≤ Real.exp ((0 : ℚ) : ℝ) := by
+  apply verify_product_interval_of_log_interval
+  · intro n hn
+    norm_num
+  · simp [finiteLogProduct]
+
+example :
     ((0 : ℚ) : ℝ) ≤ mertensLogSum 5 ∧ mertensLogSum 5 ≤ ((3 : ℚ) : ℝ) := by
   exact verify_mertensLogSum_interval 5 20 0 3 (by native_decide)
+
+example :
+    ((0 : ℚ) : ℝ) ≤ mertensAbelSum 5 ∧ mertensAbelSum 5 ≤ ((3 : ℚ) : ℝ) := by
+  exact verify_mertensAbel_interval (N := 5) (depth := 20) (by norm_num) 0 3
+    (by native_decide)
 
 end LeanCert.Examples.ANT

--- a/docs/ant.md
+++ b/docs/ant.md
@@ -1,0 +1,100 @@
+# Analytic Number Theory Certificates
+
+`LeanCert.ANT` packages reusable finite certificate machinery for analytic
+number theory pipelines:
+
+```text
+finite arithmetic data
++ rational envelopes
++ Abel / partial-summation transforms
++ Euler-product or log-product certificates
+= semantic real-number bounds
+```
+
+## Import
+
+```lean
+import LeanCert.ANT
+```
+
+or through the main API:
+
+```lean
+import LeanCert
+```
+
+## Step Sums
+
+`StepFn` represents a semantic real-valued sequence with computable rational
+lower and upper envelopes.
+
+Golden Theorems:
+
+```lean
+verify_stepSum_interval
+verify_stepSum_lower
+verify_stepSum_upper
+```
+
+These turn checks over `stepLowerRat` and `stepUpperRat` into bounds for the
+semantic finite sum.
+
+## Abel Summation
+
+The discrete Abel transform is certified exactly:
+
+```lean
+weightedSumRat_eq_abelTransformRat
+```
+
+Public checkers:
+
+```lean
+checkAbelInterval
+checkAbelUpper
+checkAbelLower
+```
+
+Golden Theorems:
+
+```lean
+verify_abel_interval
+verify_abel_upper
+verify_abel_lower
+```
+
+This is the finite backbone for later continuous partial-summation and
+Stieltjes-integral APIs.
+
+## Euler And Log Products
+
+Finite products are certified from pointwise nonnegative rational factor
+envelopes:
+
+```lean
+verify_eulerProduct_interval
+```
+
+Finite log-products are certified from pointwise logarithm envelopes:
+
+```lean
+verify_logProduct_interval
+```
+
+## Mertens-Style Prime Sums
+
+The first Chebyshev integration point is:
+
+```lean
+mertensLogSum N = ∑ p ∈ primesLE N, Real.log p / p
+```
+
+The checker uses the existing Chebyshev theta log enclosures:
+
+```lean
+checkMertensLogSumInterval
+verify_mertensLogSum_interval
+```
+
+This gives the finite Chebyshev-to-Mertens bridge. Stronger global Mertens
+certificates should build on this with Abel bounds and tail envelopes.

--- a/docs/ant.md
+++ b/docs/ant.md
@@ -23,6 +23,20 @@ or through the main API:
 import LeanCert
 ```
 
+## Certificate Helpers
+
+The ANT layer uses the shared rational interval helpers:
+
+```lean
+LeanCert.Cert.checkRatInterval
+LeanCert.Cert.verify_rat_interval
+LeanCert.Cert.verify_rat_upper
+LeanCert.Cert.verify_rat_lower
+```
+
+Domain-specific modules provide the semantic lower/upper endpoint proofs; the
+generic helper handles the repeated boolean-check-to-real-interval boilerplate.
+
 ## Step Sums
 
 `StepFn` represents a semantic real-valued sequence with computable rational
@@ -99,6 +113,8 @@ Positive products can also be bounded through their logs:
 ```lean
 finiteProduct_eq_exp_finiteLogProduct
 verify_product_interval_of_log_interval
+verify_product_lower_of_log_lower
+verify_product_upper_of_log_upper
 ```
 
 Prime-product presets are included for the most common Mertens factors:
@@ -109,6 +125,9 @@ primeEulerOnePlusInv         -- ∏ p ≤ N, (1 + 1 / p)
 verify_primeEulerOneMinusInv_interval
 verify_primeEulerOnePlusInv_interval
 ```
+
+The generic product machinery lives in `LeanCert.ANT.EulerProduct`; these
+number-theoretic presets live in `LeanCert.ANT.PrimeEuler`.
 
 ## Mertens-Style Prime Sums
 

--- a/docs/ant.md
+++ b/docs/ant.md
@@ -129,6 +129,42 @@ verify_primeEulerOnePlusInv_interval
 The generic product machinery lives in `LeanCert.ANT.EulerProduct`; these
 number-theoretic presets live in `LeanCert.ANT.PrimeEuler`.
 
+## Dirichlet Truncations
+
+`LeanCert.ANT.Dirichlet` certifies finite Dirichlet-style weighted sums:
+
+```lean
+finiteDirichletSum S a w = ∑ n ∈ S, a n * w n
+```
+
+The generic checker accepts rational coefficient envelopes and nonnegative
+weight envelopes:
+
+```lean
+checkDirichletSumInterval
+verify_dirichletSum_interval
+verify_dirichletSum_lower
+verify_dirichletSum_upper
+```
+
+The multiplication envelope is sign-aware in the coefficient interval, which is
+the common analytic-number-theory case: signed arithmetic coefficients against
+positive weights such as `1 / n^s`.
+
+Included presets:
+
+```lean
+harmonicSum
+primeHarmonicSum
+logPrimeOverPrimeSum
+verify_harmonicSum_interval
+verify_primeHarmonicSum_interval
+verify_logPrimeOverPrimeSum_interval
+```
+
+More specialized sums, such as Möbius or von Mangoldt Dirichlet truncations, can
+use the generic theorem once coefficient envelopes are supplied.
+
 ## Mertens-Style Prime Sums
 
 The first Chebyshev integration point is:

--- a/docs/ant.md
+++ b/docs/ant.md
@@ -66,6 +66,19 @@ verify_abel_lower
 This is the finite backbone for later continuous partial-summation and
 Stieltjes-integral APIs.
 
+For propagation from certified prefix bounds, use the bounded Abel API:
+
+```lean
+abelBoundLowerRat
+abelBoundUpperRat
+checkAbelBoundInterval
+verify_abelBound_interval
+```
+
+This proves weighted-sum bounds from envelopes for the prefix function
+`A(k) = ∑ i < k, a i`. Coefficient signs are handled automatically when building
+the lower and upper Abel endpoints.
+
 ## Euler And Log Products
 
 Finite products are certified from pointwise nonnegative rational factor
@@ -79,6 +92,22 @@ Finite log-products are certified from pointwise logarithm envelopes:
 
 ```lean
 verify_logProduct_interval
+```
+
+Positive products can also be bounded through their logs:
+
+```lean
+finiteProduct_eq_exp_finiteLogProduct
+verify_product_interval_of_log_interval
+```
+
+Prime-product presets are included for the most common Mertens factors:
+
+```lean
+primeEulerOneMinusInv        -- ∏ p ≤ N, (1 - 1 / p)
+primeEulerOnePlusInv         -- ∏ p ≤ N, (1 + 1 / p)
+verify_primeEulerOneMinusInv_interval
+verify_primeEulerOnePlusInv_interval
 ```
 
 ## Mertens-Style Prime Sums
@@ -96,5 +125,13 @@ checkMertensLogSumInterval
 verify_mertensLogSum_interval
 ```
 
-This gives the finite Chebyshev-to-Mertens bridge. Stronger global Mertens
-certificates should build on this with Abel bounds and tail envelopes.
+There is also an Abel-routed version:
+
+```lean
+mertensAbelSum
+checkMertensAbelInterval
+verify_mertensAbel_interval
+```
+
+This is the finite Chebyshev-to-Abel-to-Mertens bridge. Stronger global Mertens
+certificates should build on this with tail envelopes.

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -25,6 +25,10 @@ Golden Theorems are defined across multiple files:
 - `Validity/Monotonicity.lean` - Monotonicity via automatic differentiation
 - `Engine/Chebyshev/Psi.lean` - Chebyshev `ψ` finite-range certificates
 - `Engine/Chebyshev/Theta.lean` - Chebyshev `θ` finite-range certificates
+- `ANT/Step.lean` - finite arithmetic step-sum certificates
+- `ANT/Abel.lean` - finite Abel / partial-summation certificates
+- `ANT/EulerProduct.lean` - finite Euler-product and log-product certificates
+- `ANT/Mertens.lean` - finite Mertens-style prime-sum certificates
 - `QProduct/Certificate.lean` - Exact finite q-product integrals
 - `QProduct/PrimeLambda.lean` - Prime-limit q-product certificates
 
@@ -205,6 +209,38 @@ theorem verify_all_theta_rel_error
     ∀ N : Nat, 0 < N → start ≤ N → N ≤ limit →
       |Chebyshev.theta (N : ℝ) - N| ≤ (bound : ℝ) * N
 ```
+
+### Analytic Number Theory Bridges
+
+The ANT layer exposes small bridge Golden Theorems that compose with the
+Chebyshev engines.
+
+| Goal | Theorem | Checker/Data |
+|------|---------|--------------|
+| Finite step-sum interval | `verify_stepSum_interval` | `checkStepSumInterval` |
+| Exact Abel interval | `verify_abel_interval` | `checkAbelInterval` |
+| Finite Euler product interval | `verify_eulerProduct_interval` | `checkEulerProductInterval` |
+| Finite log-product interval | `verify_logProduct_interval` | `checkLogProductInterval` |
+| Finite Mertens log-sum interval | `verify_mertensLogSum_interval` | `checkMertensLogSumInterval` |
+
+The central exact identity is:
+
+```lean
+theorem weightedSumRat_eq_abelTransformRat {a f : Nat → ℚ} {m n : Nat}
+    (hmn : m < n) :
+    (weightedSumRat a f m n : ℝ) = (abelTransformRat a f m n : ℝ)
+```
+
+The first Chebyshev-to-Mertens bridge is finite:
+
+```lean
+theorem verify_mertensLogSum_interval (N depth : Nat) (lo hi : ℚ)
+    (hcheck : checkMertensLogSumInterval N depth lo hi = true) :
+    (lo : ℝ) ≤ mertensLogSum N ∧ mertensLogSum N ≤ (hi : ℝ)
+```
+
+Here `mertensLogSum N` is `∑ p ≤ N, log p / p`, and the checker uses the
+existing Chebyshev theta logarithm envelopes.
 
 ### Monotonicity
 

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -25,9 +25,11 @@ Golden Theorems are defined across multiple files:
 - `Validity/Monotonicity.lean` - Monotonicity via automatic differentiation
 - `Engine/Chebyshev/Psi.lean` - Chebyshev `ψ` finite-range certificates
 - `Engine/Chebyshev/Theta.lean` - Chebyshev `θ` finite-range certificates
+- `Cert/Interval.lean` - shared rational interval Golden Theorem combinators
 - `ANT/Step.lean` - finite arithmetic step-sum certificates
 - `ANT/Abel.lean` - finite Abel / partial-summation certificates
 - `ANT/EulerProduct.lean` - finite Euler-product and log-product certificates
+- `ANT/PrimeEuler.lean` - prime Euler-product presets
 - `ANT/Mertens.lean` - finite Mertens-style prime-sum certificates
 - `QProduct/Certificate.lean` - Exact finite q-product integrals
 - `QProduct/PrimeLambda.lean` - Prime-limit q-product certificates
@@ -215,6 +217,16 @@ theorem verify_all_theta_rel_error
 The ANT layer exposes small bridge Golden Theorems that compose with the
 Chebyshev engines.
 
+The shared interval helper used by these APIs is:
+
+```lean
+theorem LeanCert.Cert.verify_rat_interval {value : ℝ} {lower upper lo hi : ℚ}
+    (hlower : (lower : ℝ) ≤ value)
+    (hupper : value ≤ (upper : ℝ))
+    (hcheck : checkRatInterval lower upper lo hi = true) :
+    (lo : ℝ) ≤ value ∧ value ≤ (hi : ℝ)
+```
+
 | Goal | Theorem | Checker/Data |
 |------|---------|--------------|
 | Finite step-sum interval | `verify_stepSum_interval` | `checkStepSumInterval` |
@@ -223,6 +235,8 @@ Chebyshev engines.
 | Finite Euler product interval | `verify_eulerProduct_interval` | `checkEulerProductInterval` |
 | Finite log-product interval | `verify_logProduct_interval` | `checkLogProductInterval` |
 | Log interval to product interval | `verify_product_interval_of_log_interval` | log interval proof |
+| Log lower to product lower | `verify_product_lower_of_log_lower` | log lower proof |
+| Log upper to product upper | `verify_product_upper_of_log_upper` | log upper proof |
 | Prime product `∏(1 - 1/p)` | `verify_primeEulerOneMinusInv_interval` | `checkPrimeEulerOneMinusInvInterval` |
 | Prime product `∏(1 + 1/p)` | `verify_primeEulerOnePlusInv_interval` | `checkPrimeEulerOnePlusInvInterval` |
 | Finite Mertens log-sum interval | `verify_mertensLogSum_interval` | `checkMertensLogSumInterval` |

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -219,9 +219,14 @@ Chebyshev engines.
 |------|---------|--------------|
 | Finite step-sum interval | `verify_stepSum_interval` | `checkStepSumInterval` |
 | Exact Abel interval | `verify_abel_interval` | `checkAbelInterval` |
+| Bounded Abel interval | `verify_abelBound_interval` | `checkAbelBoundInterval` |
 | Finite Euler product interval | `verify_eulerProduct_interval` | `checkEulerProductInterval` |
 | Finite log-product interval | `verify_logProduct_interval` | `checkLogProductInterval` |
+| Log interval to product interval | `verify_product_interval_of_log_interval` | log interval proof |
+| Prime product `∏(1 - 1/p)` | `verify_primeEulerOneMinusInv_interval` | `checkPrimeEulerOneMinusInvInterval` |
+| Prime product `∏(1 + 1/p)` | `verify_primeEulerOnePlusInv_interval` | `checkPrimeEulerOnePlusInvInterval` |
 | Finite Mertens log-sum interval | `verify_mertensLogSum_interval` | `checkMertensLogSumInterval` |
+| Abel-routed Mertens interval | `verify_mertensAbel_interval` | `checkMertensAbelInterval` |
 
 The central exact identity is:
 
@@ -241,6 +246,18 @@ theorem verify_mertensLogSum_interval (N depth : Nat) (lo hi : ℚ)
 
 Here `mertensLogSum N` is `∑ p ≤ N, log p / p`, and the checker uses the
 existing Chebyshev theta logarithm envelopes.
+
+The bounded Abel bridge has the reusable shape:
+
+```lean
+theorem verify_abelBound_interval
+    (a : Nat → ℝ) (f ALo AHi : Nat → ℚ) {m n : Nat} (hmn : m < n)
+    (hA : ∀ k, (ALo k : ℝ) ≤ prefixSum a k ∧
+      prefixSum a k ≤ (AHi k : ℝ))
+    (lo hi : ℚ)
+    (hcheck : checkAbelBoundInterval f ALo AHi m n lo hi = true) :
+    (lo : ℝ) ≤ weightedSum a f m n ∧ weightedSum a f m n ≤ (hi : ℝ)
+```
 
 ### Monotonicity
 

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -30,6 +30,7 @@ Golden Theorems are defined across multiple files:
 - `ANT/Abel.lean` - finite Abel / partial-summation certificates
 - `ANT/EulerProduct.lean` - finite Euler-product and log-product certificates
 - `ANT/PrimeEuler.lean` - prime Euler-product presets
+- `ANT/Dirichlet.lean` - finite Dirichlet-style truncation certificates
 - `ANT/Mertens.lean` - finite Mertens-style prime-sum certificates
 - `QProduct/Certificate.lean` - Exact finite q-product integrals
 - `QProduct/PrimeLambda.lean` - Prime-limit q-product certificates
@@ -239,6 +240,10 @@ theorem LeanCert.Cert.verify_rat_interval {value : ℝ} {lower upper lo hi : ℚ
 | Log upper to product upper | `verify_product_upper_of_log_upper` | log upper proof |
 | Prime product `∏(1 - 1/p)` | `verify_primeEulerOneMinusInv_interval` | `checkPrimeEulerOneMinusInvInterval` |
 | Prime product `∏(1 + 1/p)` | `verify_primeEulerOnePlusInv_interval` | `checkPrimeEulerOnePlusInvInterval` |
+| Finite Dirichlet sum interval | `verify_dirichletSum_interval` | `checkDirichletSumInterval` |
+| Harmonic truncation interval | `verify_harmonicSum_interval` | `checkHarmonicSumInterval` |
+| Prime harmonic truncation interval | `verify_primeHarmonicSum_interval` | `checkPrimeHarmonicSumInterval` |
+| Prime log-over-prime interval | `verify_logPrimeOverPrimeSum_interval` | `checkLogPrimeOverPrimeSumInterval` |
 | Finite Mertens log-sum interval | `verify_mertensLogSum_interval` | `checkMertensLogSumInterval` |
 | Abel-routed Mertens interval | `verify_mertensAbel_interval` | `checkMertensAbelInterval` |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ LeanCert is a Lean 4 library for certified numerical computation and proof-produ
 - Proof automation for inequalities and root claims
 - Global optimization and integration certificates
 - Chebyshev function certificates
+- Analytic-number-theory certificate bridges for Abel summation and Euler products
 - Exact q-product/product-integral certificates
 - Dyadic and rational backends for different performance/precision tradeoffs
 
@@ -47,6 +48,7 @@ lake update
 | [Choosing Tactics](choosing-tactics.md) | Pick the right tactic quickly |
 | [End-to-End Example](end-to-end-example.md) | Discovery to theorem workflow |
 | [Chebyshev Certificates](chebyshev.md) | Certified `ψ` and `θ` finite-range bounds |
+| [Analytic Number Theory Certificates](ant.md) | Step sums, Abel transforms, Euler products, and Mertens-style finite sums |
 | [QProduct Certificates](qproduct.md) | Exact product-integral and prime-limit certificates |
 
 ## Architecture


### PR DESCRIPTION
## Summary
  - add `LeanCert.ANT` certificate machinery for finite step sums, Abel transforms, Euler products, and Mertens-style prime sums
  - add bounded Abel certificates from prefix envelopes via `verify_abelBound_interval`
  - add finite log-to-product bridge and prime Euler-product presets for `∏ (1 - 1/p)` and `∏ (1 + 1/p)`
  - add Abel-routed Mertens log-sum certificates using existing Chebyshev theta log envelopes
  - document the new ANT API and Golden Theorems
- add finite Dirichlet-series truncation certificates for harmonic, prime harmonic, and log-prime-over-prime sums
