### PR TITLE
Feat/cached log witness sums

### DIFF
--- a/LeanCert/Engine/IntervalEvalDyadic.lean
+++ b/LeanCert/Engine/IntervalEvalDyadic.lean
@@ -180,6 +180,18 @@ def logIntervalDyadic (I : IntervalDyadic) (cfg : DyadicConfig) : IntervalDyadic
     -- for soundness (though in practice this shouldn't happen for valid inputs)
     ⟨Core.Dyadic.ofInt (-1000), Core.Dyadic.ofInt 1000, by simp [Dyadic.toRat_ofInt]⟩
 
+/-- Real power from a cached logarithm interval.
+
+    If `Real.log x ∈ logBase`, this computes an interval for
+    `x ^ (p : ℝ)` as `exp(p * log x)` without recomputing `log x`.
+    This is the hot-path primitive for cached finite sums with many terms of
+    the form `x ^ q_k`. -/
+def rpowFromCachedLogDyadic (logBase : IntervalDyadic) (p : ℚ)
+    (cfg : DyadicConfig) : IntervalDyadic :=
+  let pInterval := IntervalDyadic.ofIntervalRat (IntervalRat.singleton p) cfg.precision
+  let pLogBase := (IntervalDyadic.mul pInterval logBase).roundOut cfg.precision
+  expIntervalDyadic pLogBase cfg
+
 /-- Real power x^p for x > 0 and rational p, computed via exp(p * log(x)).
 
     For x ∈ [lo, hi] with lo > 0 and rational exponent p:
@@ -190,9 +202,27 @@ def logIntervalDyadic (I : IntervalDyadic) (cfg : DyadicConfig) : IntervalDyadic
 def rpowIntervalDyadic (base : IntervalDyadic) (p : ℚ) (cfg : DyadicConfig) : IntervalDyadic :=
   -- x^p = exp(p * log(x)) for x > 0
   let logBase := logIntervalDyadic base cfg
-  let pInterval := IntervalDyadic.ofIntervalRat (IntervalRat.singleton p) cfg.precision
-  let pLogBase := (IntervalDyadic.mul pInterval logBase).roundOut cfg.precision
-  expIntervalDyadic pLogBase cfg
+  rpowFromCachedLogDyadic logBase p cfg
+
+/-- Correctness of `rpowFromCachedLogDyadic`: a cached interval containing
+    `Real.log x` is enough to enclose `x ^ p`. -/
+theorem mem_rpowFromCachedLogDyadic {x : ℝ} {logBase : IntervalDyadic}
+    (hlog : Real.log x ∈ logBase) (hx_pos : 0 < x)
+    (p : ℚ) (cfg : DyadicConfig) (hprec : cfg.precision ≤ 0 := by norm_num) :
+    x ^ (p : ℝ) ∈ rpowFromCachedLogDyadic logBase p cfg := by
+  simp only [rpowFromCachedLogDyadic]
+  rw [Real.rpow_def_of_pos hx_pos, mul_comm]
+  have hp_mem : (p : ℝ) ∈
+      IntervalDyadic.ofIntervalRat (IntervalRat.singleton p) cfg.precision := by
+    apply IntervalDyadic.mem_ofIntervalRat
+    · exact IntervalRat.mem_singleton p
+    · exact hprec
+  have hmul := IntervalDyadic.mem_mul hp_mem hlog
+  have hmul_rounded := IntervalDyadic.roundOut_contains hmul cfg.precision
+  simp only [expIntervalDyadic]
+  have hrat := IntervalDyadic.mem_toIntervalRat.mp hmul_rounded
+  have hexp := IntervalRat.mem_expComputable hrat cfg.taylorDepth
+  exact IntervalDyadic.mem_ofIntervalRat hexp cfg.precision hprec
 
 /-- Correctness of rpowIntervalDyadic: if x ∈ base and base.lo > 0, then x^p ∈ result -/
 theorem mem_rpowIntervalDyadic {x : ℝ} {base : IntervalDyadic} (hx : x ∈ base)
@@ -200,31 +230,16 @@ theorem mem_rpowIntervalDyadic {x : ℝ} {base : IntervalDyadic} (hx : x ∈ bas
     (hprec : cfg.precision ≤ 0 := by norm_num) :
     x ^ (p : ℝ) ∈ rpowIntervalDyadic base p cfg := by
   simp only [rpowIntervalDyadic]
-  -- x^p = exp(p * log(x)) for x > 0
   have hx_pos : 0 < x := by
     have hlo := hx.1
     have hlo_pos : (0 : ℝ) < base.lo.toRat := by exact_mod_cast hpos
     linarith
-  rw [Real.rpow_def_of_pos hx_pos, mul_comm]  -- Use commutativity: log x * p = p * log x
-  -- log(x) ∈ logIntervalDyadic base cfg
   have hlog_mem : Real.log x ∈ logIntervalDyadic base cfg := by
     simp only [logIntervalDyadic, hpos, ↓reduceIte]
     have hrat := IntervalDyadic.mem_toIntervalRat.mp hx
     have hlog := IntervalRat.mem_logComputable hrat hpos cfg.taylorDepth
     exact IntervalDyadic.mem_ofIntervalRat hlog cfg.precision hprec
-  -- p ∈ pInterval (singleton)
-  have hp_mem : (p : ℝ) ∈ IntervalDyadic.ofIntervalRat (IntervalRat.singleton p) cfg.precision := by
-    apply IntervalDyadic.mem_ofIntervalRat
-    · exact IntervalRat.mem_singleton p
-    · exact hprec
-  -- p * log(x) ∈ mul result
-  have hmul := IntervalDyadic.mem_mul hp_mem hlog_mem
-  have hmul_rounded := IntervalDyadic.roundOut_contains hmul cfg.precision
-  -- exp(p * log(x)) ∈ expIntervalDyadic
-  simp only [expIntervalDyadic]
-  have hrat := IntervalDyadic.mem_toIntervalRat.mp hmul_rounded
-  have hexp := IntervalRat.mem_expComputable hrat cfg.taylorDepth
-  exact IntervalDyadic.mem_ofIntervalRat hexp cfg.precision hprec
+  exact mem_rpowFromCachedLogDyadic hlog_mem hx_pos p cfg hprec
 
 /-! ### Main Evaluator -/
 

--- a/LeanCert/Engine/ReflectiveSum.lean
+++ b/LeanCert/Engine/ReflectiveSum.lean
@@ -141,6 +141,17 @@ def bklnwTermFromLog (logX : IntervalDyadic) (k : Nat) (cfg : BKLNWSumConfig) : 
   let p : ℚ := (1 : ℚ) / k - 1 / 3
   rpowFromCachedLogDyadic logX p cfg.toDyadicConfig
 
+/-- Direct term interval for the specialized `f(exp b)` form.
+
+For `x = exp b`, the BKLNW term is
+`x^(1/k - 1/3) = exp (b * (1/k - 1/3))`, so this avoids both the
+outer `exp b` interval and per-term cached-log multiplication. -/
+def bklnwExpTermIntervalDyadic (b k : Nat) (cfg : BKLNWSumConfig := {}) :
+    IntervalDyadic :=
+  let q : ℚ := (b : ℚ) * ((1 : ℚ) / k - 1 / 3)
+  let qInterval := IntervalDyadic.ofIntervalRat (IntervalRat.singleton q) cfg.precision
+  expIntervalDyadic qInterval cfg.toDyadicConfig
+
 /-- Optimized accumulator that uses precomputed log(x) and batched rounding.
     - logX: precomputed log(x) interval
     - roundEvery: round the accumulator every N iterations (0 = every iteration) -/
@@ -194,6 +205,31 @@ def bklnwSumDyadicCached (x : IntervalDyadic) (limit : Nat) (cfg : BKLNWSumConfi
     IntervalDyadic :=
   let logX := logIntervalDyadic x cfg.toDyadicConfig
   bklnwSumAuxCached logX 3 limit zeroDyadic cfg
+
+/-- Cached-log sum for `f(exp b)` using the exact identity `log(exp b) = b`.
+
+This avoids computing an interval for `exp b` and then recomputing its logarithm.
+It is the preferred hot path for BKLNW table rows expressed as `f(exp b)`. -/
+def bklnwSumExpDyadicCachedLog (b : Nat) (limit : Nat) (cfg : BKLNWSumConfig := {}) :
+    IntervalDyadic :=
+  let logX := IntervalDyadic.singleton (Core.Dyadic.ofInt b)
+  bklnwSumAuxCached logX 3 limit zeroDyadic cfg
+
+/-- Direct accumulator for `f(exp b)` using terms `exp (b * (1/k - 1/3))`. -/
+def bklnwSumExpAuxDirect (b current limit : Nat)
+    (acc : IntervalDyadic) (cfg : BKLNWSumConfig) : IntervalDyadic :=
+  if h : current > limit then
+    acc
+  else
+    let term := bklnwExpTermIntervalDyadic b current cfg
+    let newAcc := (IntervalDyadic.add acc term).roundOut cfg.precision
+    bklnwSumExpAuxDirect b (current + 1) limit newAcc cfg
+  termination_by limit + 1 - current
+
+/-- Direct specialized sum for `f(exp b)`. -/
+def bklnwSumExpDyadicDirect (b : Nat) (limit : Nat) (cfg : BKLNWSumConfig := {}) :
+    IntervalDyadic :=
+  bklnwSumExpAuxDirect b 3 limit zeroDyadic cfg
 
 /-! ### Certificate Checkers -/
 
@@ -273,6 +309,30 @@ def checkBKLNWExpUpperBoundOpt (b : Nat) (limit : Nat) (target : ℚ)
 def checkBKLNWExpLowerBoundOpt (b : Nat) (limit : Nat) (target : ℚ)
     (cfg : BKLNWSumConfig := {}) (roundEvery : Nat := 8) : Bool :=
   let result := bklnwSumExpDyadicOpt b limit cfg roundEvery
+  result.lowerBoundedBy target
+
+/-- Check an upper bound for `f(exp b)` using the exact cached logarithm `b`. -/
+def checkBKLNWExpUpperBoundCachedLog (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  let result := bklnwSumExpDyadicCachedLog b limit cfg
+  result.upperBoundedBy target
+
+/-- Check a lower bound for `f(exp b)` using the exact cached logarithm `b`. -/
+def checkBKLNWExpLowerBoundCachedLog (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  let result := bklnwSumExpDyadicCachedLog b limit cfg
+  result.lowerBoundedBy target
+
+/-- Check an upper bound for `f(exp b)` using direct `exp (b * q_k)` terms. -/
+def checkBKLNWExpUpperBoundDirect (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  let result := bklnwSumExpDyadicDirect b limit cfg
+  result.upperBoundedBy target
+
+/-- Check a lower bound for `f(exp b)` using direct `exp (b * q_k)` terms. -/
+def checkBKLNWExpLowerBoundDirect (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  let result := bklnwSumExpDyadicDirect b limit cfg
   result.lowerBoundedBy target
 
 /-! ### Correctness Theorems -/
@@ -426,6 +486,20 @@ theorem mem_bklnwTermDyadic {x : ℝ} {I : IntervalDyadic} (hx : x ∈ I)
   rw [← hp]
   exact mem_rpowIntervalDyadic hx hpos p cfg.toDyadicConfig hprec
 
+/-- Correctness of the cached-log BKLNW term evaluator. -/
+theorem mem_bklnwTermFromLog {x : ℝ} {logX : IntervalDyadic}
+    (hlog : Real.log x ∈ logX) (hx_pos : 0 < x)
+    (k : Nat) (_hk : k ≥ 3) (cfg : BKLNWSumConfig)
+    (hprec : cfg.precision ≤ 0 := by norm_num) :
+    x ^ ((1 : ℝ) / k - 1 / 3) ∈ bklnwTermFromLog logX k cfg := by
+  simp only [bklnwTermFromLog]
+  let p : ℚ := (1 : ℚ) / k - 1 / 3
+  have hp : (p : ℝ) = (1 : ℝ) / k - 1 / 3 := by
+    simp only [p, Rat.cast_sub, Rat.cast_div, Rat.cast_one, Rat.cast_natCast]
+    norm_num
+  rw [← hp]
+  exact mem_rpowFromCachedLogDyadic hlog hx_pos p cfg.toDyadicConfig hprec
+
 /-- `bklnwSumAux` is definitionally equal to `witnessSumAux` with `bklnwEvalTerm`. -/
 theorem bklnwSumAux_eq_witnessSumAux (I : IntervalDyadic) (current limit : Nat)
     (acc : IntervalDyadic) (cfg : BKLNWSumConfig) :
@@ -455,6 +529,38 @@ theorem mem_bklnwSumDyadic {x : ℝ} {I : IntervalDyadic} (hx : x ∈ I)
     (bklnwEvalTerm I cfg) 3 limit cfg.toDyadicConfig
   intro k hk1 _hk2
   exact mem_bklnwTermDyadic hx hpos k (by omega) cfg hprec
+
+/-- `bklnwSumAuxCached` is a witness sum over the cached-log term evaluator. -/
+theorem bklnwSumAuxCached_eq_witnessSumAux (logX : IntervalDyadic)
+    (current limit : Nat) (acc : IntervalDyadic) (cfg : BKLNWSumConfig) :
+    bklnwSumAuxCached logX current limit acc cfg =
+      witnessSumAux (fun k _cfg => bklnwTermFromLog logX k cfg)
+        current limit acc cfg.toDyadicConfig := by
+  generalize hm : limit + 1 - current = m
+  induction m using Nat.strongRecOn generalizing current acc with
+  | ind m ih =>
+      unfold bklnwSumAuxCached witnessSumAux
+      by_cases hcur : current > limit
+      · simp [hcur]
+      · simp only [hcur, ↓reduceDIte, ↓reduceIte, BKLNWSumConfig.toDyadicConfig]
+        have hm' : limit + 1 - (current + 1) < m := by omega
+        exact ih (limit + 1 - (current + 1)) hm' (current + 1)
+          ((IntervalDyadic.add acc (bklnwTermFromLog logX current cfg)).roundOut cfg.precision)
+          rfl
+
+/-- Cached-log sum correctness from a proof that `logX` contains `Real.log x`. -/
+theorem mem_bklnwSumAuxCached {x : ℝ} {logX : IntervalDyadic}
+    (hlog : Real.log x ∈ logX) (hx_pos : 0 < x)
+    (limit : Nat) (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num) :
+    bklnwF x limit ∈ bklnwSumAuxCached logX 3 limit zeroDyadic cfg := by
+  unfold bklnwF
+  rw [bklnwSumAuxCached_eq_witnessSumAux]
+  apply mem_witnessSumDyadic
+    (fun k => x ^ ((1 : ℝ) / k - 1 / 3))
+    (fun k _cfg => bklnwTermFromLog logX k cfg) 3 limit cfg.toDyadicConfig
+  intro k hk1 _hk2
+  exact mem_bklnwTermFromLog hlog hx_pos k (by omega) cfg hprec
 
 /-- Technical lemma: roundDown of a sufficiently large positive rational stays positive.
 
@@ -576,6 +682,131 @@ theorem mem_expB_of_nat (b : Nat) (cfg : BKLNWSumConfig)
   simp only
   have hb := mem_bInterval_nat b cfg.precision hprec
   exact mem_expIntervalDyadic hb cfg.toDyadicConfig hprec
+
+/-- `log(exp b) = b` lies in the exact dyadic singleton used by the fast
+`f(exp b)` cached-log checker. -/
+theorem mem_log_exp_nat_cached (b : Nat) :
+    Real.log (Real.exp (b : ℝ)) ∈
+      IntervalDyadic.singleton (Core.Dyadic.ofInt b) := by
+  rw [Real.log_exp]
+  simp only [IntervalDyadic.singleton, IntervalDyadic.mem_def, Core.Dyadic.toRat_ofInt]
+  constructor <;> norm_num
+
+/-- Correctness of the exact-log cached evaluator for `f(exp b)`. -/
+theorem mem_bklnwSumExpDyadicCachedLog (b : Nat) (limit : Nat)
+    (cfg : BKLNWSumConfig := {}) (hprec : cfg.precision ≤ 0 := by norm_num) :
+    bklnwF (Real.exp (b : ℝ)) limit ∈ bklnwSumExpDyadicCachedLog b limit cfg := by
+  unfold bklnwSumExpDyadicCachedLog
+  exact mem_bklnwSumAuxCached (mem_log_exp_nat_cached b) (Real.exp_pos _)
+    limit cfg hprec
+
+/-- Upper-bound bridge for the exact-log cached `f(exp b)` checker. -/
+theorem checkBKLNWExpUpperBoundCachedLog_correct (b : Nat) (limit : Nat)
+    (target : ℚ) (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWExpUpperBoundCachedLog b limit target cfg = true) :
+    bklnwF (Real.exp (b : ℝ)) limit ≤ target := by
+  have hmem := mem_bklnwSumExpDyadicCachedLog b limit cfg hprec
+  have hhi := IntervalDyadic.le_hi_of_mem hmem
+  simp only [checkBKLNWExpUpperBoundCachedLog] at h_check
+  have hbound := IntervalDyadic.upperBoundedBy_spec h_check
+  exact le_trans hhi hbound
+
+/-- Lower-bound bridge for the exact-log cached `f(exp b)` checker. -/
+theorem checkBKLNWExpLowerBoundCachedLog_correct (b : Nat) (limit : Nat)
+    (target : ℚ) (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWExpLowerBoundCachedLog b limit target cfg = true) :
+    target ≤ bklnwF (Real.exp (b : ℝ)) limit := by
+  have hmem := mem_bklnwSumExpDyadicCachedLog b limit cfg hprec
+  have hlo := IntervalDyadic.lo_le_of_mem hmem
+  simp only [checkBKLNWExpLowerBoundCachedLog] at h_check
+  have hbound := IntervalDyadic.lowerBoundedBy_spec h_check
+  exact le_trans hbound hlo
+
+/-- Correctness of the direct specialized term for `f(exp b)`. -/
+theorem mem_bklnwExpTermIntervalDyadic (b k : Nat) (cfg : BKLNWSumConfig)
+    (hprec : cfg.precision ≤ 0 := by norm_num) :
+    (Real.exp (b : ℝ)) ^ ((1 : ℝ) / k - 1 / 3) ∈
+      bklnwExpTermIntervalDyadic b k cfg := by
+  let q : ℚ := (b : ℚ) * ((1 : ℚ) / k - 1 / 3)
+  have hq_mem : (q : ℝ) ∈
+      IntervalDyadic.ofIntervalRat (IntervalRat.singleton q) cfg.precision := by
+    apply IntervalDyadic.mem_ofIntervalRat
+    · exact IntervalRat.mem_singleton q
+    · exact hprec
+  have hq_mem_rat : (q : ℝ) ∈
+      (IntervalDyadic.ofIntervalRat (IntervalRat.singleton q) cfg.precision).toIntervalRat :=
+    IntervalDyadic.mem_toIntervalRat.mp hq_mem
+  have hexp_rat : Real.exp (q : ℝ) ∈
+      IntervalRat.expComputable
+        ((IntervalDyadic.ofIntervalRat (IntervalRat.singleton q) cfg.precision).toIntervalRat)
+        cfg.taylorDepth := IntervalRat.mem_expComputable hq_mem_rat cfg.taylorDepth
+  have hexp_dyad : Real.exp (q : ℝ) ∈
+      expIntervalDyadic (IntervalDyadic.ofIntervalRat (IntervalRat.singleton q) cfg.precision)
+        cfg.toDyadicConfig := by
+    simp [expIntervalDyadic]
+    exact IntervalDyadic.mem_ofIntervalRat hexp_rat cfg.precision hprec
+  have hq_cast : (q : ℝ) = (b : ℝ) * ((1 : ℝ) / k - 1 / 3) := by
+    simp only [q, Rat.cast_mul, Rat.cast_sub, Rat.cast_div, Rat.cast_one, Rat.cast_natCast]
+    norm_num
+  rw [Real.rpow_def_of_pos (Real.exp_pos (b : ℝ)), Real.log_exp]
+  rw [← hq_cast]
+  simpa [bklnwExpTermIntervalDyadic, q] using hexp_dyad
+
+/-- Direct `f(exp b)` accumulator is a witness-sum accumulator. -/
+theorem bklnwSumExpAuxDirect_eq_witnessSumAux (b current limit : Nat)
+    (acc : IntervalDyadic) (cfg : BKLNWSumConfig) :
+    bklnwSumExpAuxDirect b current limit acc cfg =
+      witnessSumAux (fun k _cfg => bklnwExpTermIntervalDyadic b k cfg)
+        current limit acc cfg.toDyadicConfig := by
+  generalize hm : limit + 1 - current = m
+  induction m using Nat.strongRecOn generalizing current acc with
+  | ind m ih =>
+      unfold bklnwSumExpAuxDirect witnessSumAux
+      by_cases hcur : current > limit
+      · simp [hcur]
+      · simp only [hcur, ↓reduceDIte, ↓reduceIte, BKLNWSumConfig.toDyadicConfig]
+        have hm' : limit + 1 - (current + 1) < m := by omega
+        exact ih (limit + 1 - (current + 1)) hm' (current + 1)
+          ((IntervalDyadic.add acc (bklnwExpTermIntervalDyadic b current cfg)).roundOut cfg.precision)
+          rfl
+
+/-- Correctness of the direct specialized sum for `f(exp b)`. -/
+theorem mem_bklnwSumExpDyadicDirect (b : Nat) (limit : Nat)
+    (cfg : BKLNWSumConfig := {}) (hprec : cfg.precision ≤ 0 := by norm_num) :
+    bklnwF (Real.exp (b : ℝ)) limit ∈ bklnwSumExpDyadicDirect b limit cfg := by
+  unfold bklnwF bklnwSumExpDyadicDirect
+  rw [bklnwSumExpAuxDirect_eq_witnessSumAux]
+  apply mem_witnessSumDyadic
+    (fun k => (Real.exp (b : ℝ)) ^ ((1 : ℝ) / k - 1 / 3))
+    (fun k _cfg => bklnwExpTermIntervalDyadic b k cfg) 3 limit cfg.toDyadicConfig
+  intro k _hk1 _hk2
+  exact mem_bklnwExpTermIntervalDyadic b k cfg hprec
+
+/-- Upper-bound bridge for the direct specialized `f(exp b)` checker. -/
+theorem checkBKLNWExpUpperBoundDirect_correct (b : Nat) (limit : Nat)
+    (target : ℚ) (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWExpUpperBoundDirect b limit target cfg = true) :
+    bklnwF (Real.exp (b : ℝ)) limit ≤ target := by
+  have hmem := mem_bklnwSumExpDyadicDirect b limit cfg hprec
+  have hhi := IntervalDyadic.le_hi_of_mem hmem
+  simp only [checkBKLNWExpUpperBoundDirect] at h_check
+  have hbound := IntervalDyadic.upperBoundedBy_spec h_check
+  exact le_trans hhi hbound
+
+/-- Lower-bound bridge for the direct specialized `f(exp b)` checker. -/
+theorem checkBKLNWExpLowerBoundDirect_correct (b : Nat) (limit : Nat)
+    (target : ℚ) (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWExpLowerBoundDirect b limit target cfg = true) :
+    target ≤ bklnwF (Real.exp (b : ℝ)) limit := by
+  have hmem := mem_bklnwSumExpDyadicDirect b limit cfg hprec
+  have hlo := IntervalDyadic.lo_le_of_mem hmem
+  simp only [checkBKLNWExpLowerBoundDirect] at h_check
+  have hbound := IntervalDyadic.lowerBoundedBy_spec h_check
+  exact le_trans hbound hlo
 
 /-- Check if expComputable produces a positive lower bound.
     This is decidable and can be verified by native_decide. -/
@@ -795,6 +1026,54 @@ def checkBKLNWAlphaExpBoundsCached (b : Nat) (limit : Nat) (targetLo targetHi : 
   let result := bklnwAlphaSumExpDyadicCached b limit cfg
   result.lowerBoundedBy targetLo && result.upperBoundedBy targetHi
 
+/-- Compute `(1+α) * f(exp b)` using the exact cached logarithm `b`. -/
+def bklnwAlphaSumExpDyadicCachedLog (b : Nat) (limit : Nat)
+    (cfg : BKLNWSumConfig := {}) : IntervalDyadic :=
+  let result := bklnwSumExpDyadicCachedLog b limit cfg
+  let one_plus_alpha := IntervalDyadic.ofIntervalRat
+    (IntervalRat.singleton (1 + bklnwAlpha)) cfg.precision
+  (IntervalDyadic.mul one_plus_alpha result).roundOut cfg.precision
+
+/-- Exact-log alpha upper-bound checker. -/
+def checkBKLNWAlphaExpUpperBoundCachedLog (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  (bklnwAlphaSumExpDyadicCachedLog b limit cfg).upperBoundedBy target
+
+/-- Exact-log alpha lower-bound checker. -/
+def checkBKLNWAlphaExpLowerBoundCachedLog (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  (bklnwAlphaSumExpDyadicCachedLog b limit cfg).lowerBoundedBy target
+
+/-- Exact-log alpha two-sided checker. -/
+def checkBKLNWAlphaExpBoundsCachedLog (b : Nat) (limit : Nat) (targetLo targetHi : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  let result := bklnwAlphaSumExpDyadicCachedLog b limit cfg
+  result.lowerBoundedBy targetLo && result.upperBoundedBy targetHi
+
+/-- Compute `(1+α) * f(exp b)` using direct `exp (b * q_k)` terms. -/
+def bklnwAlphaSumExpDyadicDirect (b : Nat) (limit : Nat)
+    (cfg : BKLNWSumConfig := {}) : IntervalDyadic :=
+  let result := bklnwSumExpDyadicDirect b limit cfg
+  let one_plus_alpha := IntervalDyadic.ofIntervalRat
+    (IntervalRat.singleton (1 + bklnwAlpha)) cfg.precision
+  (IntervalDyadic.mul one_plus_alpha result).roundOut cfg.precision
+
+/-- Direct alpha upper-bound checker. -/
+def checkBKLNWAlphaExpUpperBoundDirect (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  (bklnwAlphaSumExpDyadicDirect b limit cfg).upperBoundedBy target
+
+/-- Direct alpha lower-bound checker. -/
+def checkBKLNWAlphaExpLowerBoundDirect (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  (bklnwAlphaSumExpDyadicDirect b limit cfg).lowerBoundedBy target
+
+/-- Direct alpha two-sided checker. -/
+def checkBKLNWAlphaExpBoundsDirect (b : Nat) (limit : Nat) (targetLo targetHi : ℚ)
+    (cfg : BKLNWSumConfig := {}) : Bool :=
+  let result := bklnwAlphaSumExpDyadicDirect b limit cfg
+  result.lowerBoundedBy targetLo && result.upperBoundedBy targetHi
+
 /-- Cached-log alpha interval equals the standard alpha interval. -/
 theorem bklnwAlphaSumExpDyadicCached_eq (b : Nat) (limit : Nat) (cfg : BKLNWSumConfig := {}) :
     bklnwAlphaSumExpDyadicCached b limit cfg = bklnwAlphaSumExpDyadic b limit cfg := by
@@ -853,16 +1132,10 @@ For large `b`, most terms are negligible. These checkers compute a short head
 sum reflectively and bound the tail symbolically by
 `(limit - headLimit) * term(headLimit + 1)`. -/
 
-/-- Dyadic interval for the closed-form tail term `exp(b * (1/k - 1/3))`. -/
-private def expTermIntervalDyadic (b k : Nat) (cfg : BKLNWSumConfig := {}) : IntervalDyadic :=
-  let q : ℚ := (b : ℚ) * ((1 : ℚ) / k - 1 / 3)
-  let qInterval := IntervalDyadic.ofIntervalRat (IntervalRat.singleton q) cfg.precision
-  expIntervalDyadic qInterval cfg.toDyadicConfig
-
-/-- Correctness of `expTermIntervalDyadic`. -/
+/-- Correctness of the direct dyadic tail-term interval for `bklnwExpTerm`. -/
 private theorem mem_expTermIntervalDyadic (b k : Nat) (cfg : BKLNWSumConfig)
     (hprec : cfg.precision ≤ 0 := by norm_num) :
-    bklnwExpTerm b k ∈ expTermIntervalDyadic b k cfg := by
+    bklnwExpTerm b k ∈ bklnwExpTermIntervalDyadic b k cfg := by
   let q : ℚ := (b : ℚ) * ((1 : ℚ) / k - 1 / 3)
   have hq_mem : (q : ℝ) ∈
       IntervalDyadic.ofIntervalRat (IntervalRat.singleton q) cfg.precision := by
@@ -881,14 +1154,14 @@ private theorem mem_expTermIntervalDyadic (b k : Nat) (cfg : BKLNWSumConfig)
         cfg.toDyadicConfig := by
     simp [expIntervalDyadic]
     exact IntervalDyadic.mem_ofIntervalRat hexp_rat cfg.precision hprec
-  simpa [expTermIntervalDyadic, bklnwExpTerm, q]
+  simpa [bklnwExpTermIntervalDyadic, bklnwExpTerm, q]
     using hexp_dyad
 
 /-- Symbolic upper checker: α-scaled head interval + symbolic tail majorant. -/
 def checkBKLNWAlphaExpUpperBoundHeadTail (b limit headLimit : Nat) (target : ℚ)
     (cfg : BKLNWSumConfig := {}) : Bool :=
   let head := bklnwSumExpDyadicCached b headLimit cfg
-  let tailTerm := expTermIntervalDyadic b (headLimit + 1) cfg
+  let tailTerm := bklnwExpTermIntervalDyadic b (headLimit + 1) cfg
   let upperQ : ℚ :=
     (1 + bklnwAlpha) * (head.hi.toRat + ((limit - headLimit : Nat) : ℚ) * tailTerm.hi.toRat)
   upperQ ≤ target
@@ -945,15 +1218,15 @@ theorem verify_bklnwAlpha_exp_upper_headTail (b limit headLimit : Nat) (target :
   have hhead_hi :
       bklnwF (Real.exp (b : ℝ)) headLimit ≤ (bklnwSumExpDyadicCached b headLimit cfg).hi.toRat :=
     IntervalDyadic.le_hi_of_mem hhead_mem_cached
-  have htail_mem : bklnwExpTerm b (headLimit + 1) ∈ expTermIntervalDyadic b (headLimit + 1) cfg :=
+  have htail_mem : bklnwExpTerm b (headLimit + 1) ∈ bklnwExpTermIntervalDyadic b (headLimit + 1) cfg :=
     mem_expTermIntervalDyadic b (headLimit + 1) cfg hprec
   have htail_hi :
-      bklnwExpTerm b (headLimit + 1) ≤ (expTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat :=
+      bklnwExpTerm b (headLimit + 1) ≤ (bklnwExpTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat :=
     IntervalDyadic.le_hi_of_mem htail_mem
   have hsum_upper :
       bklnwF (Real.exp (b : ℝ)) limit ≤
         (bklnwSumExpDyadicCached b headLimit cfg).hi.toRat +
-          (((limit - headLimit : Nat) : ℝ) * (expTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat) := by
+          (((limit - headLimit : Nat) : ℝ) * (bklnwExpTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat) := by
     calc
       bklnwF (Real.exp (b : ℝ)) limit
           ≤ bklnwF (Real.exp (b : ℝ)) headLimit +
@@ -963,7 +1236,7 @@ theorem verify_bklnwAlpha_exp_upper_headTail (b limit headLimit : Nat) (target :
             (((limit - headLimit : Nat) : ℝ) * bklnwExpTerm b (headLimit + 1)) := by
           gcongr
       _ ≤ (bklnwSumExpDyadicCached b headLimit cfg).hi.toRat +
-            (((limit - headLimit : Nat) : ℝ) * (expTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat) := by
+            (((limit - headLimit : Nat) : ℝ) * (bklnwExpTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat) := by
           gcongr
   have halpha_nonneg : (0 : ℝ) ≤ (1 + bklnwAlpha : ℝ) := by
     norm_num [bklnwAlpha]
@@ -971,25 +1244,25 @@ theorem verify_bklnwAlpha_exp_upper_headTail (b limit headLimit : Nat) (target :
       (1 + bklnwAlpha : ℝ) * bklnwF (Real.exp (b : ℝ)) limit ≤
         (1 + bklnwAlpha : ℝ) *
           ((bklnwSumExpDyadicCached b headLimit cfg).hi.toRat +
-            (((limit - headLimit : Nat) : ℝ) * (expTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat)) :=
+            (((limit - headLimit : Nat) : ℝ) * (bklnwExpTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat)) :=
     mul_le_mul_of_nonneg_left hsum_upper halpha_nonneg
   have hcheck_q :
       (1 + bklnwAlpha) *
           ((bklnwSumExpDyadicCached b headLimit cfg).hi.toRat +
-            ((limit - headLimit : Nat) : ℚ) * (expTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat)
+            ((limit - headLimit : Nat) : ℚ) * (bklnwExpTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat)
         ≤ target := by
     simpa [checkBKLNWAlphaExpUpperBoundHeadTail] using h_check
   have hcheck_r :
       (1 + bklnwAlpha : ℝ) *
           (((bklnwSumExpDyadicCached b headLimit cfg).hi.toRat : ℝ) +
             (((limit - headLimit : Nat) : ℚ) : ℝ) *
-              ((expTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat : ℝ))
+              ((bklnwExpTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat : ℝ))
         ≤ target := by
     exact_mod_cast hcheck_q
   have hcheck_r' :
       (1 + bklnwAlpha : ℝ) *
           ((bklnwSumExpDyadicCached b headLimit cfg).hi.toRat +
-            (((limit - headLimit : Nat) : ℝ) * (expTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat))
+            (((limit - headLimit : Nat) : ℝ) * (bklnwExpTermIntervalDyadic b (headLimit + 1) cfg).hi.toRat))
         ≤ target := by
     simpa using hcheck_r
   exact le_trans hscaled hcheck_r'
@@ -1094,6 +1367,82 @@ theorem verify_bklnwAlpha_exp_lower (b : Nat) (limit : Nat) (target : ℚ)
   have hlo := IntervalDyadic.lo_le_of_mem hmem_round
   -- Check gives bound
   simp only [checkBKLNWAlphaExpLowerBound, bklnwAlphaSumExpDyadic, bklnwSumExpDyadic] at h_check
+  have hbound := IntervalDyadic.lowerBoundedBy_spec h_check
+  exact le_trans hbound hlo
+
+/-- Bridge theorem for the exact-log alpha upper checker.
+
+Unlike `verify_bklnwAlpha_exp_upper`, this path uses `log(exp b) = b`
+directly, so it does not need a positivity certificate for the computed
+`exp b` interval. -/
+theorem verify_bklnwAlpha_exp_upper_cachedLog (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWAlphaExpUpperBoundCachedLog b limit target cfg = true) :
+    (1 + bklnwAlpha : ℝ) * bklnwF (Real.exp (b : ℝ)) limit ≤ target := by
+  have hmem_bklnw := mem_bklnwSumExpDyadicCachedLog b limit cfg hprec
+  have hmem_alpha : (1 + bklnwAlpha : ℝ) ∈
+      IntervalDyadic.ofIntervalRat (IntervalRat.singleton (1 + bklnwAlpha)) cfg.precision := by
+    exact_mod_cast IntervalDyadic.mem_ofIntervalRat
+      (IntervalRat.mem_singleton (1 + bklnwAlpha)) cfg.precision hprec
+  have hmem_prod := IntervalDyadic.mem_mul hmem_alpha hmem_bklnw
+  have hmem_round := IntervalDyadic.roundOut_contains hmem_prod cfg.precision
+  have hhi := IntervalDyadic.le_hi_of_mem hmem_round
+  simp only [checkBKLNWAlphaExpUpperBoundCachedLog, bklnwAlphaSumExpDyadicCachedLog] at h_check
+  have hbound := IntervalDyadic.upperBoundedBy_spec h_check
+  exact le_trans hhi hbound
+
+/-- Bridge theorem for the exact-log alpha lower checker. -/
+theorem verify_bklnwAlpha_exp_lower_cachedLog (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWAlphaExpLowerBoundCachedLog b limit target cfg = true) :
+    target ≤ (1 + bklnwAlpha : ℝ) * bklnwF (Real.exp (b : ℝ)) limit := by
+  have hmem_bklnw := mem_bklnwSumExpDyadicCachedLog b limit cfg hprec
+  have hmem_alpha : (1 + bklnwAlpha : ℝ) ∈
+      IntervalDyadic.ofIntervalRat (IntervalRat.singleton (1 + bklnwAlpha)) cfg.precision := by
+    exact_mod_cast IntervalDyadic.mem_ofIntervalRat
+      (IntervalRat.mem_singleton (1 + bklnwAlpha)) cfg.precision hprec
+  have hmem_prod := IntervalDyadic.mem_mul hmem_alpha hmem_bklnw
+  have hmem_round := IntervalDyadic.roundOut_contains hmem_prod cfg.precision
+  have hlo := IntervalDyadic.lo_le_of_mem hmem_round
+  simp only [checkBKLNWAlphaExpLowerBoundCachedLog, bklnwAlphaSumExpDyadicCachedLog] at h_check
+  have hbound := IntervalDyadic.lowerBoundedBy_spec h_check
+  exact le_trans hbound hlo
+
+/-- Bridge theorem for the direct alpha upper checker. -/
+theorem verify_bklnwAlpha_exp_upper_direct (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWAlphaExpUpperBoundDirect b limit target cfg = true) :
+    (1 + bklnwAlpha : ℝ) * bklnwF (Real.exp (b : ℝ)) limit ≤ target := by
+  have hmem_bklnw := mem_bklnwSumExpDyadicDirect b limit cfg hprec
+  have hmem_alpha : (1 + bklnwAlpha : ℝ) ∈
+      IntervalDyadic.ofIntervalRat (IntervalRat.singleton (1 + bklnwAlpha)) cfg.precision := by
+    exact_mod_cast IntervalDyadic.mem_ofIntervalRat
+      (IntervalRat.mem_singleton (1 + bklnwAlpha)) cfg.precision hprec
+  have hmem_prod := IntervalDyadic.mem_mul hmem_alpha hmem_bklnw
+  have hmem_round := IntervalDyadic.roundOut_contains hmem_prod cfg.precision
+  have hhi := IntervalDyadic.le_hi_of_mem hmem_round
+  simp only [checkBKLNWAlphaExpUpperBoundDirect, bklnwAlphaSumExpDyadicDirect] at h_check
+  have hbound := IntervalDyadic.upperBoundedBy_spec h_check
+  exact le_trans hhi hbound
+
+/-- Bridge theorem for the direct alpha lower checker. -/
+theorem verify_bklnwAlpha_exp_lower_direct (b : Nat) (limit : Nat) (target : ℚ)
+    (cfg : BKLNWSumConfig := {})
+    (hprec : cfg.precision ≤ 0 := by norm_num)
+    (h_check : checkBKLNWAlphaExpLowerBoundDirect b limit target cfg = true) :
+    target ≤ (1 + bklnwAlpha : ℝ) * bklnwF (Real.exp (b : ℝ)) limit := by
+  have hmem_bklnw := mem_bklnwSumExpDyadicDirect b limit cfg hprec
+  have hmem_alpha : (1 + bklnwAlpha : ℝ) ∈
+      IntervalDyadic.ofIntervalRat (IntervalRat.singleton (1 + bklnwAlpha)) cfg.precision := by
+    exact_mod_cast IntervalDyadic.mem_ofIntervalRat
+      (IntervalRat.mem_singleton (1 + bklnwAlpha)) cfg.precision hprec
+  have hmem_prod := IntervalDyadic.mem_mul hmem_alpha hmem_bklnw
+  have hmem_round := IntervalDyadic.roundOut_contains hmem_prod cfg.precision
+  have hlo := IntervalDyadic.lo_le_of_mem hmem_round
+  simp only [checkBKLNWAlphaExpLowerBoundDirect, bklnwAlphaSumExpDyadicDirect] at h_check
   have hbound := IntervalDyadic.lowerBoundedBy_spec h_check
   exact le_trans hbound hlo
 

--- a/LeanCert/Engine/ReflectiveSum.lean
+++ b/LeanCert/Engine/ReflectiveSum.lean
@@ -139,9 +139,7 @@ def oneDyadic : IntervalDyadic := IntervalDyadic.singleton (Core.Dyadic.ofInt 1)
     Formula: x^p = exp(p * log(x)) -/
 def bklnwTermFromLog (logX : IntervalDyadic) (k : Nat) (cfg : BKLNWSumConfig) : IntervalDyadic :=
   let p : ℚ := (1 : ℚ) / k - 1 / 3
-  let pInterval := IntervalDyadic.ofIntervalRat (IntervalRat.singleton p) cfg.precision
-  let pLogX := (IntervalDyadic.mul pInterval logX).roundOut cfg.precision
-  expIntervalDyadic pLogX cfg.toDyadicConfig
+  rpowFromCachedLogDyadic logX p cfg.toDyadicConfig
 
 /-- Optimized accumulator that uses precomputed log(x) and batched rounding.
     - logX: precomputed log(x) interval
@@ -711,7 +709,7 @@ private theorem bklnwTermFromLog_eq_bklnwTermDyadic
     bklnwTermFromLog (logIntervalDyadic x cfg.toDyadicConfig) k cfg =
       bklnwTermDyadic x k cfg := by
   simp only [bklnwTermFromLog, bklnwTermDyadic, rpowIntervalDyadic,
-    BKLNWSumConfig.toDyadicConfig]
+    rpowFromCachedLogDyadic, BKLNWSumConfig.toDyadicConfig]
 
 /-- Cached-log accumulator is definitionally equivalent to the standard accumulator. -/
 theorem bklnwSumAuxCached_eq_bklnwSumAux (x : IntervalDyadic)

--- a/LeanCert/Engine/WitnessSum.lean
+++ b/LeanCert/Engine/WitnessSum.lean
@@ -56,6 +56,18 @@ def witnessSumDyadic (evalTerm : Nat → DyadicConfig → IntervalDyadic)
     (a b : Nat) (cfg : DyadicConfig) : IntervalDyadic :=
   witnessSumAux evalTerm a b finSumZero cfg
 
+/-! ### Cached Evaluators -/
+
+/-- Main entry point for witness sums whose term evaluator uses data cached once
+    per configuration.  This is computationally equivalent to closing over the
+    cache manually, but gives table/generator code a stable reusable API. -/
+def witnessSumDyadicCached {Cache : Type}
+    (init : DyadicConfig → Cache)
+    (evalTerm : Cache → Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (cfg : DyadicConfig) : IntervalDyadic :=
+  let cache := init cfg
+  witnessSumDyadic (fun k cfg => evalTerm cache k cfg) a b cfg
+
 /-! ### Certificate Checkers -/
 
 /-- Check if `∑ k ∈ Icc a b, f k ≤ target` using the witness evaluator. -/
@@ -67,6 +79,20 @@ def checkWitnessSumUpperBound (evalTerm : Nat → DyadicConfig → IntervalDyadi
 def checkWitnessSumLowerBound (evalTerm : Nat → DyadicConfig → IntervalDyadic)
     (a b : Nat) (target : ℚ) (cfg : DyadicConfig) : Bool :=
   (witnessSumDyadic evalTerm a b cfg).lowerBoundedBy target
+
+/-- Check an upper bound for a cached witness sum. -/
+def checkWitnessSumUpperBoundCached {Cache : Type}
+    (init : DyadicConfig → Cache)
+    (evalTerm : Cache → Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig) : Bool :=
+  (witnessSumDyadicCached init evalTerm a b cfg).upperBoundedBy target
+
+/-- Check a lower bound for a cached witness sum. -/
+def checkWitnessSumLowerBoundCached {Cache : Type}
+    (init : DyadicConfig → Cache)
+    (evalTerm : Cache → Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig) : Bool :=
+  (witnessSumDyadicCached init evalTerm a b cfg).lowerBoundedBy target
 
 /-! ### Correctness Theorems -/
 
@@ -109,6 +135,17 @@ theorem mem_witnessSumDyadic (f : Nat → ℝ) (evalTerm : Nat → DyadicConfig 
   simp only [zero_add] at h
   exact h
 
+/-- Golden theorem for cached witness sums. -/
+theorem mem_witnessSumDyadicCached {Cache : Type} (f : Nat → ℝ)
+    (init : DyadicConfig → Cache)
+    (evalTerm : Cache → Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (cfg : DyadicConfig)
+    (hmem : ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm (init cfg) k cfg) :
+    (∑ k ∈ Finset.Icc a b, f k) ∈
+      witnessSumDyadicCached init evalTerm a b cfg := by
+  unfold witnessSumDyadicCached
+  exact mem_witnessSumDyadic f (fun k cfg' => evalTerm (init cfg) k cfg') a b cfg hmem
+
 /-! ### Bridge Theorems -/
 
 /-- If checkWitnessSumUpperBound returns true, the sum is bounded above. -/
@@ -136,6 +173,36 @@ theorem verify_witness_sum_lower (f : Nat → ℝ)
   have hlo : ((witnessSumDyadic evalTerm a b cfg).lo.toRat : ℝ) ≤
       ∑ k ∈ Finset.Icc a b, f k := hsum.1
   simp only [checkWitnessSumLowerBound, IntervalDyadic.lowerBoundedBy,
+    decide_eq_true_eq] at h_check
+  exact le_trans (by exact_mod_cast h_check) hlo
+
+/-- If `checkWitnessSumUpperBoundCached` returns true, the cached sum is bounded above. -/
+theorem verify_witness_sum_upper_cached {Cache : Type} (f : Nat → ℝ)
+    (init : DyadicConfig → Cache)
+    (evalTerm : Cache → Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig)
+    (hmem : ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm (init cfg) k cfg)
+    (h_check : checkWitnessSumUpperBoundCached init evalTerm a b target cfg = true) :
+    ∑ k ∈ Finset.Icc a b, f k ≤ target := by
+  have hsum := mem_witnessSumDyadicCached f init evalTerm a b cfg hmem
+  have hhi : ∑ k ∈ Finset.Icc a b, f k ≤
+      ((witnessSumDyadicCached init evalTerm a b cfg).hi.toRat : ℝ) := hsum.2
+  simp only [checkWitnessSumUpperBoundCached, IntervalDyadic.upperBoundedBy,
+    decide_eq_true_eq] at h_check
+  exact le_trans hhi (by exact_mod_cast h_check)
+
+/-- If `checkWitnessSumLowerBoundCached` returns true, the cached sum is bounded below. -/
+theorem verify_witness_sum_lower_cached {Cache : Type} (f : Nat → ℝ)
+    (init : DyadicConfig → Cache)
+    (evalTerm : Cache → Nat → DyadicConfig → IntervalDyadic)
+    (a b : Nat) (target : ℚ) (cfg : DyadicConfig)
+    (hmem : ∀ k, a ≤ k → k ≤ b → f k ∈ evalTerm (init cfg) k cfg)
+    (h_check : checkWitnessSumLowerBoundCached init evalTerm a b target cfg = true) :
+    target ≤ ∑ k ∈ Finset.Icc a b, f k := by
+  have hsum := mem_witnessSumDyadicCached f init evalTerm a b cfg hmem
+  have hlo : ((witnessSumDyadicCached init evalTerm a b cfg).lo.toRat : ℝ) ≤
+      ∑ k ∈ Finset.Icc a b, f k := hsum.1
+  simp only [checkWitnessSumLowerBoundCached, IntervalDyadic.lowerBoundedBy,
     decide_eq_true_eq] at h_check
   exact le_trans (by exact_mod_cast h_check) hlo
 

--- a/LeanCert/Examples/BKLNW_reflective_test.lean
+++ b/LeanCert/Examples/BKLNW_reflective_test.lean
@@ -43,6 +43,14 @@ open LeanCert.Engine
 -- The existing proof shows f(exp(300)) ≈ 1.00000001937
 #eval checkBKLNWExpUpperBound 300 432 (10001/10000) { precision := -80, taylorDepth := 15 }
 
+-- Exact-log cached path for f(exp b): avoids computing log(exp b).
+#eval checkBKLNWExpUpperBoundCachedLog 300 432 (10001/10000)
+  { precision := -80, taylorDepth := 15 }
+
+-- Direct exp-term path for f(exp b): evaluates exp(b * (1/k - 1/3)) per term.
+#eval checkBKLNWExpUpperBoundDirect 300 432 (10001/10000)
+  { precision := -80, taylorDepth := 15 }
+
 /-!
 ## Demonstration: Reflective Proofs
 
@@ -59,6 +67,40 @@ example : checkBKLNWExpUpperBound 100 144 (100025/100000) proofConfig = true := 
 example : checkBKLNWExpLowerBound 100 144 (10002/10000) proofConfig = true := by native_decide
 example : checkBKLNWExpUpperBound 300 432 (10002/10000) proofConfig = true := by native_decide
 example : checkBKLNWExpLowerBound 300 432 (1) proofConfig = true := by native_decide
+
+example : checkBKLNWExpUpperBoundCachedLog 300 432 (10002/10000) proofConfig = true := by
+  native_decide
+
+example : bklnwF (Real.exp (300 : ℝ)) 432 ≤ (10002 / 10000 : ℚ) :=
+  checkBKLNWExpUpperBoundCachedLog_correct 300 432 (10002 / 10000) proofConfig
+    (by native_decide)
+    (by native_decide)
+
+example : checkBKLNWExpUpperBoundDirect 300 432 (10002/10000) proofConfig = true := by
+  native_decide
+
+example : bklnwF (Real.exp (300 : ℝ)) 432 ≤ (10002 / 10000 : ℚ) :=
+  checkBKLNWExpUpperBoundDirect_correct 300 432 (10002 / 10000) proofConfig
+    (by native_decide)
+    (by native_decide)
+
+example : checkBKLNWAlphaExpUpperBoundCachedLog 300 432 (10003/10000) proofConfig = true := by
+  native_decide
+
+example :
+    (1 + bklnwAlpha : ℝ) * bklnwF (Real.exp (300 : ℝ)) 432 ≤ (10003 / 10000 : ℚ) :=
+  verify_bklnwAlpha_exp_upper_cachedLog 300 432 (10003 / 10000) proofConfig
+    (by native_decide)
+    (by native_decide)
+
+example : checkBKLNWAlphaExpUpperBoundDirect 300 432 (10003/10000) proofConfig = true := by
+  native_decide
+
+example :
+    (1 + bklnwAlpha : ℝ) * bklnwF (Real.exp (300 : ℝ)) 432 ≤ (10003 / 10000 : ℚ) :=
+  verify_bklnwAlpha_exp_upper_direct 300 432 (10003 / 10000) proofConfig
+    (by native_decide)
+    (by native_decide)
 
 /-!
 ## Performance Comparison

--- a/LeanCert/QProduct/Finite.lean
+++ b/LeanCert/QProduct/Finite.lean
@@ -97,7 +97,7 @@ theorem finiteIntegralRat_correct (S : Finset Nat) :
   classical
   unfold finiteIntegralRat F
   simp_rw [qProd_powerset_expand]
-  rw [intervalIntegral.integral_finset_sum]
+  rw [intervalIntegral.integral_finsetSum]
   · simp_rw [Rat.cast_sum]
     apply Finset.sum_congr rfl
     intro A hA
@@ -116,7 +116,7 @@ theorem momentRat_correct (S : Finset Nat) (k : Nat) :
   unfold momentRat moment
   simp_rw [qProd_powerset_expand]
   simp_rw [Finset.sum_mul]
-  rw [intervalIntegral.integral_finset_sum]
+  rw [intervalIntegral.integral_finsetSum]
   · simp_rw [Rat.cast_sum]
     apply Finset.sum_congr rfl
     intro A hA

--- a/LeanCert/QProduct/PrimeLambda.lean
+++ b/LeanCert/QProduct/PrimeLambda.lean
@@ -220,7 +220,7 @@ private theorem qProd_intervalIntegrable (S : Finset Nat) :
   classical
   unfold qProd
   apply Continuous.intervalIntegrable
-  exact continuous_finset_prod S fun n hn =>
+  exact continuous_finsetProd S fun n hn =>
     continuous_const.sub (continuous_id.pow n)
 
 /-- The elementary finite odd-tail certificate: every prime truncation is at least `19/36`. -/
@@ -254,7 +254,7 @@ theorem primeFRat_lower_nineteen_thirtysix (M : Nat) :
         exact by
           classical
           unfold qProd
-          exact (continuous_finset_prod ({3} : Finset Nat) fun n hn =>
+          exact (continuous_finsetProd ({3} : Finset Nat) fun n hn =>
             continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow 5)
       have hle := intervalIntegral.integral_mono_on (by norm_num : (0 : ℝ) ≤ 1)
         hIntSub hIntB (fun u hu => prime_tail_pointwise_three hM5 hu)
@@ -454,9 +454,9 @@ private theorem primeSandwichLowerFun_intervalIntegrable (N m : Nat) :
   apply Continuous.intervalIntegrable
   exact (by
     classical
-    exact (continuous_finset_prod (primesLE N) fun n hn =>
+    exact (continuous_finsetProd (primesLE N) fun n hn =>
       continuous_const.sub (continuous_id.pow n)).sub
-      ((continuous_finset_prod ((primesLE N).filter (fun p => p ≠ 2)) fun n hn =>
+      ((continuous_finsetProd ((primesLE N).filter (fun p => p ≠ 2)) fun n hn =>
         continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow m)))
 
 theorem integral_primeSandwichLowerFun_eq_rat (N m : Nat) :
@@ -472,7 +472,7 @@ theorem integral_primeSandwichLowerFun_eq_rat (N m : Nat) :
   · apply Continuous.intervalIntegrable
     exact (by
       classical
-      exact (continuous_finset_prod ((primesLE N).filter (fun p => p ≠ 2)) fun n hn =>
+      exact (continuous_finsetProd ((primesLE N).filter (fun p => p ≠ 2)) fun n hn =>
         continuous_const.sub (continuous_id.pow n)).mul (continuous_id.pow m))
 
 theorem primeSandwichLowerRat_le_truncation_of_tail_ge {N m : Nat}

--- a/LeanCert/QProduct/Stability.lean
+++ b/LeanCert/QProduct/Stability.lean
@@ -76,7 +76,7 @@ theorem F_nonneg (S : Finset Nat) : 0 ≤ F S := by
     classical
     unfold qProd
     apply Continuous.intervalIntegrable
-    exact continuous_finset_prod S fun n hn =>
+    exact continuous_finsetProd S fun n hn =>
       continuous_const.sub (continuous_id.pow n)
   apply intervalIntegral.integral_nonneg (by norm_num : (0 : ℝ) ≤ 1)
   intro u hu
@@ -89,7 +89,7 @@ theorem F_le_one (S : Finset Nat) : F S ≤ 1 := by
     classical
     unfold qProd
     apply Continuous.intervalIntegrable
-    exact continuous_finset_prod S fun n hn =>
+    exact continuous_finsetProd S fun n hn =>
       continuous_const.sub (continuous_id.pow n)
   have hConst : IntervalIntegrable (fun _ : ℝ => (1 : ℝ)) volume (0 : ℝ) 1 := by
     exact continuous_const.intervalIntegrable 0 1
@@ -106,13 +106,13 @@ theorem F_antitone {S T : Finset Nat}
     classical
     unfold qProd
     apply Continuous.intervalIntegrable
-    exact continuous_finset_prod T fun n hn =>
+    exact continuous_finsetProd T fun n hn =>
       continuous_const.sub (continuous_id.pow n)
   have hSInt : IntervalIntegrable (fun u => qProd S u) volume (0 : ℝ) 1 := by
     classical
     unfold qProd
     apply Continuous.intervalIntegrable
-    exact continuous_finset_prod S fun n hn =>
+    exact continuous_finsetProd S fun n hn =>
       continuous_const.sub (continuous_id.pow n)
   exact intervalIntegral.integral_mono_on (by norm_num : (0 : ℝ) ≤ 1) hTInt hSInt
     (fun u hu => qProd_antitone_pointwise hST hu)

--- a/LeanCert/Test/ValidityExports.lean
+++ b/LeanCert/Test/ValidityExports.lean
@@ -14,6 +14,7 @@ Smoke tests for stable Validity-layer import paths.
 namespace LeanCert.Test.ValidityExports
 
 #check LeanCert.Validity.FinSum.verify_finsum_upper_full
+#check LeanCert.Validity.FinSum.verify_witness_sum_upper_cached
 #check LeanCert.Validity.FinSum.verify_witness_sum_upper_list_full
 #check LeanCert.Validity.Dyadic.verify_upper_bound_dyadic
 #check LeanCert.Validity.Dyadic.verify_upper_bound_dyadic_withInv

--- a/LeanCert/Test/WitnessSum.lean
+++ b/LeanCert/Test/WitnessSum.lean
@@ -45,6 +45,30 @@ theorem identityEval_correct (k : Nat) (cfg : DyadicConfig) :
   rw [Core.Dyadic.toRat_ofInt] at h
   simpa using h
 
+/-! ## Cached witness evaluator tests -/
+
+def constCache (_cfg : DyadicConfig) : IntervalDyadic :=
+  IntervalDyadic.singleton (Core.Dyadic.ofInt 1)
+
+def cachedConstEval (cache : IntervalDyadic) (_k : Nat) (_cfg : DyadicConfig) :
+    IntervalDyadic :=
+  cache
+
+theorem cachedConstEval_correct (k : Nat) (cfg : DyadicConfig) :
+    (1 : ℝ) ∈ cachedConstEval (constCache cfg) k cfg := by
+  exact constEval_correct k cfg
+
+example :
+    checkWitnessSumUpperBoundCached constCache cachedConstEval 1 10 11
+      { precision := -53, taylorDepth := 10, roundAfterOps := 0 } = true := by
+  native_decide
+
+example : ∑ _k ∈ Finset.Icc 1 10, (1 : ℝ) ≤ 11 :=
+  verify_witness_sum_upper_cached (fun _ => 1) constCache cachedConstEval 1 10 11
+    { precision := -53, taylorDepth := 10, roundAfterOps := 0 }
+    (fun k _ _ => cachedConstEval_correct k _)
+    (by native_decide)
+
 /-! ## Tests via `finsum_witness` tactic (standalone) -/
 
 -- Basic: ∑ 1 ≤ 11 via constant witness

--- a/LeanCert/Validity/FinSum.lean
+++ b/LeanCert/Validity/FinSum.lean
@@ -30,6 +30,8 @@ export LeanCert.Engine
     verify_finsum_lower_list_full_withInv
     verify_witness_sum_upper
     verify_witness_sum_lower
+    verify_witness_sum_upper_cached
+    verify_witness_sum_lower_cached
     verify_witness_sum_upper_list
     verify_witness_sum_lower_list
     verify_witness_sum_upper_list_full


### PR DESCRIPTION
This pull request introduces optimized "cached logarithm" and "direct exponential" evaluation paths for the BKLNW sum and its bounds, particularly for arguments of the form `f(exp b)`. It adds new hot-path primitives, specialized accumulators, and correctness theorems, enabling more efficient and precise interval arithmetic for these cases. The changes also refactor and generalize code to reuse these new primitives, and add corresponding correctness proofs and bound checkers.

The most important changes are:

**1. Cached-logarithm and direct exponential evaluation primitives:**
- Added `rpowFromCachedLogDyadic` in `IntervalEvalDyadic.lean`, which computes `x^p` using a cached interval for `log x`, and a corresponding correctness theorem. This is now used as the hot path for repeated exponentiations with the same base. [[1]](diffhunk://#diff-2a94d4691eb4672ef8f07d5cf7e9f311f918f050ae6fb3eee3f167edabb9aec2R183-R194) [[2]](diffhunk://#diff-2a94d4691eb4672ef8f07d5cf7e9f311f918f050ae6fb3eee3f167edabb9aec2L193-R242)
- Added `bklnwExpTermIntervalDyadic` and direct-sum accumulators for terms of the form `exp(b * q_k)`, avoiding redundant logarithm and exponentiation calculations. [[1]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235L142-R153) [[2]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R209-R233)

**2. New optimized sum and bound checkers for `f(exp b)`:**
- Introduced `bklnwSumExpDyadicCachedLog`, `bklnwSumExpDyadicDirect`, and their respective upper/lower/two-sided bound checkers, providing fast and precise checking for sums at exponential arguments. [[1]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R209-R233) [[2]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R314-R337) [[3]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R1029-R1076)
- Added analogous "alpha" sum and bound checkers for `(1+α) * f(exp b)`.

**3. Correctness theorems for new primitives and checkers:**
- Added theorems proving the correctness of the cached-log and direct-exponential term/sum evaluators, including bridge theorems relating the new checkers to mathematical bounds. [[1]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R489-R502) [[2]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R533-R564) [[3]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R686-R810) [[4]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R1029-R1076)

**4. Refactoring and code reuse:**
- Updated existing code to use the new primitives (e.g., replacing manual exponentiation in `bklnwTermFromLog` with `rpowFromCachedLogDyadic`). [[1]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235L142-R153) [[2]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235L714-R943)
- Removed the now-redundant `expTermIntervalDyadic` in favor of the new direct term function.

**5. Documentation and minor improvements:**
- Added and improved docstrings for new and existing functions, clarifying their purpose and usage. [[1]](diffhunk://#diff-2a94d4691eb4672ef8f07d5cf7e9f311f918f050ae6fb3eee3f167edabb9aec2R183-R194) [[2]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R209-R233) [[3]](diffhunk://#diff-95a50cd102b680d89c6d9f8a006db9270abe068612eea2dc29e8a304a9f09235R1029-R1076)

These changes significantly improve the efficiency and clarity of interval evaluation for exponential arguments in the BKLNW sum and related bound-checking routines.