### PR TITLE
Add reusable certificate engines for tables, envelopes, contour shifts, and constant factories

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -12,6 +12,7 @@ import LeanCert.Core.IntervalRealEndpoints
 import LeanCert.Core.Taylor
 import LeanCert.Core.DerivativeIntervals
 import LeanCert.Cert.Interval
+import LeanCert.Analysis.ContourShift
 -- v1.1: Dyadic arithmetic (high-performance alternative to Rat)
 import LeanCert.Core.Dyadic
 import LeanCert.Core.IntervalDyadic
@@ -61,6 +62,8 @@ import LeanCert.Engine.SearchAPI
 
 -- Q-product product-integral certificates
 import LeanCert.QProduct
+import LeanCert.ConstantFactory
+import LeanCert.ConstantFactory.IntervalBank
 
 -- Analytic number theory certificate machinery
 import LeanCert.ANT
@@ -136,6 +139,43 @@ export LeanCert.Cert (
   verify_rat_interval
   verify_rat_upper
   verify_rat_lower
+)
+
+-- Re-export contour-shift certificate API
+export LeanCert.Analysis.ContourShift (
+  bottomIntegral
+  topIntegral
+  rightIntegral
+  leftIntegral
+  rectBoundary
+  rectBoundary_eq_zero_of_continuousOn_of_differentiableOn
+  VerticalShiftCert
+  verticalIntegral
+  topHorizontalIntegral
+  bottomHorizontalIntegral
+  StripPoleCert
+  stripResidueSum
+  RectangleShiftCert
+  HorizontalVanishCert
+  HorizontalBoundCert
+  ContourShiftCert
+)
+
+export LeanCert.Analysis.ContourShift.VerticalShiftCert (
+  vertical_shift
+  ofHolomorphicRectangle
+)
+
+export LeanCert.Analysis.ContourShift.HorizontalBoundCert (
+  toVanishCert
+)
+
+export LeanCert.Analysis.ContourShift.ContourShiftCert (
+  leftValue
+  rightValue
+  residueSum
+  shift_identity
+  shift_identity'
 )
 
 -- v1.1: Re-export Dyadic types (high-performance arithmetic)
@@ -233,6 +273,14 @@ export LeanCert.Engine (
 -- Re-export integration
 export LeanCert.Engine (
   integrateInterval
+)
+
+export LeanCert.Engine.TaylorModel (
+  integrateShiftedPoly
+  integralBoundPolyExact
+  integralBoundCoarse
+  integral_mem_bound_polyExact_of_poly_integral
+  integral_mem_bound_coarse
 )
 
 -- Re-export optimization
@@ -417,6 +465,32 @@ export LeanCert.QProduct (
   primeLambda_gt_half
 )
 
+-- Re-export ConstantFactory API
+export LeanCert.ConstantFactory (
+  observerIntegralRat
+  observerIntegral
+  observerIntegralRat_correct
+  F_union_eq_observerIntegral
+  observerIntegralRat_eq_F_union
+  checkConstantFactoryInterval
+  verify_constantFactory_interval
+  checkConstantFactoryUpper
+  checkConstantFactoryLower
+  verify_constantFactory_upper
+  verify_constantFactory_lower
+  KernelIntervalBank
+  observerTerm
+  observerIntervalTerm
+  observerIntegralList
+  observerIntervalList
+  observerInterval
+  observerTerm_mem_interval
+  observerIntegralList_mem_observerIntervalList
+  observerIntegralList_powerset_eq
+  F_union_mem_observerInterval
+  exactKernelIntervalBank
+)
+
 -- Re-export ANT certificate API
 export LeanCert.ANT (
   StepFn
@@ -534,6 +608,72 @@ export LeanCert.ANT (
   mertensLogSum_le_mertensLogSumUpperRat
   checkMertensLogSumInterval
   verify_mertensLogSum_interval
+)
+
+-- Re-export asymptotic envelope API
+export LeanCert.ANT.Asymp (
+  AsympEnv
+  evalAtNat
+  ErrorDomination
+  PointwiseEnvelope
+  SlabInequalityCert
+  InequalityTableRow
+  checkInequalityTableRow
+  InequalityTableCert
+)
+
+export LeanCert.ANT.Asymp.AsympEnv (
+  summatory
+  summatoryReal
+  lower
+  upper
+  lowerReal
+  upperReal
+  lower_le_summatory
+  summatory_le_upper
+  lowerReal_le_summatoryReal
+  summatoryReal_le_upperReal
+  certReal
+  weakenError
+  shiftCutoff
+  add
+  neg
+  sub
+  constMul
+  toPointwiseFloorEnvelope
+)
+
+export LeanCert.ANT.Asymp.PointwiseEnvelope (
+  lower
+  upper
+  lower_le_value
+  value_le_upper
+  weakenError
+)
+
+export LeanCert.ANT.Asymp.SlabInequalityCert (
+  verify
+)
+
+export LeanCert.ANT.Asymp.InequalityTableCert (
+  verify
+  failingIndices
+)
+
+export LeanCert.ANT.PrimePowerExt (
+  ext_prime_powers
+  eq_iff_eq_on_prime_powers
+  LocalPrimePowerCert
+)
+
+export LeanCert.ANT.PrimePowerExt.LocalPrimePowerCert (
+  sound
+)
+
+export LeanCert.ANT.PNTCompilers (
+  psi_to_theta_bound
+  theta_to_pi_bound_of_decomposition
+  theta_to_pi_bound
 )
 
 /-! ### Convenience abbreviations -/

--- a/LeanCert/ANT.lean
+++ b/LeanCert/ANT.lean
@@ -7,9 +7,11 @@ import LeanCert.ANT.Step
 import LeanCert.ANT.Abel
 import LeanCert.ANT.EulerProduct
 import LeanCert.ANT.PrimeEuler
+import LeanCert.ANT.PrimePowerExt
 import LeanCert.ANT.Dirichlet
 import LeanCert.ANT.Mertens
 import LeanCert.ANT.Asymp
+import LeanCert.ANT.PNTCompilers
 
 /-!
 # Analytic number theory certificate machinery

--- a/LeanCert/ANT/Asymp.lean
+++ b/LeanCert/ANT/Asymp.lean
@@ -4,14 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
 import LeanCert.ANT.Asymp.Env
+import LeanCert.ANT.Asymp.Pointwise
 import LeanCert.ANT.Asymp.Stieltjes
 import LeanCert.ANT.Asymp.Hyperbola
 import LeanCert.ANT.Asymp.Checkers
+import LeanCert.ANT.Asymp.Inequality
 
 /-!
 # Certified asymptotic envelope machinery
 
 This namespace contains the semantic core, compositional envelope algebra,
-Stieltjes-Abel transform kernel, Dirichlet-hyperbola split kernel, and dyadic
-checker wrappers for asymptotic arithmetic-function certificates.
+pointwise real-variable envelopes, Stieltjes-Abel transform kernel,
+Dirichlet-hyperbola split kernel, and dyadic checker wrappers for asymptotic
+arithmetic-function certificates and explicit interval inequalities.
 -/

--- a/LeanCert/ANT/Asymp/Inequality.lean
+++ b/LeanCert/ANT/Asymp/Inequality.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.ANT.Asymp.Checkers
+import LeanCert.Engine.Table
+
+/-!
+# PNT-facing inequality certificates
+
+This module packages the existing dyadic slab checker into small certificate
+objects intended for explicit PNT-style inequalities and generated numerical
+tables.  The trusted core remains the checker soundness theorem in
+`LeanCert.ANT.Asymp.Checkers`; this file only gives the standard user-facing
+shape.
+-/
+
+namespace LeanCert.ANT.Asymp
+
+open LeanCert.Core
+open LeanCert.Engine
+
+/-- Certificate that `lhs ≤ rhs` on every rational slab in `slabs`. -/
+structure SlabInequalityCert where
+  lhs : Expr
+  rhs : Expr
+  slabs : List IntervalRat
+  prec : Int
+  depth : Nat
+  supported : ExprSupportedWithInv (Expr.sub lhs rhs)
+  prec_ok : prec ≤ 0
+  checked : checkExprLeOnSlabsDyadic lhs rhs slabs prec depth = true
+
+namespace SlabInequalityCert
+
+/-- Soundness of a packaged slab inequality certificate. -/
+theorem verify (C : SlabInequalityCert) :
+    ∀ I ∈ C.slabs, ∀ x ∈ Set.Icc (I.lo : ℝ) I.hi,
+      Expr.eval (fun _ => x) C.lhs ≤ Expr.eval (fun _ => x) C.rhs :=
+  verify_expr_le_on_slabs_dyadic C.lhs C.rhs C.slabs C.prec C.depth
+    C.supported C.prec_ok C.checked
+
+end SlabInequalityCert
+
+/--
+One generated table row for a closed interval inequality.
+
+Rows are intentionally proof-free data.  The table certificate below carries
+the support and precision hypotheses needed to use the dyadic checker.
+-/
+structure InequalityTableRow where
+  lhs : Expr
+  rhs : Expr
+  interval : IntervalRat
+  prec : Int
+  depth : Nat
+  deriving Repr
+
+/-- Boolean checker for one inequality table row. -/
+def checkInequalityTableRow (row : InequalityTableRow) : Bool :=
+  checkExprLeOnIntervalDyadic row.lhs row.rhs row.interval row.prec row.depth
+
+/--
+Generated table certificate for row-wise interval inequalities.
+
+This is the PNT/table-oriented specialization of `TableCert`: data rows are
+checked by `native_decide`, while support/precision side conditions are proved
+once over table membership.
+-/
+structure InequalityTableCert where
+  table : TableCert InequalityTableRow
+  supported :
+    ∀ row, row ∈ table.rows.toList →
+      ExprSupportedWithInv (Expr.sub row.lhs row.rhs)
+  prec_ok :
+    ∀ row, row ∈ table.rows.toList → row.prec ≤ 0
+  checked : table.checkAll checkInequalityTableRow = true
+
+namespace InequalityTableCert
+
+/-- Soundness of a generated inequality table certificate. -/
+theorem verify (C : InequalityTableCert) :
+    ∀ row, row ∈ C.table.rows.toList →
+      ∀ x ∈ Set.Icc (row.interval.lo : ℝ) row.interval.hi,
+        Expr.eval (fun _ => x) row.lhs ≤ Expr.eval (fun _ => x) row.rhs := by
+  intro row hrow x hx
+  have hchecked :
+      checkInequalityTableRow row = true :=
+    TableCert.row_checked_of_list_all C.checked hrow
+  exact verify_expr_le_on_interval_dyadic row.lhs row.rhs row.interval row.prec row.depth
+    (C.supported row hrow) (C.prec_ok row hrow) hchecked x hx
+
+/-- Diagnostic list of failing row indices for a generated inequality table. -/
+def failingIndices (C : InequalityTableCert) : List Nat :=
+  C.table.failingIndices checkInequalityTableRow
+
+end InequalityTableCert
+
+end LeanCert.ANT.Asymp

--- a/LeanCert/ANT/Asymp/Pointwise.lean
+++ b/LeanCert/ANT/Asymp/Pointwise.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.ANT.Asymp.Env
+
+/-!
+# Pointwise error envelopes
+
+`AsympEnv` is the canonical envelope type for summatory arithmetic functions.
+This module adds the sibling type for ordinary real-variable estimates:
+
+`|f x - main x| ≤ error x` on a domain.
+
+The conversion from `AsympEnv` uses the existing floored real-endpoint
+semantics, so later explicit-PNT transfer functors can consume either discrete
+summatory envelopes or genuine real-variable envelopes without duplicating the
+core absolute-error algebra.
+-/
+
+namespace LeanCert.ANT.Asymp
+
+/-- A pointwise real-variable error envelope. -/
+structure PointwiseEnvelope where
+  /-- Function being bounded. -/
+  f : ℝ → ℝ
+  /-- Main approximation term. -/
+  main : ℝ → ℝ
+  /-- Nonnegative error radius. -/
+  error : ℝ → ℝ
+  /-- Domain on which the envelope is valid. -/
+  domain : Set ℝ
+  /-- Absolute-error certificate. -/
+  cert : ∀ x ∈ domain, |f x - main x| ≤ error x
+  /-- Error radius is nonnegative on the domain. -/
+  error_nonneg : ∀ x ∈ domain, 0 ≤ error x
+
+namespace PointwiseEnvelope
+
+/-- Lower endpoint induced by a pointwise envelope. -/
+noncomputable def lower (E : PointwiseEnvelope) (x : ℝ) : ℝ :=
+  E.main x - E.error x
+
+/-- Upper endpoint induced by a pointwise envelope. -/
+noncomputable def upper (E : PointwiseEnvelope) (x : ℝ) : ℝ :=
+  E.main x + E.error x
+
+/-- A pointwise envelope as a lower bound. -/
+theorem lower_le_value (E : PointwiseEnvelope) {x : ℝ} (hx : x ∈ E.domain) :
+    E.lower x ≤ E.f x := by
+  unfold lower
+  have h := E.cert x hx
+  have hneg : -E.error x ≤ E.f x - E.main x := neg_le_of_abs_le h
+  linarith
+
+/-- A pointwise envelope as an upper bound. -/
+theorem value_le_upper (E : PointwiseEnvelope) {x : ℝ} (hx : x ∈ E.domain) :
+    E.f x ≤ E.upper x := by
+  unfold upper
+  have h := E.cert x hx
+  have hpos : E.f x - E.main x ≤ E.error x := le_of_abs_le h
+  linarith
+
+/-- Weaken a pointwise envelope to a larger error term. -/
+noncomputable def weakenError (E : PointwiseEnvelope) (newError : ℝ → ℝ)
+    (hnew : ∀ x ∈ E.domain, E.error x ≤ newError x) :
+    PointwiseEnvelope where
+  f := E.f
+  main := E.main
+  error := newError
+  domain := E.domain
+  cert := by
+    intro x hx
+    exact (E.cert x hx).trans (hnew x hx)
+  error_nonneg := by
+    intro x hx
+    exact (E.error_nonneg x hx).trans (hnew x hx)
+
+/-- Sum of two pointwise envelopes on their common domain. -/
+noncomputable def add (E G : PointwiseEnvelope) : PointwiseEnvelope where
+  f := fun x => E.f x + G.f x
+  main := fun x => E.main x + G.main x
+  error := fun x => E.error x + G.error x
+  domain := E.domain ∩ G.domain
+  cert := by
+    intro x hx
+    rcases hx with ⟨hE, hG⟩
+    have hEcert := E.cert x hE
+    have hGcert := G.cert x hG
+    calc
+      |(E.f x + G.f x) - (E.main x + G.main x)|
+          = |(E.f x - E.main x) + (G.f x - G.main x)| := by ring_nf
+      _ ≤ |E.f x - E.main x| + |G.f x - G.main x| := abs_add_le _ _
+      _ ≤ E.error x + G.error x := add_le_add hEcert hGcert
+  error_nonneg := by
+    intro x hx
+    exact add_nonneg (E.error_nonneg x hx.1) (G.error_nonneg x hx.2)
+
+/-- Negation of a pointwise envelope. -/
+noncomputable def neg (E : PointwiseEnvelope) : PointwiseEnvelope where
+  f := fun x => -E.f x
+  main := fun x => -E.main x
+  error := E.error
+  domain := E.domain
+  cert := by
+    intro x hx
+    calc
+      |-E.f x - -E.main x| = |E.f x - E.main x| := by
+        have h : -E.f x - -E.main x = -(E.f x - E.main x) := by ring
+        rw [h, abs_neg]
+      _ ≤ E.error x := E.cert x hx
+  error_nonneg := E.error_nonneg
+
+/-- Difference of two pointwise envelopes on their common domain. -/
+noncomputable def sub (E G : PointwiseEnvelope) : PointwiseEnvelope :=
+  add E (neg G)
+
+/-- Rational scalar multiplication of a pointwise envelope. -/
+noncomputable def constMul (q : ℚ) (E : PointwiseEnvelope) : PointwiseEnvelope where
+  f := fun x => (q : ℝ) * E.f x
+  main := fun x => (q : ℝ) * E.main x
+  error := fun x => ((|q| : ℚ) : ℝ) * E.error x
+  domain := E.domain
+  cert := by
+    intro x hx
+    have hE := E.cert x hx
+    calc
+      |(q : ℝ) * E.f x - (q : ℝ) * E.main x|
+          = |(q : ℝ) * (E.f x - E.main x)| := by ring_nf
+      _ = |(q : ℝ)| * |E.f x - E.main x| := abs_mul _ _
+      _ = ((|q| : ℚ) : ℝ) * |E.f x - E.main x| := by rw [Rat.cast_abs]
+      _ ≤ ((|q| : ℚ) : ℝ) * E.error x := by
+        exact mul_le_mul_of_nonneg_left hE (by exact_mod_cast abs_nonneg q)
+  error_nonneg := by
+    intro x hx
+    exact mul_nonneg (by exact_mod_cast abs_nonneg q) (E.error_nonneg x hx)
+
+end PointwiseEnvelope
+
+namespace AsympEnv
+
+/--
+Convert a discrete summatory envelope to a pointwise envelope using the existing
+floored real-endpoint semantics.
+-/
+noncomputable def toPointwiseFloorEnvelope (A : AsympEnv) : PointwiseEnvelope where
+  f := A.summatoryReal
+  main := fun x => evalAtNat A.mainTerm ⌊x⌋₊
+  error := fun x => evalAtNat A.errorTerm ⌊x⌋₊
+  domain := {x | A.cutoff ≤ ⌊x⌋₊}
+  cert := by
+    intro x hx
+    exact A.certReal x hx
+  error_nonneg := by
+    intro x hx
+    exact A.error_nonneg ⌊x⌋₊ hx
+
+theorem toPointwiseFloorEnvelope_cert (A : AsympEnv) :
+    ∀ x ∈ (A.toPointwiseFloorEnvelope).domain,
+      |(A.toPointwiseFloorEnvelope).f x -
+          (A.toPointwiseFloorEnvelope).main x| ≤
+        (A.toPointwiseFloorEnvelope).error x :=
+  A.toPointwiseFloorEnvelope.cert
+
+end AsympEnv
+
+end LeanCert.ANT.Asymp

--- a/LeanCert/ANT/PNTCompilers.lean
+++ b/LeanCert/ANT/PNTCompilers.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.ANT.Asymp.Pointwise
+
+/-!
+# Explicit-PNT compiler theorem schemas
+
+This module contains project-agnostic theorem schemas for the two standard
+explicit-PNT envelope transfers:
+
+* `psi -> theta`, after bounding prime-power contributions;
+* `theta -> pi`, after a partial-summation decomposition has been proved.
+
+The actual functions `ψ`, `θ`, `π`, and `Li` are intentionally parameters.
+LeanCert supplies the reusable inequality algebra; project files supply the
+semantic definitions and decomposition identities.
+-/
+
+namespace LeanCert.ANT.PNTCompilers
+
+/--
+Generic `ψ -> θ` envelope transfer.
+
+If `theta x - x = (psi x - x) - powerContribution`, the psi error is bounded by
+`psiError`, and the prime-power contribution is between `0` and `powerBound`,
+then the theta error is bounded by `psiError + powerBound`.
+-/
+theorem psi_to_theta_bound
+    {psi theta : ℝ → ℝ} {x psiError powerContribution powerBound : ℝ}
+    (hdecomp : theta x - x = (psi x - x) - powerContribution)
+    (hpsi : |psi x - x| ≤ psiError)
+    (hpower_nonneg : 0 ≤ powerContribution)
+    (hpower_bound : powerContribution ≤ powerBound) :
+    |theta x - x| ≤ psiError + powerBound := by
+  rw [hdecomp]
+  have htri : |(psi x - x) - powerContribution| ≤
+      |psi x - x| + |powerContribution| := by
+    have hrewrite :
+        |(psi x - x) - powerContribution| =
+          |(psi x - x) + (-powerContribution)| := by ring_nf
+    rw [hrewrite]
+    simpa [abs_neg] using abs_add_le (psi x - x) (-powerContribution)
+  have hpow_abs : |powerContribution| = powerContribution := abs_of_nonneg hpower_nonneg
+  linarith
+
+/--
+Generic `θ -> π` envelope transfer after partial summation.
+
+The decomposition field should package the project-specific partial-summation
+identity.  The endpoint and integral terms are supplied as already-bounded
+absolute values, which keeps this theorem independent of the concrete choice of
+`Li`, endpoint constants, and integral certificate backend.
+-/
+theorem theta_to_pi_bound_of_decomposition
+    {primeCount li : ℝ → ℝ} {x : ℝ}
+    {constant endpointX endpointBase integralTerm
+      endpointXBound endpointBaseBound integralBound : ℝ}
+    (hdecomp :
+      primeCount x - li x =
+        constant + endpointX - endpointBase + integralTerm)
+    (hEndpointX : |endpointX| ≤ endpointXBound)
+    (hEndpointBase : |endpointBase| ≤ endpointBaseBound)
+    (hIntegral : |integralTerm| ≤ integralBound) :
+    |primeCount x - li x| ≤
+      |constant| + endpointXBound + endpointBaseBound + integralBound := by
+  rw [hdecomp]
+  have hmain :
+      |constant + endpointX - endpointBase + integralTerm| ≤
+        |constant| + |endpointX| + |endpointBase| + |integralTerm| := by
+    have hrewrite :
+        |constant + endpointX - endpointBase + integralTerm| =
+          |constant + (endpointX + (-endpointBase) + integralTerm)| := by ring_nf
+    rw [hrewrite]
+    have h1 :
+        |constant + (endpointX + (-endpointBase) + integralTerm)| ≤
+          |constant| + |endpointX + (-endpointBase) + integralTerm| :=
+      abs_add_le _ _
+    have h2 :
+        |endpointX + (-endpointBase) + integralTerm| ≤
+          |endpointX + (-endpointBase)| + |integralTerm| :=
+      abs_add_le _ _
+    have h3 :
+        |endpointX + (-endpointBase)| ≤ |endpointX| + |-endpointBase| :=
+      abs_add_le _ _
+    have hneg : |-endpointBase| = |endpointBase| := abs_neg _
+    linarith
+  linarith
+
+/--
+Endpoint form of the `θ -> π` transfer where the endpoint terms are explicitly
+`deltaTheta / log`.
+
+This theorem only needs positivity of the logarithms to turn bounds on
+`deltaTheta` into bounds on the divided endpoint terms.
+-/
+theorem theta_to_pi_bound
+    {primeCount li deltaTheta thetaError : ℝ → ℝ} {x x0 : ℝ}
+    {constant integralTerm integralBound : ℝ}
+    (hdecomp :
+      primeCount x - li x =
+        constant +
+          deltaTheta x / Real.log x -
+            deltaTheta x0 / Real.log x0 +
+              integralTerm)
+    (hThetaX : |deltaTheta x| ≤ thetaError x)
+    (hThetaX0 : |deltaTheta x0| ≤ thetaError x0)
+    (hLogX : 0 < Real.log x)
+    (hLogX0 : 0 < Real.log x0)
+    (hIntegral : |integralTerm| ≤ integralBound) :
+    |primeCount x - li x| ≤
+      |constant| +
+        thetaError x / Real.log x +
+          thetaError x0 / Real.log x0 +
+            integralBound := by
+  apply theta_to_pi_bound_of_decomposition (hdecomp := hdecomp)
+  · rw [abs_div, abs_of_pos hLogX]
+    exact div_le_div_of_nonneg_right hThetaX (le_of_lt hLogX)
+  · rw [abs_div, abs_of_pos hLogX0]
+    exact div_le_div_of_nonneg_right hThetaX0 (le_of_lt hLogX0)
+  · exact hIntegral
+
+end LeanCert.ANT.PNTCompilers

--- a/LeanCert/ANT/PrimePowerExt.lean
+++ b/LeanCert/ANT/PrimePowerExt.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction.Defs
+
+/-!
+# Prime-power extensionality helpers
+
+Mathlib already proves the main theorem: two multiplicative arithmetic functions
+are equal iff they agree on all prime powers.  This module gives LeanCert a
+small, stable ANT-facing wrapper with names intended for certificate/tactic
+workflows.
+-/
+
+namespace LeanCert.ANT.PrimePowerExt
+
+open ArithmeticFunction
+
+/--
+Two multiplicative arithmetic functions are equal when they agree on every prime
+power.
+
+This is a LeanCert-facing wrapper around
+`ArithmeticFunction.IsMultiplicative.eq_iff_eq_on_prime_powers`.
+-/
+theorem ext_prime_powers {R : Type*} [CommMonoidWithZero R]
+    (f g : ArithmeticFunction R)
+    (hf : f.IsMultiplicative)
+    (hg : g.IsMultiplicative)
+    (h : ∀ p i : Nat, Nat.Prime p → f (p ^ i) = g (p ^ i)) :
+    f = g :=
+  (ArithmeticFunction.IsMultiplicative.eq_iff_eq_on_prime_powers f hf g hg).2 h
+
+/--
+Iff form of prime-power extensionality, exposed under LeanCert's ANT namespace.
+-/
+theorem eq_iff_eq_on_prime_powers {R : Type*} [CommMonoidWithZero R]
+    (f g : ArithmeticFunction R)
+    (hf : f.IsMultiplicative)
+    (hg : g.IsMultiplicative) :
+    f = g ↔ ∀ p i : Nat, Nat.Prime p → f (p ^ i) = g (p ^ i) :=
+  ArithmeticFunction.IsMultiplicative.eq_iff_eq_on_prime_powers f hf g hg
+
+/--
+Certificate object for arithmetic-function equality by local prime-power
+checks.
+
+This packages the common ANT workflow: prove both sides multiplicative, then
+verify equality on every `p^k`.
+-/
+structure LocalPrimePowerCert {R : Type*} [CommMonoidWithZero R]
+    (f g : ArithmeticFunction R) where
+  left_multiplicative : f.IsMultiplicative
+  right_multiplicative : g.IsMultiplicative
+  local_eq : ∀ p k : Nat, Nat.Prime p → f (p ^ k) = g (p ^ k)
+
+namespace LocalPrimePowerCert
+
+/-- Soundness theorem for a local prime-power equality certificate. -/
+theorem sound {R : Type*} [CommMonoidWithZero R] {f g : ArithmeticFunction R}
+    (cert : LocalPrimePowerCert f g) :
+    f = g :=
+  ext_prime_powers f g cert.left_multiplicative cert.right_multiplicative cert.local_eq
+
+end LocalPrimePowerCert
+
+end LeanCert.ANT.PrimePowerExt

--- a/LeanCert/Analysis/ContourShift.lean
+++ b/LeanCert/Analysis/ContourShift.lean
@@ -1,0 +1,322 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import Mathlib.Analysis.Complex.CauchyIntegral
+
+/-!
+# Contour-shift certificates
+
+This module provides a small certificate-facing wrapper around mathlib's
+rectangle Cauchy-Goursat theorem.  The goal is to make orientation bookkeeping
+explicit before adding residue automation.
+
+The boundary convention is:
+
+`bottom - top + I * right - I * left`.
+
+Here `right` and `left` are real-parameter vertical integrals, so multiplying by
+`I` converts them to complex contour integrals with the standard orientation.
+-/
+
+namespace LeanCert.Analysis.ContourShift
+
+open Complex
+open MeasureTheory
+open Filter
+open Topology
+open scoped Real
+open scoped BigOperators
+
+/-- Bottom horizontal side of the rectangle from `z.re + z.im * I` to
+`w.re + z.im * I`. -/
+noncomputable def bottomIntegral (f : ℂ → ℂ) (z w : ℂ) : ℂ :=
+  ∫ x : ℝ in z.re..w.re, f (x + z.im * I)
+
+/-- Top horizontal side of the rectangle from `z.re + w.im * I` to
+`w.re + w.im * I`.  It appears with a minus sign in the positive boundary. -/
+noncomputable def topIntegral (f : ℂ → ℂ) (z w : ℂ) : ℂ :=
+  ∫ x : ℝ in z.re..w.re, f (x + w.im * I)
+
+/-- Right vertical side, parameterized upward from `z.im` to `w.im`. -/
+noncomputable def rightIntegral (f : ℂ → ℂ) (z w : ℂ) : ℂ :=
+  ∫ y : ℝ in z.im..w.im, f (w.re + y * I)
+
+/-- Left vertical side, parameterized upward from `z.im` to `w.im`.
+It appears with a minus sign in the positive boundary. -/
+noncomputable def leftIntegral (f : ℂ → ℂ) (z w : ℂ) : ℂ :=
+  ∫ y : ℝ in z.im..w.im, f (z.re + y * I)
+
+/-- Positively oriented rectangle boundary integral in side-integral form. -/
+noncomputable def rectBoundary (f : ℂ → ℂ) (z w : ℂ) : ℂ :=
+  bottomIntegral f z w - topIntegral f z w +
+    I * rightIntegral f z w - I * leftIntegral f z w
+
+/--
+Mathlib's rectangle Cauchy-Goursat theorem in LeanCert's named-side notation.
+-/
+theorem rectBoundary_eq_zero_of_continuousOn_of_differentiableOn
+    (f : ℂ → ℂ) (z w : ℂ)
+    (Hc : ContinuousOn f (Set.uIcc z.re w.re ×ℂ Set.uIcc z.im w.im))
+    (Hd : DifferentiableOn ℂ f
+      (Set.Ioo (min z.re w.re) (max z.re w.re) ×ℂ
+        Set.Ioo (min z.im w.im) (max z.im w.im))) :
+    rectBoundary f z w = 0 := by
+  simpa [rectBoundary, bottomIntegral, topIntegral, rightIntegral, leftIntegral]
+    using Complex.integral_boundary_rect_eq_zero_of_continuousOn_of_differentiableOn
+      f z w Hc Hd
+
+/--
+A boundary identity certificate for one rectangle.
+
+The residue side is deliberately supplied as data.  This lets contour-shift
+users prove or import residue identities separately, while the shift algebra and
+orientation bookkeeping are centralized here.
+-/
+structure VerticalShiftCert where
+  f : ℂ → ℂ
+  z : ℂ
+  w : ℂ
+  residueSum : ℂ
+  boundary_eq :
+    rectBoundary f z w = (2 * Real.pi * I) * residueSum
+
+namespace VerticalShiftCert
+
+/-- Algebraic vertical-shift identity induced by the boundary certificate. -/
+theorem vertical_shift (C : VerticalShiftCert) :
+    I * rightIntegral C.f C.z C.w =
+      I * leftIntegral C.f C.z C.w +
+        (2 * Real.pi * I) * C.residueSum -
+          bottomIntegral C.f C.z C.w +
+            topIntegral C.f C.z C.w := by
+  have h := C.boundary_eq
+  unfold rectBoundary at h
+  rw [← h]
+  ring
+
+/-- Holomorphic rectangle certificates have zero residue side. -/
+def ofHolomorphicRectangle
+    (f : ℂ → ℂ) (z w : ℂ)
+    (Hc : ContinuousOn f (Set.uIcc z.re w.re ×ℂ Set.uIcc z.im w.im))
+    (Hd : DifferentiableOn ℂ f
+      (Set.Ioo (min z.re w.re) (max z.re w.re) ×ℂ
+        Set.Ioo (min z.im w.im) (max z.im w.im))) :
+    VerticalShiftCert where
+  f := f
+  z := z
+  w := w
+  residueSum := 0
+  boundary_eq := by
+    simpa using rectBoundary_eq_zero_of_continuousOn_of_differentiableOn f z w Hc Hd
+
+end VerticalShiftCert
+
+/-! ## Shift-oriented finite and infinite certificates -/
+
+/--
+Vertical-line integral over the symmetric segment `[-T, T]`, oriented upward.
+-/
+noncomputable def verticalIntegral (F : ℂ → ℂ) (σ : ℝ) (T : ℝ) : ℂ :=
+  ∫ t : ℝ in (-T)..T, F (σ + t * I) * I
+
+/-- Top horizontal side from `σ₀ + T i` to `σ₁ + T i`. -/
+noncomputable def topHorizontalIntegral (F : ℂ → ℂ) (σ₀ σ₁ T : ℝ) : ℂ :=
+  ∫ x : ℝ in σ₀..σ₁, F (x + T * I)
+
+/-- Bottom horizontal side from `σ₁ - T i` to `σ₀ - T i`. -/
+noncomputable def bottomHorizontalIntegral (F : ℂ → ℂ) (σ₀ σ₁ T : ℝ) : ℂ :=
+  ∫ x : ℝ in σ₁..σ₀, F (x - T * I)
+
+/-- Finite pole data in a vertical strip. -/
+structure StripPoleCert (F : ℂ → ℂ) (σ₀ σ₁ : ℝ) where
+  poles : Finset ℂ
+  in_strip : ∀ ρ ∈ poles, σ₀ < ρ.re ∧ ρ.re < σ₁
+  residue : ℂ → ℂ
+
+/-- Sum of finite residue data. -/
+noncomputable def stripResidueSum {F : ℂ → ℂ} {σ₀ σ₁ : ℝ}
+    (P : StripPoleCert F σ₀ σ₁) : ℂ :=
+  ∑ ρ ∈ P.poles, P.residue ρ
+
+/--
+Finite rectangle shift certificate.
+
+This structure intentionally stores the finite rectangle identity as data.  A
+future residue-theorem constructor can produce this field, while the rest of the
+contour-shift engine can already use it.
+-/
+structure RectangleShiftCert (F : ℂ → ℂ) (σ₀ σ₁ T : ℝ) where
+  poles : Finset ℂ
+  residue : ℂ → ℂ
+  rectangle_identity :
+    verticalIntegral F σ₀ T =
+      verticalIntegral F σ₁ T -
+        topHorizontalIntegral F σ₀ σ₁ T -
+          bottomHorizontalIntegral F σ₀ σ₁ T +
+            (2 * Real.pi * I) * ∑ ρ ∈ poles, residue ρ
+
+namespace RectangleShiftCert
+
+/-- Residue sum for a finite rectangle certificate. -/
+noncomputable def residueSum {F : ℂ → ℂ} {σ₀ σ₁ T : ℝ}
+    (C : RectangleShiftCert F σ₀ σ₁ T) : ℂ :=
+  ∑ ρ ∈ C.poles, C.residue ρ
+
+end RectangleShiftCert
+
+/-- Horizontal sides vanish along a height sequence. -/
+structure HorizontalVanishCert
+    (F : ℂ → ℂ) (σ₀ σ₁ : ℝ) (T : ℕ → ℝ) where
+  top_vanish :
+    Tendsto (fun n => topHorizontalIntegral F σ₀ σ₁ (T n)) atTop (𝓝 0)
+  bottom_vanish :
+    Tendsto (fun n => bottomHorizontalIntegral F σ₀ σ₁ (T n)) atTop (𝓝 0)
+
+/--
+Horizontal vanishing from explicit norm bounds.
+
+The conversion theorem is kept separate so users can either provide direct
+vanishing or prove it by bounding both horizontal sides.
+-/
+structure HorizontalBoundCert
+    (F : ℂ → ℂ) (σ₀ σ₁ : ℝ) (T : ℕ → ℝ) where
+  bound : ℕ → ℝ
+  bound_nonneg : ∀ n, 0 ≤ bound n
+  bound_tendsto_zero : Tendsto bound atTop (𝓝 0)
+  top_norm_le :
+    ∀ n, ‖topHorizontalIntegral F σ₀ σ₁ (T n)‖ ≤ bound n
+  bottom_norm_le :
+    ∀ n, ‖bottomHorizontalIntegral F σ₀ σ₁ (T n)‖ ≤ bound n
+
+namespace HorizontalBoundCert
+
+/-- Norm-bound horizontal certificate implies horizontal vanishing. -/
+theorem toVanishCert {F : ℂ → ℂ} {σ₀ σ₁ : ℝ} {T : ℕ → ℝ}
+    (B : HorizontalBoundCert F σ₀ σ₁ T) :
+    HorizontalVanishCert F σ₀ σ₁ T where
+  top_vanish := by
+    rw [tendsto_zero_iff_norm_tendsto_zero]
+    exact squeeze_zero (fun n => norm_nonneg _)
+      (fun n => B.top_norm_le n) B.bound_tendsto_zero
+  bottom_vanish := by
+    rw [tendsto_zero_iff_norm_tendsto_zero]
+    exact squeeze_zero (fun n => norm_nonneg _)
+      (fun n => B.bottom_norm_le n) B.bound_tendsto_zero
+
+end HorizontalBoundCert
+
+/--
+Infinite contour-shift certificate.
+
+This is the main reusable certificate object: finite rectangle identities are
+provided for each height, horizontal sides vanish, vertical sides converge, and
+finite pole data is stable across the sequence.
+-/
+structure ContourShiftCert (F : ℂ → ℂ) (σ₀ σ₁ : ℝ) where
+  T : ℕ → ℝ
+  hT_pos : ∀ n, 0 < T n
+  hT_tendsto : Tendsto T atTop atTop
+  poles : Finset ℂ
+  residue : ℂ → ℂ
+  rectCert : ∀ n, RectangleShiftCert F σ₀ σ₁ (T n)
+  same_poles : ∀ n, (rectCert n).poles = poles
+  same_residue : ∀ n ρ, (rectCert n).residue ρ = residue ρ
+  left_limit :
+    ∃ L₀ : ℂ, Tendsto (fun n => verticalIntegral F σ₀ (T n)) atTop (𝓝 L₀)
+  right_limit :
+    ∃ L₁ : ℂ, Tendsto (fun n => verticalIntegral F σ₁ (T n)) atTop (𝓝 L₁)
+  horizontal : HorizontalVanishCert F σ₀ σ₁ T
+
+namespace ContourShiftCert
+
+/-- Chosen left vertical limit. -/
+noncomputable def leftValue {F : ℂ → ℂ} {σ₀ σ₁ : ℝ}
+    (C : ContourShiftCert F σ₀ σ₁) : ℂ :=
+  Classical.choose C.left_limit
+
+/-- Chosen right vertical limit. -/
+noncomputable def rightValue {F : ℂ → ℂ} {σ₀ σ₁ : ℝ}
+    (C : ContourShiftCert F σ₀ σ₁) : ℂ :=
+  Classical.choose C.right_limit
+
+/-- Stable finite residue sum for an infinite shift certificate. -/
+noncomputable def residueSum {F : ℂ → ℂ} {σ₀ σ₁ : ℝ}
+    (C : ContourShiftCert F σ₀ σ₁) : ℂ :=
+  ∑ ρ ∈ C.poles, C.residue ρ
+
+private theorem rectangle_identity_stable {F : ℂ → ℂ} {σ₀ σ₁ : ℝ}
+    (C : ContourShiftCert F σ₀ σ₁) (n : ℕ) :
+    verticalIntegral F σ₀ (C.T n) =
+      verticalIntegral F σ₁ (C.T n) -
+        topHorizontalIntegral F σ₀ σ₁ (C.T n) -
+          bottomHorizontalIntegral F σ₀ σ₁ (C.T n) +
+            (2 * Real.pi * I) * C.residueSum := by
+  have h := (C.rectCert n).rectangle_identity
+  have hsum :
+      ∑ ρ ∈ (C.rectCert n).poles, (C.rectCert n).residue ρ =
+        ∑ ρ ∈ C.poles, C.residue ρ := by
+    rw [C.same_poles n]
+    exact Finset.sum_congr rfl (fun ρ hρ => C.same_residue n ρ)
+  simpa [ContourShiftCert.residueSum, hsum] using h
+
+/-- Limit-passing contour-shift identity, existential-limit form. -/
+theorem shift_identity {F : ℂ → ℂ} {σ₀ σ₁ : ℝ}
+    (C : ContourShiftCert F σ₀ σ₁) :
+    ∃ L₀ L₁ : ℂ,
+      Tendsto (fun n => verticalIntegral F σ₀ (C.T n)) atTop (𝓝 L₀) ∧
+      Tendsto (fun n => verticalIntegral F σ₁ (C.T n)) atTop (𝓝 L₁) ∧
+      L₀ = L₁ + (2 * Real.pi * I) * C.residueSum := by
+  rcases C.left_limit with ⟨L₀, hL₀⟩
+  rcases C.right_limit with ⟨L₁, hL₁⟩
+  refine ⟨L₀, L₁, hL₀, hL₁, ?_⟩
+  let R : ℂ := (2 * Real.pi * I) * C.residueSum
+  have hRhs :
+      Tendsto
+        (fun n =>
+          verticalIntegral F σ₁ (C.T n) -
+            topHorizontalIntegral F σ₀ σ₁ (C.T n) -
+              bottomHorizontalIntegral F σ₀ σ₁ (C.T n) + R)
+        atTop (𝓝 (L₁ - 0 - 0 + R)) :=
+    ((hL₁.sub C.horizontal.top_vanish).sub C.horizontal.bottom_vanish).add
+      tendsto_const_nhds
+  have hRhs' :
+      Tendsto
+        (fun n =>
+          verticalIntegral F σ₁ (C.T n) -
+            topHorizontalIntegral F σ₀ σ₁ (C.T n) -
+              bottomHorizontalIntegral F σ₀ σ₁ (C.T n) + R)
+        atTop (𝓝 (L₁ + R)) := by
+    simpa using hRhs
+  have hfun :
+      (fun n => verticalIntegral F σ₀ (C.T n)) =
+        fun n =>
+          verticalIntegral F σ₁ (C.T n) -
+            topHorizontalIntegral F σ₀ σ₁ (C.T n) -
+              bottomHorizontalIntegral F σ₀ σ₁ (C.T n) + R := by
+    funext n
+    simpa [R] using rectangle_identity_stable C n
+  have hLeftToR : Tendsto (fun n => verticalIntegral F σ₀ (C.T n)) atTop
+      (𝓝 (L₁ + R)) := by
+    rw [hfun]
+    exact hRhs'
+  have huniq := tendsto_nhds_unique hL₀ hLeftToR
+  simpa [R] using huniq
+
+/-- Limit-passing contour-shift identity using chosen limit accessors. -/
+theorem shift_identity' {F : ℂ → ℂ} {σ₀ σ₁ : ℝ}
+    (C : ContourShiftCert F σ₀ σ₁) :
+    C.leftValue = C.rightValue + (2 * Real.pi * I) * C.residueSum := by
+  have hL₀ := Classical.choose_spec C.left_limit
+  have hL₁ := Classical.choose_spec C.right_limit
+  rcases C.shift_identity with ⟨L₀, L₁, h0, h1, hEq⟩
+  have hLeft : C.leftValue = L₀ := tendsto_nhds_unique hL₀ h0
+  have hRight : C.rightValue = L₁ := tendsto_nhds_unique hL₁ h1
+  rw [hLeft, hRight]
+  exact hEq
+
+end ContourShiftCert
+
+end LeanCert.Analysis.ContourShift

--- a/LeanCert/ConstantFactory.lean
+++ b/LeanCert/ConstantFactory.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.QProduct
+
+/-!
+# ConstantFactory
+
+Finite observer certificates for q-product constants.
+
+The first layer reuses the exact `QProduct` moment checker.  A base exponent set
+`R` supplies the kernel bank
+
+`moment R m = ∫ u in 0..1, qProd R u * u^m`,
+
+and a finite perturbation set `Q` supplies signed subset-sum coefficients.  The
+main theorem says that, when `R` and `Q` are disjoint, the product integral for
+`R ∪ Q` is exactly the finite observer sum over moments of `R`.
+-/
+
+namespace LeanCert.ConstantFactory
+
+open scoped BigOperators
+open LeanCert.QProduct
+
+/-- Exact rational observer sum for the perturbation `Q` around a base `R`. -/
+def observerIntegralRat (R Q : Finset Nat) : ℚ :=
+  ∑ A ∈ Q.powerset, subsetSign A * momentRat R (subsetWeight A)
+
+/-- Real observer sum, useful as the semantic bridge before using exact rationals. -/
+noncomputable def observerIntegral (R Q : Finset Nat) : ℝ :=
+  ∑ A ∈ Q.powerset, (subsetSign A : ℝ) * moment R (subsetWeight A)
+
+/-- Exact observer sum computes the semantic observer sum. -/
+theorem observerIntegralRat_correct (R Q : Finset Nat) :
+    (observerIntegralRat R Q : ℝ) = observerIntegral R Q := by
+  classical
+  unfold observerIntegralRat observerIntegral
+  simp_rw [Rat.cast_sum, Rat.cast_mul, momentRat_correct]
+
+private theorem continuous_qProd (S : Finset Nat) :
+    Continuous fun u : ℝ => qProd S u := by
+  classical
+  refine Finset.induction_on S ?empty ?insert
+  · simpa [qProd] using (continuous_const : Continuous fun _ : ℝ => (1 : ℝ))
+  · intro n S hn hS
+    have hfactor : Continuous fun u : ℝ => 1 - u ^ n :=
+      continuous_const.sub (continuous_id.pow n)
+    simpa [qProd, hn] using hfactor.mul hS
+
+/-- Observer algebra identity at the integrand level. -/
+theorem qProd_union_eq_observer_sum (R Q : Finset Nat) (hdisj : Disjoint R Q)
+    (u : ℝ) :
+    qProd (R ∪ Q) u =
+      ∑ A ∈ Q.powerset,
+        (subsetSign A : ℝ) * (qProd R u * u ^ subsetWeight A) := by
+  classical
+  rw [qProd, Finset.prod_union hdisj]
+  change qProd R u * qProd Q u =
+    ∑ A ∈ Q.powerset,
+      (subsetSign A : ℝ) * (qProd R u * u ^ subsetWeight A)
+  rw [qProd_powerset_expand Q u]
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro A hA
+  ring
+
+/--
+Semantic ConstantFactory identity.
+
+After the base kernel `R` is known, every disjoint finite perturbation `Q`
+reduces to a finite signed sum of moments of `R`.
+-/
+theorem F_union_eq_observerIntegral (R Q : Finset Nat) (hdisj : Disjoint R Q) :
+    F (R ∪ Q) = observerIntegral R Q := by
+  classical
+  unfold F observerIntegral moment
+  simp_rw [qProd_union_eq_observer_sum R Q hdisj]
+  rw [intervalIntegral.integral_finsetSum]
+  · apply Finset.sum_congr rfl
+    intro A hA
+    rw [intervalIntegral.integral_const_mul]
+  · intro A hA
+    have hcont :
+        Continuous fun u : ℝ =>
+          (subsetSign A : ℝ) * (qProd R u * u ^ subsetWeight A) :=
+      continuous_const.mul
+        ((continuous_qProd R).mul (continuous_id.pow (subsetWeight A)))
+    exact hcont.intervalIntegrable 0 1
+
+/-- Exact rational ConstantFactory identity. -/
+theorem observerIntegralRat_eq_F_union (R Q : Finset Nat) (hdisj : Disjoint R Q) :
+    (observerIntegralRat R Q : ℝ) = F (R ∪ Q) := by
+  rw [observerIntegralRat_correct, ← F_union_eq_observerIntegral R Q hdisj]
+
+/-- Exact interval checker for a ConstantFactory observer certificate. -/
+def checkConstantFactoryInterval (R Q : Finset Nat) (lo hi : ℚ) : Bool :=
+  decide (Disjoint R Q ∧
+    lo ≤ observerIntegralRat R Q ∧
+      observerIntegralRat R Q ≤ hi)
+
+/-- Golden theorem for exact ConstantFactory interval certificates. -/
+theorem verify_constantFactory_interval (R Q : Finset Nat) (lo hi : ℚ)
+    (hcheck : checkConstantFactoryInterval R Q lo hi = true) :
+    (lo : ℝ) ≤ F (R ∪ Q) ∧ F (R ∪ Q) ≤ (hi : ℝ) := by
+  simp only [checkConstantFactoryInterval, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨hdisj, hlo, hhi⟩
+  rw [← observerIntegralRat_eq_F_union R Q hdisj]
+  exact ⟨by exact_mod_cast hlo, by exact_mod_cast hhi⟩
+
+/-- Exact upper-bound checker for a ConstantFactory observer certificate. -/
+def checkConstantFactoryUpper (R Q : Finset Nat) (hi : ℚ) : Bool :=
+  decide (Disjoint R Q ∧ observerIntegralRat R Q ≤ hi)
+
+/-- Exact lower-bound checker for a ConstantFactory observer certificate. -/
+def checkConstantFactoryLower (R Q : Finset Nat) (lo : ℚ) : Bool :=
+  decide (Disjoint R Q ∧ lo ≤ observerIntegralRat R Q)
+
+/-- Golden theorem for exact ConstantFactory upper-bound certificates. -/
+theorem verify_constantFactory_upper (R Q : Finset Nat) (hi : ℚ)
+    (hcheck : checkConstantFactoryUpper R Q hi = true) :
+    F (R ∪ Q) ≤ (hi : ℝ) := by
+  simp only [checkConstantFactoryUpper, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨hdisj, hhi⟩
+  rw [← observerIntegralRat_eq_F_union R Q hdisj]
+  exact_mod_cast hhi
+
+/-- Golden theorem for exact ConstantFactory lower-bound certificates. -/
+theorem verify_constantFactory_lower (R Q : Finset Nat) (lo : ℚ)
+    (hcheck : checkConstantFactoryLower R Q lo = true) :
+    (lo : ℝ) ≤ F (R ∪ Q) := by
+  simp only [checkConstantFactoryLower, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨hdisj, hlo⟩
+  rw [← observerIntegralRat_eq_F_union R Q hdisj]
+  exact_mod_cast hlo
+
+end LeanCert.ConstantFactory

--- a/LeanCert/ConstantFactory/IntervalBank.lean
+++ b/LeanCert/ConstantFactory/IntervalBank.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.ConstantFactory
+import LeanCert.Engine.Integrate
+
+/-!
+# Interval Kernel Banks for ConstantFactory
+
+This module adds the interval analogue of the exact ConstantFactory observer
+identity.  A `KernelIntervalBank R` supplies certified intervals for the base
+moments `moment R m`; a finite perturbation `Q` is then checked by summing the
+signed scaled kernel intervals.
+
+The first implementation follows the existing powerset observer representation:
+
+`F (R ∪ Q) = ∑ A ∈ Q.powerset, subsetSign A * moment R (subsetWeight A)`.
+
+Coefficient-compressed perturbation polynomials can be layered on top later.
+-/
+
+namespace LeanCert.ConstantFactory
+
+open LeanCert.Core
+open LeanCert.QProduct
+open LeanCert.Engine
+
+/-- Certified interval enclosures for all monomial moments of a base profile `R`. -/
+structure KernelIntervalBank (R : Finset Nat) where
+  /-- Interval enclosure for `moment R m`. -/
+  interval : Nat → IntervalRat
+  /-- Soundness of each interval enclosure. -/
+  correct : ∀ m, moment R m ∈ interval m
+
+/-- Semantic contribution of one perturbation subset. -/
+noncomputable def observerTerm (R : Finset Nat) (A : Finset Nat) : ℝ :=
+  (subsetSign A : ℝ) * moment R (subsetWeight A)
+
+/-- Interval contribution of one perturbation subset. -/
+def observerIntervalTerm {R : Finset Nat} (bank : KernelIntervalBank R)
+    (A : Finset Nat) : IntervalRat :=
+  IntervalRat.scale (subsetSign A) (bank.interval (subsetWeight A))
+
+/-- Semantic observer sum over an explicit subset list. -/
+noncomputable def observerIntegralList (R : Finset Nat) (terms : List (Finset Nat)) : ℝ :=
+  (terms.map (observerTerm R)).sum
+
+/-- Interval observer sum over an explicit subset list. -/
+def observerIntervalList {R : Finset Nat} (bank : KernelIntervalBank R) :
+    List (Finset Nat) → IntervalRat
+  | [] => IntervalRat.singleton 0
+  | A :: rest => IntervalRat.add (observerIntervalTerm bank A) (observerIntervalList bank rest)
+
+/-- Interval observer certificate for perturbation `Q`, using the existing powerset basis. -/
+noncomputable def observerInterval {R : Finset Nat} (Q : Finset Nat) (bank : KernelIntervalBank R) :
+    IntervalRat :=
+  observerIntervalList bank Q.powerset.toList
+
+theorem observerTerm_mem_interval {R : Finset Nat} (bank : KernelIntervalBank R)
+    (A : Finset Nat) :
+    observerTerm R A ∈ observerIntervalTerm bank A := by
+  unfold observerTerm observerIntervalTerm
+  exact IntervalRat.mem_scale (subsetSign A) (bank.correct (subsetWeight A))
+
+/-- List-level interval observer soundness. -/
+theorem observerIntegralList_mem_observerIntervalList {R : Finset Nat}
+    (bank : KernelIntervalBank R) :
+    ∀ terms, observerIntegralList R terms ∈ observerIntervalList bank terms
+  | [] => by
+      simpa [observerIntegralList, observerIntervalList] using
+        (IntervalRat.mem_singleton (0 : ℚ))
+  | A :: rest => by
+      simp only [observerIntegralList, observerIntervalList, List.map_cons, List.sum_cons]
+      exact IntervalRat.mem_add (observerTerm_mem_interval bank A)
+        (observerIntegralList_mem_observerIntervalList bank rest)
+
+theorem observerIntegralList_powerset_eq (R Q : Finset Nat) :
+    observerIntegralList R Q.powerset.toList = observerIntegral R Q := by
+  classical
+  simp [observerIntegralList, observerIntegral, observerTerm]
+
+/--
+Interval ConstantFactory identity.
+
+If a bank encloses every base moment of `R`, then the product integral for every
+disjoint finite perturbation `Q` lies in the signed interval observer sum.
+-/
+theorem F_union_mem_observerInterval {R Q : Finset Nat} (hdisj : Disjoint R Q)
+    (bank : KernelIntervalBank R) :
+    F (R ∪ Q) ∈ observerInterval Q bank := by
+  rw [F_union_eq_observerIntegral R Q hdisj]
+  rw [← observerIntegralList_powerset_eq R Q]
+  exact observerIntegralList_mem_observerIntervalList bank Q.powerset.toList
+
+/-- Exact rational moments as a degenerate interval bank. -/
+def exactKernelIntervalBank (R : Finset Nat) : KernelIntervalBank R where
+  interval m := IntervalRat.singleton (momentRat R m)
+  correct m := by
+    rw [← momentRat_correct R m]
+    exact IntervalRat.mem_singleton (momentRat R m)
+
+end LeanCert.ConstantFactory

--- a/LeanCert/Engine/TaylorModel.lean
+++ b/LeanCert/Engine/TaylorModel.lean
@@ -6,6 +6,7 @@ Authors: LeanCert Contributors
 import LeanCert.Engine.TaylorModel.Core
 import LeanCert.Engine.TaylorModel.Functions
 import LeanCert.Engine.TaylorModel.Expr
+import LeanCert.Engine.TaylorModel.Integral
 
 /-!
 # Taylor Models
@@ -15,4 +16,5 @@ This file re-exports all Taylor model functionality. The implementation is split
 * `TaylorModel.Core` - Core data structure, polynomial helpers, basic operations
 * `TaylorModel.Functions` - Function-specific Taylor series (sin, cos, exp, etc.)
 * `TaylorModel.Expr` - Composition operations and expression integration
+* `TaylorModel.Integral` - Definite-integral enclosures from Taylor-model bounds
 -/

--- a/LeanCert/Engine/TaylorModel/Integral.lean
+++ b/LeanCert/Engine/TaylorModel/Integral.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.Engine.TaylorModel.Core
+import LeanCert.Engine.Integrate
+
+/-!
+# Taylor Model Integration
+
+This module connects Taylor-model pointwise enclosures to certified interval
+enclosures for definite integrals.
+
+The first bridge is deliberately conservative: it integrates the global
+Taylor-model range bound over the domain.  This is enough to certify interval
+kernel banks and constant-factory observers today.  Tighter polynomial-exact
+Taylor integration can be layered on top without changing this API.
+
+The second bridge is the polynomial-exact enclosure shape used by certified
+quadrature: if the integral of the Taylor polynomial is known exactly, the
+only interval over-approximation comes from integrating the remainder interval.
+-/
+
+namespace LeanCert.Engine
+
+open LeanCert.Core
+open MeasureTheory
+open scoped ENNReal
+
+namespace TaylorModel
+
+/--
+Exact rational formula for integrating a shifted polynomial over `[a,b]`.
+
+This is the computational primitive for polynomial-exact Taylor quadrature:
+
+`∫ x in a..b, p(x-c) dx =
+  Σ_i p_i ((b-c)^(i+1) - (a-c)^(i+1))/(i+1)`.
+-/
+noncomputable def integrateShiftedPoly (p : Polynomial ℚ) (a b c : ℚ) : ℚ :=
+  ∑ i ∈ Finset.range (p.natDegree + 1),
+    p.coeff i *
+      (((b - c) ^ (i + 1) - (a - c) ^ (i + 1)) / (i + 1 : ℚ))
+
+/--
+Polynomial-exact integral enclosure for a Taylor model over its own domain.
+
+The polynomial part is integrated exactly by `integrateShiftedPoly`; the
+remainder interval is scaled by the domain width.
+-/
+noncomputable def integralBoundPolyExact (tm : TaylorModel) : IntervalRat :=
+  IntervalRat.add
+    (IntervalRat.singleton
+      (integrateShiftedPoly tm.poly tm.domain.lo tm.domain.hi tm.center))
+    (IntervalRat.scale tm.domain.width tm.remainder)
+
+/--
+Coarse integral enclosure for a Taylor model over its own domain.
+
+If `tm.bound = [lo, hi]` contains all values of `f` on `tm.domain`, this interval
+is `[width * lo, width * hi]`, expressed through the standard interval product.
+-/
+noncomputable def integralBoundCoarse (tm : TaylorModel) : IntervalRat :=
+  IntervalRat.mul (IntervalRat.singleton tm.domain.width) tm.bound
+
+/--
+Soundness of the coarse Taylor-model integral bound.
+
+This theorem is intentionally phrased in terms of the Taylor-model semantic
+predicate `evalSet`, so any Taylor-model construction that proves
+`∀ x ∈ tm.domain, f x ∈ tm.evalSet x` can immediately produce an integral
+certificate.
+-/
+theorem integral_mem_bound_coarse (tm : TaylorModel) (f : ℝ → ℝ)
+    (hf : ∀ x ∈ tm.domain, f x ∈ tm.evalSet x)
+    (hInt : IntervalIntegrable f volume tm.domain.lo tm.domain.hi) :
+    ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x ∈
+      integralBoundCoarse tm := by
+  unfold integralBoundCoarse
+  set fBound := tm.bound with hfBound_def
+  have hbounds : ∀ x : ℝ, x ∈ tm.domain → f x ∈ fBound := by
+    intro x hx
+    simpa [hfBound_def] using (taylorModel_correct tm f hf x hx)
+  have hlo : ∀ x ∈ Set.Icc (tm.domain.lo : ℝ) (tm.domain.hi : ℝ),
+      (fBound.lo : ℝ) ≤ f x := by
+    intro x hx
+    exact (hbounds x hx).1
+  have hhi : ∀ x ∈ Set.Icc (tm.domain.lo : ℝ) (tm.domain.hi : ℝ),
+      f x ≤ (fBound.hi : ℝ) := by
+    intro x hx
+    exact (hbounds x hx).2
+  have hIle : (tm.domain.lo : ℝ) ≤ tm.domain.hi := by
+    exact_mod_cast tm.domain.le
+  have ⟨h_lower, h_upper⟩ := integral_bounds_of_bounds hIle hInt hlo hhi
+  have hwidth : (tm.domain.width : ℝ) =
+      (tm.domain.hi : ℝ) - tm.domain.lo := by
+    simp only [IntervalRat.width, Rat.cast_sub]
+  have hwidth_nn : (0 : ℝ) ≤ tm.domain.width := by
+    exact_mod_cast IntervalRat.width_nonneg tm.domain
+  have hfBound_le : (fBound.lo : ℝ) ≤ fBound.hi := by
+    exact_mod_cast fBound.le
+  have h_lo' : (tm.domain.width : ℝ) * fBound.lo ≤
+      ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x := by
+    calc (tm.domain.width : ℝ) * fBound.lo = fBound.lo * tm.domain.width := by ring
+       _ = fBound.lo * ((tm.domain.hi : ℝ) - tm.domain.lo) := by rw [hwidth]
+       _ ≤ ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x := h_lower
+  have h_hi' : ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x ≤
+      (tm.domain.width : ℝ) * fBound.hi := by
+    calc ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x
+       ≤ fBound.hi * ((tm.domain.hi : ℝ) - tm.domain.lo) := h_upper
+     _ = fBound.hi * tm.domain.width := by rw [hwidth]
+     _ = (tm.domain.width : ℝ) * fBound.hi := by ring
+  have hcorners : (tm.domain.width : ℝ) * fBound.lo ≤
+      tm.domain.width * fBound.hi :=
+    mul_le_mul_of_nonneg_left hfBound_le hwidth_nn
+  rw [IntervalRat.mem_def]
+  constructor
+  · have hcorner : (IntervalRat.mul (IntervalRat.singleton tm.domain.width) fBound).lo =
+        min (min (tm.domain.width * fBound.lo) (tm.domain.width * fBound.hi))
+            (min (tm.domain.width * fBound.lo) (tm.domain.width * fBound.hi)) := rfl
+    simp only [hcorner, min_self, Rat.cast_min, Rat.cast_mul]
+    calc (↑tm.domain.width * ↑fBound.lo) ⊓ (↑tm.domain.width * ↑fBound.hi)
+        = ↑tm.domain.width * ↑fBound.lo := min_eq_left hcorners
+      _ ≤ ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x := h_lo'
+  · have hcorner : (IntervalRat.mul (IntervalRat.singleton tm.domain.width) fBound).hi =
+        max (max (tm.domain.width * fBound.lo) (tm.domain.width * fBound.hi))
+            (max (tm.domain.width * fBound.lo) (tm.domain.width * fBound.hi)) := rfl
+    simp only [hcorner, max_self, Rat.cast_max, Rat.cast_mul]
+    calc ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x
+        ≤ ↑tm.domain.width * ↑fBound.hi := h_hi'
+      _ = (↑tm.domain.width * ↑fBound.lo) ⊔ (↑tm.domain.width * ↑fBound.hi) :=
+          (max_eq_right hcorners).symm
+
+/--
+Soundness of the polynomial-exact Taylor-model integral bound, assuming the
+Taylor polynomial integral has been identified with `integrateShiftedPoly`.
+
+The assumption `hPolyIntegral` is intentionally explicit: the reusable numeric
+soundness theorem here is the interval/remainder part of Taylor quadrature,
+while callers may discharge the polynomial antiderivative equality using the
+best local polynomial API available for their representation.
+-/
+theorem integral_mem_bound_polyExact_of_poly_integral (tm : TaylorModel) (f : ℝ → ℝ)
+    (hf : ∀ x ∈ tm.domain, f x ∈ tm.evalSet x)
+    (hInt : IntervalIntegrable f volume (tm.domain.lo : ℝ) (tm.domain.hi : ℝ))
+    (hPolyInt : IntervalIntegrable tm.evalPoly volume
+      (tm.domain.lo : ℝ) (tm.domain.hi : ℝ))
+    (hPolyIntegral :
+      ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), tm.evalPoly x =
+        (integrateShiftedPoly tm.poly tm.domain.lo tm.domain.hi tm.center : ℝ)) :
+    ∫ x in (tm.domain.lo : ℝ)..(tm.domain.hi : ℝ), f x ∈
+      integralBoundPolyExact tm := by
+  unfold integralBoundPolyExact
+  set a : ℝ := (tm.domain.lo : ℝ)
+  set b : ℝ := (tm.domain.hi : ℝ)
+  set pInt : ℚ := integrateShiftedPoly tm.poly tm.domain.lo tm.domain.hi tm.center
+  have hab : a ≤ b := by
+    dsimp [a, b]
+    exact_mod_cast tm.domain.le
+  have hwidth : (tm.domain.width : ℝ) = b - a := by
+    dsimp [a, b]
+    simp only [IntervalRat.width, Rat.cast_sub]
+  have hpoly_lower : IntervalIntegrable
+      (fun x => tm.evalPoly x + (tm.remainder.lo : ℝ)) volume a b := by
+    dsimp [a, b]
+    exact hPolyInt.add (Continuous.intervalIntegrable continuous_const _ _)
+  have hpoly_upper : IntervalIntegrable
+      (fun x => tm.evalPoly x + (tm.remainder.hi : ℝ)) volume a b := by
+    dsimp [a, b]
+    exact hPolyInt.add (Continuous.intervalIntegrable continuous_const _ _)
+  have hrem_bounds : ∀ x ∈ Set.Icc a b,
+      tm.evalPoly x + (tm.remainder.lo : ℝ) ≤ f x ∧
+        f x ≤ tm.evalPoly x + (tm.remainder.hi : ℝ) := by
+    intro x hx
+    have hxDomain : x ∈ tm.domain := by
+      simpa [a, b] using hx
+    rcases hf x hxDomain with ⟨r, hr, hfx⟩
+    rw [hfx]
+    simp only [TaylorModel.evalPoly]
+    have hrl : (tm.remainder.lo : ℝ) ≤ r := hr.1
+    have hrh : r ≤ (tm.remainder.hi : ℝ) := hr.2
+    constructor <;> linarith
+  have h_lower_int :
+      ∫ x in a..b, tm.evalPoly x + (tm.remainder.lo : ℝ) ≤
+        ∫ x in a..b, f x := by
+    exact intervalIntegral.integral_mono_on hab hpoly_lower
+      (by simpa [a, b] using hInt) (fun x hx => (hrem_bounds x hx).1)
+  have h_upper_int :
+      ∫ x in a..b, f x ≤
+        ∫ x in a..b, tm.evalPoly x + (tm.remainder.hi : ℝ) := by
+    exact intervalIntegral.integral_mono_on hab
+      (by simpa [a, b] using hInt) hpoly_upper (fun x hx => (hrem_bounds x hx).2)
+  have hpoly_lower_eval :
+      ∫ x in a..b, tm.evalPoly x + (tm.remainder.lo : ℝ) =
+        (pInt : ℝ) + (b - a) * tm.remainder.lo := by
+    dsimp [a, b, pInt]
+    rw [intervalIntegral.integral_add hPolyInt
+      (Continuous.intervalIntegrable continuous_const _ _), hPolyIntegral]
+    simp [a, b, pInt, intervalIntegral.integral_const, mul_comm]
+  have hpoly_upper_eval :
+      ∫ x in a..b, tm.evalPoly x + (tm.remainder.hi : ℝ) =
+        (pInt : ℝ) + (b - a) * tm.remainder.hi := by
+    dsimp [a, b, pInt]
+    rw [intervalIntegral.integral_add hPolyInt
+      (Continuous.intervalIntegrable continuous_const _ _), hPolyIntegral]
+    simp [a, b, pInt, intervalIntegral.integral_const, mul_comm]
+  rw [IntervalRat.mem_def]
+  have hscale_lower :
+      ((IntervalRat.scale tm.domain.width tm.remainder).lo : ℝ) ≤
+        tm.domain.width * tm.remainder.lo := by
+    exact (IntervalRat.mem_scale tm.domain.width
+      (show (tm.remainder.lo : ℝ) ∈ tm.remainder from
+        ⟨by rfl, by exact_mod_cast tm.remainder.le⟩)).1
+  have hscale_upper :
+      (tm.domain.width : ℝ) * tm.remainder.hi ≤
+        (IntervalRat.scale tm.domain.width tm.remainder).hi := by
+    exact (IntervalRat.mem_scale tm.domain.width
+      (show (tm.remainder.hi : ℝ) ∈ tm.remainder from
+        ⟨by exact_mod_cast tm.remainder.le, by rfl⟩)).2
+  constructor
+  · simp only [IntervalRat.add, IntervalRat.singleton, Rat.cast_add]
+    calc
+      (pInt : ℝ) + (IntervalRat.scale tm.domain.width tm.remainder).lo
+          ≤ (pInt : ℝ) + tm.domain.width * tm.remainder.lo := by
+            gcongr
+      _ = (pInt : ℝ) + (b - a) * tm.remainder.lo := by rw [hwidth]
+      _ = ∫ x in a..b, tm.evalPoly x + (tm.remainder.lo : ℝ) := hpoly_lower_eval.symm
+      _ ≤ ∫ x in a..b, f x := h_lower_int
+  · simp only [IntervalRat.add, IntervalRat.singleton, Rat.cast_add]
+    calc
+      ∫ x in a..b, f x
+          ≤ ∫ x in a..b, tm.evalPoly x + (tm.remainder.hi : ℝ) := h_upper_int
+      _ = (pInt : ℝ) + (b - a) * tm.remainder.hi := hpoly_upper_eval
+      _ = (pInt : ℝ) + tm.domain.width * tm.remainder.hi := by rw [hwidth]
+      _ ≤ (pInt : ℝ) + (IntervalRat.scale tm.domain.width tm.remainder).hi := by
+            gcongr
+
+end TaylorModel
+end LeanCert.Engine

--- a/LeanCert/Examples.lean
+++ b/LeanCert/Examples.lean
@@ -8,6 +8,7 @@ import LeanCert.Examples.EdgeCases
 import LeanCert.Examples.NeuralNet
 import LeanCert.Examples.Showcase
 import LeanCert.Examples.Chebyshev
+import LeanCert.Examples.ConstantFactory
 import LeanCert.Examples.ANT.Basic
 import LeanCert.Examples.QProduct.Basic
 import LeanCert.Examples.QProduct.PrimeLambda

--- a/LeanCert/Examples/ConstantFactory.lean
+++ b/LeanCert/Examples/ConstantFactory.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+import LeanCert.ConstantFactory.IntervalBank
+
+/-!
+# ConstantFactory examples
+-/
+
+open LeanCert.ConstantFactory
+open LeanCert.QProduct
+
+example :
+    observerIntegralRat ({2} : Finset Nat) ({3} : Finset Nat) = 7 / 12 := by
+  native_decide
+
+example :
+    F ({2, 3} : Finset Nat) = ((7 / 12 : ℚ) : ℝ) := by
+  have h :
+      (observerIntegralRat ({2} : Finset Nat) ({3} : Finset Nat) : ℝ) =
+        F (({2} : Finset Nat) ∪ ({3} : Finset Nat)) := by
+    exact observerIntegralRat_eq_F_union ({2} : Finset Nat) ({3} : Finset Nat)
+      (by simp)
+  have hrat : observerIntegralRat ({2} : Finset Nat) ({3} : Finset Nat) = 7 / 12 := by
+    native_decide
+  have hset : (({2} : Finset Nat) ∪ ({3} : Finset Nat)) = ({2, 3} : Finset Nat) := by
+    ext n
+    simp
+  rw [← hset, ← h, hrat]
+
+example :
+    ((7 / 12 : ℚ) : ℝ) ≤ F (({2} : Finset Nat) ∪ ({3} : Finset Nat)) ∧
+      F (({2} : Finset Nat) ∪ ({3} : Finset Nat)) ≤ ((7 / 12 : ℚ) : ℝ) :=
+  verify_constantFactory_interval ({2} : Finset Nat) ({3} : Finset Nat)
+    (7 / 12) (7 / 12) (by native_decide)
+
+example :
+    F (({2} : Finset Nat) ∪ ({3} : Finset Nat)) ∈
+      observerInterval ({3} : Finset Nat)
+        (exactKernelIntervalBank ({2} : Finset Nat)) := by
+  exact F_union_mem_observerInterval (by simp)
+    (exactKernelIntervalBank ({2} : Finset Nat))

--- a/docs/certificates/ant-asymp.md
+++ b/docs/certificates/ant-asymp.md
@@ -191,6 +191,37 @@ verify_stieltjes_error_le_target_with_slab_tail_dyadic
 verify_hyperbola_error_le_target_with_slab_tail_dyadic
 ```
 
+## Slab And Table Inequality Certificates
+
+For explicit PNT estimates and generated numerical tables, the dyadic slab
+checker is packaged as a small certificate API:
+
+```lean
+SlabInequalityCert
+SlabInequalityCert.verify
+```
+
+`SlabInequalityCert` proves:
+
+```lean
+∀ I ∈ slabs, ∀ x ∈ Set.Icc (I.lo : ℝ) I.hi,
+  Expr.eval (fun _ => x) lhs ≤ Expr.eval (fun _ => x) rhs
+```
+
+The table-oriented wrapper uses the generic `TableCert` traversal:
+
+```lean
+InequalityTableRow
+checkInequalityTableRow
+InequalityTableCert
+InequalityTableCert.verify
+InequalityTableCert.failingIndices
+```
+
+Rows remain proof-free data.  The table certificate carries the support and
+precision side conditions once over row membership, while `native_decide` checks
+the row booleans.
+
 ## Pattern: Generate, Dominate, Weaken
 
 The usual envelope workflow is:
@@ -240,6 +271,7 @@ generate the transform payload and slab coverage mechanically.
 
 ## Current Scope
 
-This layer currently includes semantic envelope algebra, Stieltjes-Abel
-kernels, Dirichlet-hyperbola kernels, and dyadic slab/tail domination checks.
-High-level automated asymptotic derivation is not yet part of this layer.
+This layer currently includes semantic envelope algebra, pointwise floor
+envelopes, Stieltjes-Abel kernels, Dirichlet-hyperbola kernels, dyadic slab/tail
+domination checks, and table-oriented slab inequality certificates. High-level
+automated asymptotic derivation is not yet part of this layer.

--- a/docs/certificates/ant-asymp.md
+++ b/docs/certificates/ant-asymp.md
@@ -69,6 +69,48 @@ AsympEnv.lowerReal_le_summatoryReal
 AsympEnv.summatoryReal_le_upperReal
 ```
 
+## Pointwise Error Envelopes
+
+`PointwiseEnvelope` is the real-variable sibling of `AsympEnv`.  It certifies:
+
+```text
+|f x - main x| <= error x
+```
+
+on an arbitrary real domain, with a proof that `error` is nonnegative on that
+domain.
+
+Core API:
+
+```lean
+PointwiseEnvelope.lower
+PointwiseEnvelope.upper
+PointwiseEnvelope.lower_le_value
+PointwiseEnvelope.value_le_upper
+PointwiseEnvelope.weakenError
+```
+
+Algebra:
+
+```lean
+PointwiseEnvelope.add
+PointwiseEnvelope.neg
+PointwiseEnvelope.sub
+PointwiseEnvelope.constMul
+```
+
+The algebra keeps the common-domain and nonnegative-error obligations inside
+the certificate object.  This is the preferred target for explicit real-variable
+estimates that are not naturally discrete summatory functions.
+
+To turn a summatory `AsympEnv` into a real-variable pointwise envelope using the
+existing floor semantics, use:
+
+```lean
+AsympEnv.toPointwiseFloorEnvelope
+AsympEnv.toPointwiseFloorEnvelope_cert
+```
+
 ## Stieltjes-Abel Transforms
 
 The Stieltjes-Abel kernel certifies weighted summatory transforms.
@@ -273,5 +315,6 @@ generate the transform payload and slab coverage mechanically.
 
 This layer currently includes semantic envelope algebra, pointwise floor
 envelopes, Stieltjes-Abel kernels, Dirichlet-hyperbola kernels, dyadic slab/tail
-domination checks, and table-oriented slab inequality certificates. High-level
-automated asymptotic derivation is not yet part of this layer.
+domination checks, pointwise-envelope algebra, and table-oriented slab
+inequality certificates. High-level automated asymptotic derivation is not yet
+part of this layer.

--- a/docs/certificates/ant.md
+++ b/docs/certificates/ant.md
@@ -140,6 +140,17 @@ LeanCert.ANT.PrimePowerExt.ext_prime_powers
 LeanCert.ANT.PrimePowerExt.eq_iff_eq_on_prime_powers
 ```
 
+For generated or data-driven local-factor proofs, LeanCert also exposes a
+certificate object:
+
+```lean
+LeanCert.ANT.PrimePowerExt.LocalPrimePowerCert
+LeanCert.ANT.PrimePowerExt.LocalPrimePowerCert.sound
+```
+
+`LocalPrimePowerCert f g` stores multiplicativity for both arithmetic functions
+and equality on every prime power.  The soundness theorem proves `f = g`.
+
 The intended workflow is:
 
 ```lean
@@ -151,6 +162,42 @@ apply LeanCert.ANT.PrimePowerExt.ext_prime_powers
 
 This is the lightweight first layer for local Euler-factor and
 arithmetic-function identity certificates.
+
+## Explicit-PNT Compiler Schemas
+
+`LeanCert.ANT.PNTCompilers` contains theorem schemas for the two standard
+explicit-PNT envelope transfers.  They are deliberately project-agnostic:
+LeanCert proves the reusable inequality algebra, while project files provide
+the semantic definitions of `ψ`, `θ`, `π`, `Li`, and the decomposition
+identities.
+
+Public theorems:
+
+```lean
+psi_to_theta_bound
+theta_to_pi_bound_of_decomposition
+theta_to_pi_bound
+```
+
+`psi_to_theta_bound` proves the abstract transfer:
+
+```text
+theta x - x = (psi x - x) - powerContribution
+|psi x - x| <= psiError
+0 <= powerContribution <= powerBound
+------------------------------------------------
+|theta x - x| <= psiError + powerBound
+```
+
+`theta_to_pi_bound_of_decomposition` packages the partial-summation error
+algebra once the project has proved a decomposition of `primeCount x - li x`
+into endpoint and integral terms.
+
+`theta_to_pi_bound` is the endpoint-specialized version where the endpoint
+terms are `deltaTheta x / log x` and `deltaTheta x0 / log x0`.
+
+These schemas are intended as the bridge between project-specific analytic
+identities and LeanCert's table, interval, and Taylor integral certificates.
 
 ## Dirichlet Truncations
 

--- a/docs/certificates/ant.md
+++ b/docs/certificates/ant.md
@@ -129,6 +129,29 @@ verify_primeEulerOnePlusInv_interval
 The generic product machinery lives in `LeanCert.ANT.EulerProduct`; these
 number-theoretic presets live in `LeanCert.ANT.PrimeEuler`.
 
+## Prime-Power Extensionality
+
+For multiplicative arithmetic functions, equality can be reduced to equality on
+prime powers.  LeanCert exposes a stable ANT-facing wrapper around mathlib's
+prime-power extensionality theorem:
+
+```lean
+LeanCert.ANT.PrimePowerExt.ext_prime_powers
+LeanCert.ANT.PrimePowerExt.eq_iff_eq_on_prime_powers
+```
+
+The intended workflow is:
+
+```lean
+apply LeanCert.ANT.PrimePowerExt.ext_prime_powers
+-- prove multiplicativity of both sides
+-- reduce the goal to:
+--   ∀ p k, Nat.Prime p → f (p ^ k) = g (p ^ k)
+```
+
+This is the lightweight first layer for local Euler-factor and
+arithmetic-function identity certificates.
+
 ## Dirichlet Truncations
 
 `LeanCert.ANT.Dirichlet` certifies finite Dirichlet-style weighted sums:

--- a/docs/certificates/constants.md
+++ b/docs/certificates/constants.md
@@ -1,0 +1,194 @@
+# ConstantFactory Certificates
+
+`LeanCert.ConstantFactory` certifies exact finite observer identities for
+q-product constants.
+
+## Import
+
+```lean
+import LeanCert.ConstantFactory
+```
+
+For approximate kernel banks, import:
+
+```lean
+import LeanCert.ConstantFactory.IntervalBank
+```
+
+or through the aggregate API:
+
+```lean
+import LeanCert
+```
+
+## Observer Sums
+
+The base q-product moment is already provided by `LeanCert.QProduct`:
+
+```lean
+moment R m = ∫ u in (0 : ℝ)..1, qProd R u * u ^ m
+momentRat R m
+```
+
+`ConstantFactory` adds a finite perturbation compiler. For a base set `R` and
+a disjoint perturbation set `Q`, it computes:
+
+```lean
+observerIntegralRat R Q =
+  ∑ A ∈ Q.powerset, subsetSign A * momentRat R (subsetWeight A)
+```
+
+The Golden Theorem is:
+
+```lean
+theorem observerIntegralRat_eq_F_union
+    (R Q : Finset Nat) (hdisj : Disjoint R Q) :
+    (observerIntegralRat R Q : ℝ) = F (R ∪ Q)
+```
+
+This is the finite observer identity:
+
+\[
+F_{R \cup Q}
+=
+\sum_{A \subseteq Q} (-1)^{|A|} K_R\!\left(\sum_{q \in A} q\right),
+\]
+
+where \(K_R(m)\) is the `m`th q-product moment of `R`.
+
+## Boolean Certificates
+
+The checker is exact rational arithmetic:
+
+```lean
+checkConstantFactoryInterval
+checkConstantFactoryUpper
+checkConstantFactoryLower
+```
+
+The public interval bridge is:
+
+```lean
+theorem verify_constantFactory_interval
+    (R Q : Finset Nat) (lo hi : ℚ)
+    (hcheck : checkConstantFactoryInterval R Q lo hi = true) :
+    (lo : ℝ) ≤ F (R ∪ Q) ∧ F (R ∪ Q) ≤ (hi : ℝ)
+```
+
+The checker includes the disjointness condition, so a successful certificate
+proves both the finite observer algebra side condition and the rational bound.
+
+## Interval Kernel Banks
+
+Exact rational moments are convenient for small finite products, but large
+constant factories often need approximate or externally generated kernel
+enclosures. `LeanCert.ConstantFactory.IntervalBank` provides that layer:
+
+```lean
+structure KernelIntervalBank (R : Finset Nat) where
+  interval : Nat → IntervalRat
+  correct : ∀ m, moment R m ∈ interval m
+```
+
+Given a certified bank for the base profile `R`, the interval observer sums the
+signed perturbation terms:
+
+```lean
+observerInterval Q bank
+```
+
+The Golden Theorem is:
+
+```lean
+theorem F_union_mem_observerInterval
+    {R Q : Finset Nat} (hdisj : Disjoint R Q)
+    (bank : KernelIntervalBank R) :
+    F (R ∪ Q) ∈ observerInterval Q bank
+```
+
+This is the interval analogue of the exact observer identity:
+
+\[
+K_R(m) \in I_m
+\quad\Longrightarrow\quad
+F_{R \cup Q}
+\in
+\sum_{A \subseteq Q} (-1)^{|A|}
+I_{\sum_{q \in A} q}.
+\]
+
+The current implementation uses the existing powerset observer basis. A later
+coefficient-compressed perturbation polynomial can reuse the same bank theorem
+without changing the trust boundary.
+
+There is also a degenerate exact bank:
+
+```lean
+exactKernelIntervalBank R
+```
+
+which wraps `momentRat R m` in singleton intervals.
+
+## Taylor Integration Bridge
+
+Taylor models can generate kernel enclosures. The first verified bridge lives at:
+
+```lean
+import LeanCert.Engine.TaylorModel.Integral
+```
+
+and exposes:
+
+```lean
+TaylorModel.integralBoundCoarse
+TaylorModel.integral_mem_bound_coarse
+```
+
+If a Taylor model semantically encloses `f` on `tm.domain`, then
+`integral_mem_bound_coarse` certifies the definite integral of `f` over that
+domain using the global Taylor-model range bound. This is deliberately
+conservative; exact polynomial-plus-remainder Taylor integration is the natural
+next tightening layer.
+
+## Example
+
+```lean
+import LeanCert.ConstantFactory.IntervalBank
+
+open LeanCert.ConstantFactory
+open LeanCert.QProduct
+
+example :
+    observerIntegralRat ({2} : Finset Nat) ({3} : Finset Nat) = 7 / 12 := by
+  native_decide
+
+example :
+    ((7 / 12 : ℚ) : ℝ) ≤ F (({2} : Finset Nat) ∪ ({3} : Finset Nat)) ∧
+      F (({2} : Finset Nat) ∪ ({3} : Finset Nat)) ≤ ((7 / 12 : ℚ) : ℝ) :=
+  verify_constantFactory_interval ({2} : Finset Nat) ({3} : Finset Nat)
+    (7 / 12) (7 / 12) (by native_decide)
+
+example :
+    F (({2} : Finset Nat) ∪ ({3} : Finset Nat)) ∈
+      observerInterval ({3} : Finset Nat)
+        (exactKernelIntervalBank ({2} : Finset Nat)) := by
+  exact F_union_mem_observerInterval (by simp)
+    (exactKernelIntervalBank ({2} : Finset Nat))
+```
+
+## Current Scope
+
+The first implementation is finite and exact, with an approximate interval-bank
+extension:
+
+- finite perturbation observers;
+- exact rational moment reuse from `QProduct`;
+- exact interval, upper, and lower certificates;
+- a semantic identity reducing `F (R ∪ Q)` to moments of `R`.
+- interval kernel banks for approximate or externally generated moment
+  enclosures;
+- a coarse Taylor-model integral bridge for producing verified integral
+  intervals.
+
+Beta/Gamma kernels and infinite eta-product observer banks are natural later
+extensions, but they are not part of this finite MVP.

--- a/docs/certificates/constants.md
+++ b/docs/certificates/constants.md
@@ -140,15 +140,37 @@ import LeanCert.Engine.TaylorModel.Integral
 and exposes:
 
 ```lean
+TaylorModel.integrateShiftedPoly
+TaylorModel.integralBoundPolyExact
 TaylorModel.integralBoundCoarse
+TaylorModel.integral_mem_bound_polyExact_of_poly_integral
 TaylorModel.integral_mem_bound_coarse
 ```
 
 If a Taylor model semantically encloses `f` on `tm.domain`, then
 `integral_mem_bound_coarse` certifies the definite integral of `f` over that
 domain using the global Taylor-model range bound. This is deliberately
-conservative; exact polynomial-plus-remainder Taylor integration is the natural
-next tightening layer.
+conservative and useful when only a range enclosure is available.
+
+For tighter quadrature, `integralBoundPolyExact` integrates the Taylor
+polynomial by the rational formula:
+
+```text
+sum_i coeff_i * ((b - c)^(i+1) - (a - c)^(i+1)) / (i+1)
+```
+
+and scales only the Taylor remainder interval by the domain width.  Its
+soundness theorem is:
+
+```lean
+TaylorModel.integral_mem_bound_polyExact_of_poly_integral
+```
+
+The theorem intentionally takes the polynomial integral equality as a
+hypothesis.  This keeps the trusted reusable theorem focused on the interval
+and remainder enclosure logic, while callers can discharge the polynomial
+antiderivative identity using the polynomial API most convenient for their
+construction.
 
 ## Example
 
@@ -187,8 +209,8 @@ extension:
 - a semantic identity reducing `F (R ∪ Q)` to moments of `R`.
 - interval kernel banks for approximate or externally generated moment
   enclosures;
-- a coarse Taylor-model integral bridge for producing verified integral
-  intervals.
+- coarse and polynomial-exact Taylor-model integral bridges for producing
+  verified integral intervals.
 
 Beta/Gamma kernels and infinite eta-product observer banks are natural later
 extensions, but they are not part of this finite MVP.

--- a/docs/certificates/contour-shift.md
+++ b/docs/certificates/contour-shift.md
@@ -1,0 +1,192 @@
+# Contour-Shift Certificates
+
+`LeanCert.Analysis.ContourShift` packages reusable contour-shift bookkeeping for
+complex-analysis arguments.
+
+The current layer is intentionally a certificate engine, not an automatic
+residue calculator.  It centralizes:
+
+- named rectangle side integrals;
+- the rectangle boundary orientation convention;
+- finite rectangle shift identities;
+- horizontal-side vanishing from norm bounds;
+- vertical-line limit passing;
+- stable finite residue sums.
+
+## Import
+
+```lean
+import LeanCert.Analysis.ContourShift
+```
+
+or through the aggregate API:
+
+```lean
+import LeanCert
+```
+
+## Rectangle Side API
+
+For rectangle corners `z w : ℂ`, the named side integrals are:
+
+```lean
+bottomIntegral
+topIntegral
+rightIntegral
+leftIntegral
+rectBoundary
+```
+
+The boundary convention is:
+
+```text
+bottom - top + I * right - I * left
+```
+
+The holomorphic rectangle theorem is exposed in this notation:
+
+```lean
+rectBoundary_eq_zero_of_continuousOn_of_differentiableOn
+```
+
+This is a wrapper around mathlib's rectangle Cauchy-Goursat theorem.
+
+## Finite Vertical Shift Certificates
+
+`VerticalShiftCert` stores a boundary identity:
+
+```lean
+rectBoundary f z w = (2 * Real.pi * Complex.I) * residueSum
+```
+
+Its soundness theorem rearranges this into the vertical-shift identity:
+
+```lean
+VerticalShiftCert.vertical_shift
+```
+
+For holomorphic rectangles with no residue contribution, use:
+
+```lean
+VerticalShiftCert.ofHolomorphicRectangle
+```
+
+## Shift-Oriented Segment Integrals
+
+For analytic-number-theory contour shifts, the symmetric vertical-line notation
+is often more convenient:
+
+```lean
+verticalIntegral F σ T
+topHorizontalIntegral F σ₀ σ₁ T
+bottomHorizontalIntegral F σ₀ σ₁ T
+```
+
+Here `verticalIntegral F σ T` is the upward integral over
+`σ + it`, `-T <= t <= T`.
+
+## Finite Rectangle Shift Certificates
+
+`RectangleShiftCert F σ₀ σ₁ T` stores the finite identity:
+
+```lean
+verticalIntegral F σ₀ T =
+  verticalIntegral F σ₁ T
+    - topHorizontalIntegral F σ₀ σ₁ T
+    - bottomHorizontalIntegral F σ₀ σ₁ T
+    + (2 * Real.pi * Complex.I) * residueSum
+```
+
+The residue theorem is not baked into this structure.  Projects can supply the
+finite rectangle identity from a residue theorem, from a specialized local
+calculation, or from a future LeanCert residue constructor.
+
+Finite pole metadata can be stored separately with:
+
+```lean
+StripPoleCert
+stripResidueSum
+```
+
+## Horizontal Vanishing
+
+For limit-passing shifts, horizontal sides can be supplied directly:
+
+```lean
+HorizontalVanishCert
+```
+
+or derived from explicit norm bounds:
+
+```lean
+HorizontalBoundCert
+HorizontalBoundCert.toVanishCert
+```
+
+The bound certificate stores a nonnegative bound tending to zero and proves both
+horizontal side norms are bounded by it.
+
+## Infinite Contour-Shift Certificates
+
+`ContourShiftCert F σ₀ σ₁` is the main limit-passing certificate.  It stores:
+
+- a height sequence `T : Nat -> ℝ`;
+- finite rectangle certificates at each height;
+- stable pole and residue data;
+- left and right vertical-line limits;
+- horizontal vanishing.
+
+The chosen outputs are:
+
+```lean
+ContourShiftCert.leftValue
+ContourShiftCert.rightValue
+ContourShiftCert.residueSum
+```
+
+The main soundness theorem is:
+
+```lean
+ContourShiftCert.shift_identity'
+```
+
+which proves:
+
+```text
+leftValue =
+  rightValue + (2 * Real.pi * Complex.I) * residueSum
+```
+
+There is also an existential version:
+
+```lean
+ContourShiftCert.shift_identity
+```
+
+## Intended Workflow
+
+Use this layer when the analytic proof has already been decomposed as:
+
+```text
+finite rectangle identity
++ horizontal side vanishing
++ vertical-line convergence
++ stable residue data
+= contour shift identity
+```
+
+A project should prove the residue identities and analytic decay estimates in
+project-specific files, then package them into `RectangleShiftCert`,
+`HorizontalBoundCert`, and `ContourShiftCert`.
+
+## Current Scope
+
+This layer does not yet automate:
+
+- residue discovery;
+- meromorphic-on-region hypotheses;
+- infinite pole exhaustion;
+- Laurent or simple-pole residue calculation.
+
+Those are natural future constructors.  The current API is the reusable
+orientation and limit algebra that those constructors should target.

--- a/docs/certificates/overview.md
+++ b/docs/certificates/overview.md
@@ -17,10 +17,11 @@ Use this page as the map for choosing the right certificate API.
 | Certificate family | Use when you need |
 |---|---|
 | [Chebyshev](chebyshev.md) | finite-range bounds for the Chebyshev functions `ψ` and `θ` |
-| [ANT finite bridges](ant.md) | step sums, Abel transforms, Euler products, log products, Dirichlet truncations, and Mertens-style finite sums |
-| [ANT asymptotic envelopes](ant-asymp.md) | main-term plus error-term certificates for summatory functions and transforms |
+| [ANT finite bridges](ant.md) | step sums, Abel transforms, Euler products, log products, Dirichlet truncations, prime-power extensionality, and explicit-PNT compiler schemas |
+| [ANT asymptotic envelopes](ant-asymp.md) | main-term plus error-term certificates for summatory functions, pointwise estimates, dyadic slab inequalities, and transforms |
 | [QProduct](qproduct.md) | exact finite q-product integrals and prime-limit sandwich certificates |
-| [ConstantFactory](constants.md) | exact observer-generated q-product constants from perturbation sums and reusable moment kernels |
+| [ConstantFactory](constants.md) | exact and interval observer-generated q-product constants from perturbation sums and reusable moment kernels |
+| [Contour Shift](contour-shift.md) | finite rectangle identities, horizontal-side vanishing, vertical-line limits, and residue-sum shift identities |
 
 ## Imports
 
@@ -31,6 +32,8 @@ import LeanCert.ANT
 import LeanCert.ANT.Asymp
 import LeanCert.QProduct
 import LeanCert.ConstantFactory
+import LeanCert.ConstantFactory.IntervalBank
+import LeanCert.Analysis.ContourShift
 import LeanCert.Engine.ChebyshevPsi
 import LeanCert.Engine.ChebyshevTheta
 ```
@@ -58,3 +61,8 @@ prime-limit sandwich arguments.
 Use ConstantFactory certificates when a q-product constant is best proved by
 holding a base kernel bank fixed and verifying finite observer perturbations
 around it.
+
+Use contour-shift certificates when the analytic work has been decomposed into
+finite rectangle identities, horizontal decay, vertical-line convergence, and a
+stable finite residue sum.  The current API centralizes the orientation and
+limit algebra; residue-theorem constructors can be layered on top.

--- a/docs/certificates/overview.md
+++ b/docs/certificates/overview.md
@@ -20,6 +20,7 @@ Use this page as the map for choosing the right certificate API.
 | [ANT finite bridges](ant.md) | step sums, Abel transforms, Euler products, log products, Dirichlet truncations, and Mertens-style finite sums |
 | [ANT asymptotic envelopes](ant-asymp.md) | main-term plus error-term certificates for summatory functions and transforms |
 | [QProduct](qproduct.md) | exact finite q-product integrals and prime-limit sandwich certificates |
+| [ConstantFactory](constants.md) | exact observer-generated q-product constants from perturbation sums and reusable moment kernels |
 
 ## Imports
 
@@ -29,6 +30,7 @@ Most certificate families can be imported directly:
 import LeanCert.ANT
 import LeanCert.ANT.Asymp
 import LeanCert.QProduct
+import LeanCert.ConstantFactory
 import LeanCert.Engine.ChebyshevPsi
 import LeanCert.Engine.ChebyshevTheta
 ```
@@ -52,3 +54,7 @@ These can feed into ANT and asymptotic envelope arguments.
 
 Use QProduct certificates for exact product-integral identities and finite
 prime-limit sandwich arguments.
+
+Use ConstantFactory certificates when a q-product constant is best proved by
+holding a base kernel bank fixed and verifying finite observer perturbations
+around it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ lake update
 | [ANT Certificates](certificates/ant.md) | Step sums, Abel transforms, Euler products, and Mertens-style finite sums |
 | [Asymptotic Envelopes](certificates/ant-asymp.md) | Summatory main-term/error envelopes, Stieltjes transforms, and hyperbola kernels |
 | [QProduct Certificates](certificates/qproduct.md) | Exact product-integral and prime-limit certificates |
+| [ConstantFactory Certificates](certificates/constants.md) | Observer-generated q-product constants from finite perturbation sums |
 
 ## ML
 
@@ -76,6 +77,7 @@ lake update
 | Document | Description |
 |----------|-------------|
 | [Golden Theorems](architecture/golden-theorems.md) | Why the checkers imply theorems |
+| [Table Certificates](architecture/table-certificates.md) | Generic finite-table checking infrastructure |
 | [Root Finding](architecture/root-finding.md) | Existence and uniqueness flow |
 | [Verification Status](architecture/verification-status.md) | Proven components and known gaps |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,9 @@ LeanCert is a Lean 4 library for certified numerical computation and proof-produ
 - Proof automation for inequalities and root claims
 - Global optimization and integration certificates
 - Chebyshev function certificates
-- Analytic-number-theory certificate bridges for Abel summation and Euler products
+- Analytic-number-theory certificate bridges for Abel summation, Euler products, prime-power extensionality, and explicit-PNT envelope transfers
 - Exact q-product/product-integral certificates
+- Table, slab, and contour-shift certificate frameworks
 - Dyadic and rational backends for different performance/precision tradeoffs
 
 ## Quick Lean Example
@@ -61,9 +62,10 @@ lake update
 | [Certificate Overview](certificates/overview.md) | Domain-specific certificate families |
 | [Chebyshev Certificates](certificates/chebyshev.md) | Certified `ψ` and `θ` finite-range bounds |
 | [ANT Certificates](certificates/ant.md) | Step sums, Abel transforms, Euler products, and Mertens-style finite sums |
-| [Asymptotic Envelopes](certificates/ant-asymp.md) | Summatory main-term/error envelopes, Stieltjes transforms, and hyperbola kernels |
+| [Asymptotic Envelopes](certificates/ant-asymp.md) | Summatory and pointwise error envelopes, slab inequalities, Stieltjes transforms, and hyperbola kernels |
 | [QProduct Certificates](certificates/qproduct.md) | Exact product-integral and prime-limit certificates |
 | [ConstantFactory Certificates](certificates/constants.md) | Observer-generated q-product constants from finite perturbation sums |
+| [Contour-Shift Certificates](certificates/contour-shift.md) | Rectangle, horizontal-vanishing, and limit-passing contour-shift certificates |
 
 ## ML
 


### PR DESCRIPTION
## Summary

Adds reusable certificate-engine infrastructure for LeanCert:

- finite/table-oriented inequality certificates;
- pointwise error-envelope algebra;
- explicit-PNT transfer theorem schemas (`ψ → θ`, `θ → π`);
- prime-power extensionality certificate wrapper;
- contour-shift certificate layer;
- constant-factory observer and interval-bank certificates;
- Taylor-model integral certificate bridges, including polynomial-exact remainder enclosure.

