### PR TITLE
Feat/limit wall certs

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -13,6 +13,7 @@ import LeanCert.Core.Taylor
 import LeanCert.Core.DerivativeIntervals
 import LeanCert.Cert.Interval
 import LeanCert.Analysis.ContourShift
+import LeanCert.Analysis.WallQuotient
 -- v1.1: Dyadic arithmetic (high-performance alternative to Rat)
 import LeanCert.Core.Dyadic
 import LeanCert.Core.IntervalDyadic

--- a/LeanCert/Analysis/WallQuotient.lean
+++ b/LeanCert/Analysis/WallQuotient.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Mathlib.Analysis.Calculus.Deriv.MeanValue
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+
+/-!
+# Wall quotients: enclosures at removable singularities
+
+Interval evaluation degenerates at a point `w` where an expression has the
+form `num/den` with `num w = den w = 0`: the order-0 data is `0/0`, and a
+naive enclosure is vacuous. The information lives one jet order up. This
+module provides the order-1 enclosure: by the Cauchy mean value theorem,
+on an interval to the right of the wall the quotient is trapped by any
+uniform bounds on the derivative ratio,
+
+  `lo · den′ ≤ num′ ≤ hi · den′  on (w, b)   ⟹   num t / den t ∈ [lo, hi]`.
+
+The derivative bounds are ordinary (wall-free) interval-evaluation targets,
+so this theorem converts a singular enclosure problem into a regular one.
+
+`expm1_div_self_mem` is the model instance: `(eˣ − 1)/x ∈ [1, e]` on `(0,1)`.
+
+## Roadmap
+
+* Order-`k` walls (`num`, `den` vanishing to higher order) via iterated
+  Cauchy MVT or Taylor remainders, for quotients like the symmetric
+  log integrand of the Li2 development, whose wall data currently uses
+  bespoke tail lemmas.
+* A left-of-wall variant and a two-sided wrapper.
+* Engine hookup: a wall-aware partition step for `interval_integrate`
+  that evaluates jets at singular endpoints and the standard interval
+  engine elsewhere.
+-/
+
+namespace LeanCert.Analysis.WallQuotient
+
+open Set
+
+/-- Order-1 wall enclosure. If `num` and `den` both vanish at `w`, `den`
+has positive derivative on `(w, b)`, and the derivative ratio is trapped in
+`[lo, hi]` there, then the quotient is trapped in `[lo, hi]` on `(w, b)`. -/
+theorem quotient_mem_of_deriv_ratio_bounds
+    {num den num' den' : ℝ → ℝ} {w b lo hi : ℝ}
+    (hnum0 : num w = 0) (hden0 : den w = 0)
+    (hnumc : ContinuousOn num (Icc w b))
+    (hdenc : ContinuousOn den (Icc w b))
+    (hnumd : ∀ x ∈ Ioo w b, HasDerivAt num (num' x) x)
+    (hdend : ∀ x ∈ Ioo w b, HasDerivAt den (den' x) x)
+    (hden'pos : ∀ x ∈ Ioo w b, 0 < den' x)
+    (hlo : ∀ x ∈ Ioo w b, lo * den' x ≤ num' x)
+    (hhi : ∀ x ∈ Ioo w b, num' x ≤ hi * den' x)
+    {t : ℝ} (ht : t ∈ Ioo w b) :
+    num t / den t ∈ Icc lo hi := by
+  obtain ⟨hwt, htb⟩ := ht
+  have hIccSub : Icc w t ⊆ Icc w b := Icc_subset_Icc_right htb.le
+  have hIooSub : Ioo w t ⊆ Ioo w b := Ioo_subset_Ioo_right htb.le
+  -- `den t > 0` by the mean value theorem and `den′ > 0`.
+  obtain ⟨c₀, hc₀mem, hc₀⟩ := exists_hasDerivAt_eq_slope den den' hwt
+    (hdenc.mono hIccSub) (fun x hx => hdend x (hIooSub hx))
+  have hdent_pos : 0 < den t := by
+    have hd'c₀ := hden'pos c₀ (hIooSub hc₀mem)
+    have htw : (0 : ℝ) < t - w := by linarith
+    have hEq : den t - den w = den' c₀ * (t - w) := by
+      rw [hc₀]
+      field_simp
+    have hpos : 0 < den' c₀ * (t - w) := mul_pos hd'c₀ htw
+    rw [← hEq, hden0] at hpos
+    linarith
+  -- Cauchy MVT: the quotient is a derivative ratio at an interior point.
+  obtain ⟨c, hcmem, hc⟩ := exists_ratio_hasDerivAt_eq_ratio_slope num num' hwt
+    (hnumc.mono hIccSub) (fun x hx => hnumd x (hIooSub hx))
+    den den' (hdenc.mono hIccSub) (fun x hx => hdend x (hIooSub hx))
+  rw [hnum0, hden0, sub_zero, sub_zero] at hc
+  -- `hc : den t * num' c = num t * den' c`
+  have hcb := hIooSub hcmem
+  have hd'c := hden'pos c hcb
+  constructor
+  · rw [le_div_iff₀ hdent_pos]
+    have h1 : lo * den' c ≤ num' c := hlo c hcb
+    have h2 : lo * den' c * den t ≤ num' c * den t :=
+      mul_le_mul_of_nonneg_right h1 hdent_pos.le
+    have h3 : (lo * den t) * den' c ≤ num t * den' c := by nlinarith [hc]
+    exact le_of_mul_le_mul_right h3 hd'c
+  · rw [div_le_iff₀ hdent_pos]
+    have h1 : num' c ≤ hi * den' c := hhi c hcb
+    have h2 : num' c * den t ≤ hi * den' c * den t :=
+      mul_le_mul_of_nonneg_right h1 hdent_pos.le
+    have h3 : num t * den' c ≤ (hi * den t) * den' c := by nlinarith [hc]
+    exact le_of_mul_le_mul_right h3 hd'c
+
+/-- Model instance: `(eˣ − 1)/x ∈ [1, e]` on `(0, 1)`, with the wall at
+`x = 0` handled by `quotient_mem_of_deriv_ratio_bounds` and the derivative
+bounds `1 ≤ eˣ ≤ e` as the regular interval data. -/
+theorem expm1_div_self_mem {t : ℝ} (ht : t ∈ Ioo (0 : ℝ) 1) :
+    (Real.exp t - 1) / t ∈ Icc (1 : ℝ) (Real.exp 1) := by
+  have h := quotient_mem_of_deriv_ratio_bounds
+    (num := fun x => Real.exp x - 1) (den := fun x => x)
+    (num' := fun x => Real.exp x) (den' := fun _ => (1 : ℝ))
+    (w := 0) (b := 1) (lo := 1) (hi := Real.exp 1)
+    (by simp) rfl
+    ((Real.continuous_exp.sub continuous_const).continuousOn)
+    (continuous_id.continuousOn)
+    (fun x _ => (Real.hasDerivAt_exp x).sub_const 1)
+    (fun x _ => hasDerivAt_id x)
+    (fun _ _ => one_pos)
+    (fun x hx => by simpa using Real.one_le_exp hx.1.le)
+    (fun x hx => by simpa using Real.exp_le_exp.mpr hx.2.le)
+    ht
+  simpa using h
+
+end LeanCert.Analysis.WallQuotient

--- a/LeanCert/Analysis/WallQuotient.lean
+++ b/LeanCert/Analysis/WallQuotient.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
 import Mathlib.Analysis.Calculus.Deriv.MeanValue
+import Mathlib.Analysis.Calculus.Deriv.Pow
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Tactic.IntervalCases
 
 /-!
 # Wall quotients: enclosures at removable singularities
@@ -110,5 +112,186 @@ theorem expm1_div_self_mem {t : ℝ} (ht : t ∈ Ioo (0 : ℝ) 1) :
     (fun x hx => by simpa using Real.exp_le_exp.mpr hx.2.le)
     ht
   simpa using h
+
+/-! ### Order-`k` walls via derivative ladders
+
+When numerator and denominator both vanish to order `k` at the wall, the
+quotient is controlled by ratio bounds on the `k`-th derivatives. The
+derivative data is packaged as a ladder: explicit functions `f 0, …, f k`
+with each `f (i+1)` the derivative of `f i`, avoiding the `iteratedDeriv`
+API entirely. -/
+
+/-- A derivative ladder of order `k` on `[w, b]`: functions `f 0, …, f k`
+with `f (i+1)` the derivative of `f i` on `(w, b)` for `i < k`, each level
+below the top continuous on `[w, b]` and vanishing at the wall `w`. -/
+structure DerivLadder (k : ℕ) (w b : ℝ) where
+  /-- The ladder of functions; only levels `0, …, k` are meaningful. -/
+  f : ℕ → ℝ → ℝ
+  cont : ∀ i < k, ContinuousOn (f i) (Icc w b)
+  deriv : ∀ i < k, ∀ x ∈ Ioo w b, HasDerivAt (f i) (f (i + 1) x) x
+  zero : ∀ i < k, f i w = 0
+
+namespace DerivLadder
+
+/-- Drop the bottom level of a ladder. -/
+def tail {k : ℕ} {w b : ℝ} (L : DerivLadder (k + 1) w b) : DerivLadder k w b where
+  f i := L.f (i + 1)
+  cont i hi := L.cont (i + 1) (by omega)
+  deriv i hi := L.deriv (i + 1) (by omega)
+  zero i hi := L.zero (i + 1) (by omega)
+
+/-- Positivity propagates down a ladder: if the top level is positive on
+`(w, b)`, every level is, by the mean value theorem and the wall zeros. -/
+theorem pos_of_top (k : ℕ) : ∀ (w b : ℝ) (L : DerivLadder k w b),
+    (∀ x ∈ Ioo w b, 0 < L.f k x) →
+    ∀ i ≤ k, ∀ x ∈ Ioo w b, 0 < L.f i x := by
+  induction k with
+  | zero =>
+    intro w b L htop i hi x hx
+    obtain rfl : i = 0 := Nat.le_zero.mp hi
+    exact htop x hx
+  | succ k ih =>
+    intro w b L htop i hi x hx
+    cases i with
+    | succ j => exact ih w b L.tail htop j (by omega) x hx
+    | zero =>
+      obtain ⟨hwx, hxb⟩ := hx
+      have hcont : ContinuousOn (L.f 0) (Icc w x) :=
+        (L.cont 0 (by omega)).mono (Icc_subset_Icc_right hxb.le)
+      have hderiv : ∀ y ∈ Ioo w x, HasDerivAt (L.f 0) (L.f 1 y) y :=
+        fun y hy => L.deriv 0 (by omega) y (Ioo_subset_Ioo_right hxb.le hy)
+      obtain ⟨c, hcmem, hc⟩ :=
+        exists_hasDerivAt_eq_slope (L.f 0) (L.f 1) hwx hcont hderiv
+      have hpos1 : 0 < L.f 1 c :=
+        ih w b L.tail htop 0 (Nat.zero_le k) c (Ioo_subset_Ioo_right hxb.le hcmem)
+      have htw : (0 : ℝ) < x - w := by linarith
+      have hEq : L.f 0 x - L.f 0 w = L.f 1 c * (x - w) := by
+        rw [hc]
+        field_simp
+      have hpos := mul_pos hpos1 htw
+      rw [← hEq, L.zero 0 (by omega)] at hpos
+      linarith
+
+end DerivLadder
+
+/-- **Order-`k` wall enclosure.** If numerator and denominator ladders vanish
+to order `k` at the wall and the top-level derivative ratio is trapped in
+`[lo, hi]` on `(w, b)` (with positive top denominator derivative), then the
+quotient of the bottom levels is trapped in `[lo, hi]` on `(w, b)`. -/
+theorem quotient_mem_of_derivLadder {w b lo hi : ℝ} :
+    ∀ (k : ℕ), 0 < k → ∀ (N D : DerivLadder k w b),
+    (∀ x ∈ Ioo w b, 0 < D.f k x) →
+    (∀ x ∈ Ioo w b, lo * D.f k x ≤ N.f k x) →
+    (∀ x ∈ Ioo w b, N.f k x ≤ hi * D.f k x) →
+    ∀ t ∈ Ioo w b, N.f 0 t / D.f 0 t ∈ Icc lo hi := by
+  intro k
+  induction k with
+  | zero => omega
+  | succ k ih =>
+    intro _ N D hpos hlo hhi t ht
+    rcases Nat.eq_zero_or_pos k with rfl | hk
+    · -- order 1: the Cauchy MVT core.
+      exact quotient_mem_of_deriv_ratio_bounds
+        (N.zero 0 (by omega)) (D.zero 0 (by omega))
+        (N.cont 0 (by omega)) (D.cont 0 (by omega))
+        (N.deriv 0 (by omega)) (D.deriv 0 (by omega))
+        hpos hlo hhi ht
+    · -- order k+1, k ≥ 1: the tails give level-1 quotient bounds everywhere,
+      -- which convert to level-1 ratio bounds for the order-1 core.
+      have hDpos1 : ∀ x ∈ Ioo w b, 0 < D.f 1 x := fun x hx =>
+        DerivLadder.pos_of_top (k + 1) w b D hpos 1 (by omega) x hx
+      have hq : ∀ x ∈ Ioo w b, N.tail.f 0 x / D.tail.f 0 x ∈ Icc lo hi :=
+        fun x hx => ih hk N.tail D.tail hpos hlo hhi x hx
+      have hlo1 : ∀ x ∈ Ioo w b, lo * D.f 1 x ≤ N.f 1 x := by
+        intro x hx
+        have h : lo ≤ N.f 1 x / D.f 1 x := (hq x hx).1
+        have hp := hDpos1 x hx
+        rw [le_div_iff₀ hp] at h
+        exact h
+      have hhi1 : ∀ x ∈ Ioo w b, N.f 1 x ≤ hi * D.f 1 x := by
+        intro x hx
+        have h : N.f 1 x / D.f 1 x ≤ hi := (hq x hx).2
+        have hp := hDpos1 x hx
+        rw [div_le_iff₀ hp] at h
+        exact h
+      exact quotient_mem_of_deriv_ratio_bounds
+        (N.zero 0 (by omega)) (D.zero 0 (by omega))
+        (N.cont 0 (by omega)) (D.cont 0 (by omega))
+        (N.deriv 0 (by omega)) (D.deriv 0 (by omega))
+        hDpos1 hlo1 hhi1 ht
+
+/-- Numerator ladder for the order-2 model instance:
+`eˣ − x − 1`, `eˣ − 1`, `eˣ`. -/
+private noncomputable def expm1SubLadder : DerivLadder 2 0 1 where
+  f
+    | 0 => fun x => Real.exp x - x - 1
+    | 1 => fun x => Real.exp x - 1
+    | _ + 2 => fun x => Real.exp x
+  cont := by
+    intro i hi
+    interval_cases i
+    · exact ((Real.continuous_exp.sub continuous_id).sub
+        continuous_const).continuousOn
+    · exact (Real.continuous_exp.sub continuous_const).continuousOn
+  deriv := by
+    intro i hi x hx
+    interval_cases i
+    · show HasDerivAt (fun y => Real.exp y - y - 1) (Real.exp x - 1) x
+      simpa using ((Real.hasDerivAt_exp x).sub (hasDerivAt_id x)).sub_const 1
+    · show HasDerivAt (fun y => Real.exp y - 1) (Real.exp x) x
+      exact (Real.hasDerivAt_exp x).sub_const 1
+  zero := by
+    intro i hi
+    interval_cases i
+    · show Real.exp 0 - 0 - 1 = 0
+      simp
+    · show Real.exp 0 - 1 = 0
+      simp
+
+/-- Denominator ladder for the order-2 model instance: `x²`, `2x`, `2`. -/
+private noncomputable def sqLadder : DerivLadder 2 0 1 where
+  f
+    | 0 => fun x => x ^ 2
+    | 1 => fun x => 2 * x
+    | _ + 2 => fun _ => 2
+  cont := by
+    intro i hi
+    interval_cases i
+    · exact (continuous_pow 2).continuousOn
+    · exact (continuous_const.mul continuous_id).continuousOn
+  deriv := by
+    intro i hi x hx
+    interval_cases i
+    · show HasDerivAt (fun y => y ^ 2) (2 * x) x
+      simpa using hasDerivAt_pow 2 x
+    · show HasDerivAt (fun y => 2 * y) (2 : ℝ) x
+      simpa using (hasDerivAt_id x).const_mul (2 : ℝ)
+  zero := by
+    intro i hi
+    interval_cases i
+    · show (0 : ℝ) ^ 2 = 0
+      simp
+    · show 2 * (0 : ℝ) = 0
+      simp
+
+/-- Order-2 model instance: `(eᵗ − t − 1)/t² ∈ [1/2, e/2]` on `(0, 1)`.
+Numerator and denominator vanish to order 2 at the wall `t = 0`; the
+second-derivative ratio bounds `1 ≤ eˣ ≤ e` are the regular interval data. -/
+theorem expm1_sub_self_div_sq_mem {t : ℝ} (ht : t ∈ Ioo (0 : ℝ) 1) :
+    (Real.exp t - t - 1) / t ^ 2 ∈ Icc (1 / 2 : ℝ) (Real.exp 1 / 2) := by
+  have h := quotient_mem_of_derivLadder 2 (by omega) expm1SubLadder sqLadder
+    (fun x _ => by
+      show (0 : ℝ) < 2
+      norm_num)
+    (fun x hx => by
+      show 1 / 2 * (2 : ℝ) ≤ Real.exp x
+      have := Real.one_le_exp hx.1.le
+      linarith)
+    (fun x hx => by
+      show Real.exp x ≤ Real.exp 1 / 2 * 2
+      have := Real.exp_le_exp.mpr hx.2.le
+      linarith)
+    t ht
+  exact h
 
 end LeanCert.Analysis.WallQuotient

--- a/LeanCert/Examples/QProduct/PrimeLambda.lean
+++ b/LeanCert/Examples/QProduct/PrimeLambda.lean
@@ -47,3 +47,13 @@ example : ((19 / 36 : ℚ) : ℝ) ≤ primeLambda := by
 
 example : (1 : ℝ) / 2 < primeLambda := by
   exact primeLambda_gt_half
+
+/-- The same two-sided enclosure through the directed-limit certificate:
+one boolean check at truncation index 1 (`approx 1 = primeFRat 3`,
+`tail 1 = primeSandwichErrorRat 3 5`), no tail hypothesis at the use site. -/
+example : ((19 / 36 : ℚ) : ℝ) ≤ primeLambda ∧ primeLambda ≤ ((7 / 12 : ℚ) : ℝ) :=
+  LeanCert.Validity.verify_limit_interval
+    primeLambda_le_shiftedTrunc
+    shiftedTrunc_sub_tail_le_primeLambda
+    1 (19 / 36) (7 / 12)
+    (by native_decide)

--- a/LeanCert/QProduct.lean
+++ b/LeanCert/QProduct.lean
@@ -9,6 +9,8 @@ import LeanCert.QProduct.Stability
 import LeanCert.QProduct.Certificate
 import LeanCert.QProduct.PrimeLambda
 import LeanCert.QProduct.LimitCert
+import LeanCert.QProduct.Differences
+import LeanCert.QProduct.InfiniteProduct
 
 /-!
 # QProduct

--- a/LeanCert/QProduct.lean
+++ b/LeanCert/QProduct.lean
@@ -8,6 +8,7 @@ import LeanCert.QProduct.Finite
 import LeanCert.QProduct.Stability
 import LeanCert.QProduct.Certificate
 import LeanCert.QProduct.PrimeLambda
+import LeanCert.QProduct.LimitCert
 
 /-!
 # QProduct

--- a/LeanCert/QProduct/Differences.lean
+++ b/LeanCert/QProduct/Differences.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.QProduct.Stability
+
+/-!
+# Difference calculus for finite q-product integrals
+
+Removing an exponent from `F S = ∫₀¹ ∏_{n∈S}(1-uⁿ) du` changes the value by
+exactly a moment of the remaining product, and mixed second differences are
+moments at the *sum* of the removed exponents:
+
+* `F_erase_sub_eq_moment` :
+  `F (S.erase c) - F S = moment (S.erase c) c`
+* `F_second_difference_eq_moment` :
+  `F S - F (S.erase c) - F (S.erase d) + F ((S.erase c).erase d)
+     = moment ((S.erase c).erase d) (c + d)`
+
+Both right-hand sides are nonnegative, so single-exponent removals only
+increase the integral (`F_erase_sub_nonneg`), removals of smaller exponents
+increase it more (`moment_antitone_exponent`), and the family of differences
+is discretely convex (`F_second_difference_nonneg`). The second difference
+depends on the removed pair only through `c + d`, which is the analytic
+source of the subset-sum expansion of `F`.
+
+These identities support self-bounding tail estimates for directed-limit
+certificates: consecutive truncation increments are moments, and moment
+monotonicity converts observed increments into certified tail majorants.
+-/
+
+namespace LeanCert.QProduct
+
+open MeasureTheory intervalIntegral
+
+/-- `qProd` is continuous (duplicated here to keep this file independent of
+the infinite-product development). -/
+private theorem qProd_continuous' (S : Finset Nat) :
+    Continuous fun u : ℝ => qProd S u := by
+  unfold qProd
+  exact continuous_finsetProd S fun n _ => continuous_const.sub (continuous_pow n)
+
+private theorem qProd_intervalIntegrable (S : Finset Nat) :
+    IntervalIntegrable (fun u => qProd S u) volume (0:ℝ) 1 :=
+  (qProd_continuous' S).intervalIntegrable 0 1
+
+private theorem qProd_mul_pow_intervalIntegrable (S : Finset Nat) (k : Nat) :
+    IntervalIntegrable (fun u => qProd S u * u ^ k) volume (0:ℝ) 1 :=
+  ((qProd_continuous' S).mul (continuous_pow k)).intervalIntegrable 0 1
+
+/-- Moments of q-products are nonnegative. -/
+theorem moment_nonneg (S : Finset Nat) (k : Nat) : 0 ≤ moment S k := by
+  unfold moment
+  apply intervalIntegral.integral_nonneg (by norm_num)
+  intro u hu
+  exact mul_nonneg (qProd_nonneg S hu) (pow_nonneg hu.1 k)
+
+/-- Moments are antitone in the exponent. -/
+theorem moment_antitone_exponent (S : Finset Nat) {k l : Nat} (hkl : k ≤ l) :
+    moment S l ≤ moment S k := by
+  unfold moment
+  apply intervalIntegral.integral_mono_on (by norm_num)
+    (qProd_mul_pow_intervalIntegrable S l) (qProd_mul_pow_intervalIntegrable S k)
+  intro u hu
+  exact mul_le_mul_of_nonneg_left
+    (pow_le_pow_of_le_one hu.1 hu.2 hkl) (qProd_nonneg S hu)
+
+/-- Removing the factor of an exponent `c ∈ S` splits the product. -/
+theorem qProd_erase_mul {S : Finset Nat} {c : Nat} (hc : c ∈ S) (u : ℝ) :
+    qProd S u = (1 - u ^ c) * qProd (S.erase c) u := by
+  unfold qProd
+  exact (Finset.mul_prod_erase S _ hc).symm
+
+/-- **First difference = moment.** Removing one exponent raises the integral
+by exactly the corresponding moment of the remaining product. -/
+theorem F_erase_sub_eq_moment {S : Finset Nat} {c : Nat} (hc : c ∈ S) :
+    F (S.erase c) - F S = moment (S.erase c) c := by
+  unfold F moment
+  rw [← intervalIntegral.integral_sub (qProd_intervalIntegrable (S.erase c))
+    (qProd_intervalIntegrable S)]
+  apply intervalIntegral.integral_congr
+  intro u _
+  show qProd (S.erase c) u - qProd S u = qProd (S.erase c) u * u ^ c
+  rw [qProd_erase_mul hc]
+  ring
+
+/-- Single-exponent removal never decreases the integral. -/
+theorem F_erase_sub_nonneg {S : Finset Nat} {c : Nat} (hc : c ∈ S) :
+    0 ≤ F (S.erase c) - F S := by
+  rw [F_erase_sub_eq_moment hc]
+  exact moment_nonneg _ _
+
+/-- **Second difference = moment at the sum.** The mixed second difference of
+removals depends on the removed pair `{c, d}` only through `c + d`. -/
+theorem F_second_difference_eq_moment {S : Finset Nat} {c d : Nat}
+    (hc : c ∈ S) (hd : d ∈ S) (hcd : c ≠ d) :
+    F S - F (S.erase c) - F (S.erase d) + F ((S.erase c).erase d) =
+      moment ((S.erase c).erase d) (c + d) := by
+  have hd' : d ∈ S.erase c := Finset.mem_erase.mpr ⟨(Ne.symm hcd), hd⟩
+  have hc' : c ∈ S.erase d := Finset.mem_erase.mpr ⟨hcd, hc⟩
+  have hcomm : (S.erase d).erase c = (S.erase c).erase d := by
+    ext x
+    simp only [Finset.mem_erase]
+    tauto
+  unfold F moment
+  rw [← intervalIntegral.integral_sub (qProd_intervalIntegrable S)
+        (qProd_intervalIntegrable (S.erase c)),
+      ← intervalIntegral.integral_sub
+        ((qProd_intervalIntegrable S).sub (qProd_intervalIntegrable (S.erase c)))
+        (qProd_intervalIntegrable (S.erase d)),
+      ← intervalIntegral.integral_add
+        (((qProd_intervalIntegrable S).sub
+            (qProd_intervalIntegrable (S.erase c))).sub
+          (qProd_intervalIntegrable (S.erase d)))
+        (qProd_intervalIntegrable ((S.erase c).erase d))]
+  apply intervalIntegral.integral_congr
+  intro u _
+  show qProd S u - qProd (S.erase c) u - qProd (S.erase d) u +
+      qProd ((S.erase c).erase d) u =
+    qProd ((S.erase c).erase d) u * u ^ (c + d)
+  have h1 : qProd S u = (1 - u ^ c) * ((1 - u ^ d) * qProd ((S.erase c).erase d) u) := by
+    rw [qProd_erase_mul hc, qProd_erase_mul hd']
+  have h2 : qProd (S.erase c) u = (1 - u ^ d) * qProd ((S.erase c).erase d) u :=
+    qProd_erase_mul hd' u
+  have h3 : qProd (S.erase d) u = (1 - u ^ c) * qProd ((S.erase c).erase d) u := by
+    rw [qProd_erase_mul hc', hcomm]
+  simp only [h1, h2, h3, pow_add]
+  ring
+
+/-- Discrete convexity: mixed second differences are nonnegative. -/
+theorem F_second_difference_nonneg {S : Finset Nat} {c d : Nat}
+    (hc : c ∈ S) (hd : d ∈ S) (hcd : c ≠ d) :
+    0 ≤ F S - F (S.erase c) - F (S.erase d) + F ((S.erase c).erase d) := by
+  rw [F_second_difference_eq_moment hc hd hcd]
+  exact moment_nonneg _ _
+
+/-- The second difference factors through the sum of the removed exponents:
+two removal pairs over the same base with equal sums produce identical second
+differences. -/
+theorem F_second_difference_factors_through_sum {S : Finset Nat}
+    {c d c' d' : Nat} (hc : c ∈ S) (hd : d ∈ S) (hcd : c ≠ d)
+    (hc' : c' ∈ S) (hd' : d' ∈ S) (hcd' : c' ≠ d')
+    (hbase : (S.erase c).erase d = (S.erase c').erase d')
+    (hsum : c + d = c' + d') :
+    F S - F (S.erase c) - F (S.erase d) + F ((S.erase c).erase d) =
+      F S - F (S.erase c') - F (S.erase d') + F ((S.erase c').erase d') := by
+  rw [F_second_difference_eq_moment hc hd hcd,
+    F_second_difference_eq_moment hc' hd' hcd', hbase, hsum]
+
+end LeanCert.QProduct

--- a/LeanCert/QProduct/InfiniteProduct.lean
+++ b/LeanCert/QProduct/InfiniteProduct.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.QProduct.PrimeLambda
+import Mathlib.Analysis.SpecialFunctions.Log.Summable
+import Mathlib.Topology.Algebra.InfiniteSum.NatInt
+import Mathlib.MeasureTheory.Integral.DominatedConvergence
+
+/-!
+# The analytic bridge: `primeLambda` is the prime product integral
+
+`primeLambda` is defined as the infimum of the truncation values
+`primeFRat N`. This file identifies it with the integral of the infinite
+prime product:
+
+  `primeLambda = ∫ u in 0..1, ∏' p : Nat.Primes, (1 - u ^ (p : ℕ))`.
+
+The proof has three parts:
+
+1. pointwise, for `0 ≤ u < 1`, the finite products `qProd (primesLE N) u`
+   converge to the infinite product (multipliability via comparison with the
+   geometric series);
+2. dominated convergence (dominating function `1`) passes the limit through
+   the integral;
+3. the truncation integrals are antitone and bounded below, so they converge
+   to their infimum, which is `primeLambda` by definition; limits are unique.
+
+Consequently every certified enclosure of `primeLambda` in this development
+is an enclosure of the analytic constant.
+-/
+
+namespace LeanCert.QProduct
+
+open Filter MeasureTheory intervalIntegral Set
+open scoped Topology
+
+/-- `qProd S` is continuous. -/
+theorem qProd_continuous (S : Finset Nat) : Continuous fun u : ℝ => qProd S u := by
+  unfold qProd
+  exact continuous_finsetProd S fun n _ => continuous_const.sub (continuous_pow n)
+
+/-- The prime-indicator geometric coefficients are summable for `0 ≤ u < 1`. -/
+theorem summable_primeIndicator_pow {u : ℝ} (h0 : 0 ≤ u) (h1 : u < 1) :
+    Summable fun n : ℕ => if Nat.Prime n then -(u ^ n) else 0 := by
+  have hgeom : Summable fun n : ℕ => u ^ n := summable_geometric_of_lt_one h0 h1
+  refine Summable.of_abs (hgeom.of_nonneg_of_le (fun n => abs_nonneg _) fun n => ?_)
+  by_cases hn : Nat.Prime n
+  · simp [hn, abs_of_nonneg (pow_nonneg h0 n)]
+  · simp [hn, pow_nonneg h0 n]
+
+/-- Pointwise convergence of the finite prime products to the infinite
+product, for `0 ≤ u < 1`. -/
+theorem qProd_primesLE_tendsto_tprod {u : ℝ} (h0 : 0 ≤ u) (h1 : u < 1) :
+    Tendsto (fun N => qProd (primesLE N) u) atTop
+      (𝓝 (∏' p : Nat.Primes, (1 - u ^ (p : ℕ)))) := by
+  classical
+  set h : ℕ → ℝ := fun n => if Nat.Prime n then 1 - u ^ n else 1 with hh
+  have hfh : (fun n : ℕ => 1 + (if Nat.Prime n then -(u ^ n) else 0)) = h := by
+    funext n
+    by_cases hn : Nat.Prime n <;> simp [hh, hn, sub_eq_add_neg]
+  have hM : Multipliable h := by
+    rw [← hfh]
+    exact Real.multipliable_one_add_of_summable (summable_primeIndicator_pow h0 h1)
+  -- tprod over ℕ of `h` equals the tprod over the primes.
+  have htp : ∏' n : ℕ, h n = ∏' p : Nat.Primes, (1 - u ^ (p : ℕ)) := by
+    have hind :
+        h = Set.mulIndicator {n : ℕ | Nat.Prime n} (fun n => 1 - u ^ n) := by
+      funext n
+      by_cases hn : Nat.Prime n <;>
+        simp [hh, hn, Set.mem_setOf_eq]
+    rw [hind, ← tprod_subtype {n : ℕ | Nat.Prime n} (fun n => 1 - u ^ n)]
+    rfl
+  -- partial products over `range (N+1)` are the truncations.
+  have hrange : ∀ N, ∏ i ∈ Finset.range (N + 1), h i = qProd (primesLE N) u := by
+    intro N
+    unfold qProd primesLE
+    rw [Finset.prod_filter]
+  have htends := hM.hasProd.tendsto_prod_nat
+  rw [htp] at htends
+  have hshift :
+      Tendsto (fun N : ℕ => ∏ i ∈ Finset.range (N + 1), h i) atTop
+        (𝓝 (∏' p : Nat.Primes, (1 - u ^ (p : ℕ)))) :=
+    htends.comp (tendsto_add_atTop_nat 1)
+  simpa [hrange] using hshift
+
+/-- Dominated convergence: the truncation integrals converge to the integral
+of the infinite product. -/
+theorem tendsto_primeFRat_integral_tprod :
+    Tendsto (fun N => (primeFRat N : ℝ)) atTop
+      (𝓝 (∫ u in (0:ℝ)..1, ∏' p : Nat.Primes, (1 - u ^ (p : ℕ)))) := by
+  have hcast : ∀ N, (primeFRat N : ℝ) = F (primesLE N) := by
+    intro N
+    unfold primeFRat
+    rw [finiteIntegralRat_correct]
+  have hF : ∀ N, F (primesLE N) =
+      ∫ u in Set.Ioc (0:ℝ) 1, qProd (primesLE N) u := by
+    intro N
+    unfold F
+    exact integral_of_le (by norm_num)
+  have hG : (∫ u in (0:ℝ)..1, ∏' p : Nat.Primes, (1 - u ^ (p : ℕ))) =
+      ∫ u in Set.Ioc (0:ℝ) 1, ∏' p : Nat.Primes, (1 - u ^ (p : ℕ)) :=
+    integral_of_le (by norm_num)
+  rw [funext hcast]
+  simp only [hF, hG]
+  -- dominated convergence over `volume.restrict (Ioc 0 1)` with bound `1`.
+  apply MeasureTheory.tendsto_integral_of_dominated_convergence
+    (bound := fun _ : ℝ => (1 : ℝ))
+  · exact fun N => ((qProd_continuous (primesLE N)).aestronglyMeasurable).restrict
+  · exact MeasureTheory.integrableOn_const measure_Ioc_lt_top.ne
+  · intro N
+    refine (MeasureTheory.ae_restrict_iff' measurableSet_Ioc).mpr
+      (Filter.Eventually.of_forall fun u hu => ?_)
+    have hu' : u ∈ Set.Icc (0:ℝ) 1 := ⟨hu.1.le, hu.2⟩
+    have h0 := qProd_nonneg (primesLE N) hu'
+    have h1 := qProd_le_one (primesLE N) hu'
+    rw [Real.norm_eq_abs, abs_of_nonneg h0]
+    exact h1
+  · -- a.e. pointwise convergence: everywhere on `Ioc 0 1` except `u = 1`.
+    have hmem : ∀ᵐ u ∂(volume.restrict (Set.Ioc (0:ℝ) 1)),
+        u ∈ Set.Ioc (0:ℝ) 1 := ae_restrict_mem measurableSet_Ioc
+    have hne : ∀ᵐ u : ℝ ∂volume, u ≠ (1:ℝ) := by
+      have hz : volume ({(1:ℝ)} : Set ℝ) = 0 := measure_singleton _
+      have := MeasureTheory.measure_eq_zero_iff_ae_notMem.mp hz
+      exact this.mono fun u hu => by simpa using hu
+    have hne' : ∀ᵐ u ∂(volume.restrict (Set.Ioc (0:ℝ) 1)), u ≠ (1:ℝ) :=
+      hne.filter_mono (MeasureTheory.ae_mono Measure.restrict_le_self)
+    filter_upwards [hmem, hne'] with u hu hu1
+    exact qProd_primesLE_tendsto_tprod hu.1.le (lt_of_le_of_ne hu.2 hu1)
+
+/-- The truncation integrals converge to `primeLambda`. -/
+theorem tendsto_primeFRat_primeLambda :
+    Tendsto (fun N => (primeFRat N : ℝ)) atTop (𝓝 primeLambda) := by
+  have hanti : Antitone fun N => (primeFRat N : ℝ) := fun a b hab =>
+    primeFRat_antitone hab
+  have hbdd : BddBelow (Set.range fun N => (primeFRat N : ℝ)) := by
+    refine ⟨0, ?_⟩
+    rintro x ⟨M, rfl⟩
+    show (0:ℝ) ≤ (primeFRat M : ℝ)
+    unfold primeFRat
+    rw [finiteIntegralRat_correct]
+    unfold F
+    apply intervalIntegral.integral_nonneg (by norm_num)
+    intro u hu
+    exact qProd_nonneg _ hu
+  exact tendsto_atTop_ciInf hanti hbdd
+
+/-- **The analytic bridge**: the directed prime limit equals the integral of
+the infinite prime product. Every certified enclosure of `primeLambda` is an
+enclosure of this analytic constant. -/
+theorem primeLambda_eq_integral_tprod :
+    primeLambda = ∫ u in (0:ℝ)..1, ∏' p : Nat.Primes, (1 - u ^ (p : ℕ)) :=
+  tendsto_nhds_unique tendsto_primeFRat_primeLambda tendsto_primeFRat_integral_tprod
+
+end LeanCert.QProduct

--- a/LeanCert/QProduct/LimitCert.lean
+++ b/LeanCert/QProduct/LimitCert.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.QProduct.PrimeLambda
+import LeanCert.Validity.DirectedLimit
+
+/-!
+# Directed-limit certificate for the prime q-product limit
+
+Packages the prime sandwich (`primeLambda_sandwich`) as a
+`LeanCert.Validity.DirectedLimitCert`, so two-sided rational bounds on
+`primeLambda` become a single `checkLimitInterval` evaluation — no per-bound
+`∀ M` tail hypothesis at the use site.
+
+The truncation index is shifted by two (`approx N = primeFRat (N + 2)`) so
+the sandwich's `2 ≤ N` side condition holds at every index, and the tail
+exponent `oddAbove (N + 2)` is the least odd number exceeded by every prime
+beyond the truncation, discharging the sandwich's parity and tail-size
+hypotheses uniformly.
+-/
+
+namespace LeanCert.QProduct
+
+/-- The least odd number `> N` (so every odd number `> N`, in particular
+every prime `> max N 2`, is at least this). -/
+def oddAbove (N : ℕ) : ℕ :=
+  if N % 2 = 0 then N + 1 else N + 2
+
+theorem oddAbove_odd (N : ℕ) : Odd (oddAbove N) := by
+  unfold oddAbove
+  rw [Nat.odd_iff]
+  split <;> omega
+
+theorem le_oddAbove_of_prime_gt {N p : ℕ} (hN : 2 ≤ N)
+    (hp : Nat.Prime p) (hgt : N < p) : oddAbove N ≤ p := by
+  have hp2 : p ≠ 2 := by omega
+  have hodd : p % 2 = 1 := Nat.odd_iff.mp (hp.odd_of_ne_two hp2)
+  unfold oddAbove
+  split <;> omega
+
+/-- Shifted truncations bound `primeLambda` from above. -/
+theorem primeLambda_le_shiftedTrunc (N : ℕ) :
+    primeLambda ≤ (primeFRat (N + 2) : ℝ) :=
+  primeLambda_le_trunc (N + 2)
+
+/-- Tail-corrected shifted truncations bound `primeLambda` from below. -/
+theorem shiftedTrunc_sub_tail_le_primeLambda (N : ℕ) :
+    (primeFRat (N + 2) : ℝ) -
+        (primeSandwichErrorRat (N + 2) (oddAbove (N + 2)) : ℝ) ≤
+      primeLambda :=
+  (primeLambda_sandwich (by omega) (oddAbove_odd _)
+    (fun p hp hgt => le_oddAbove_of_prime_gt (by omega) hp hgt)).1
+
+/-- The prime q-product directed limit as a `DirectedLimitCert`. -/
+noncomputable def primeLambdaLimitCert : Validity.DirectedLimitCert where
+  approx N := primeFRat (N + 2)
+  tail N := primeSandwichErrorRat (N + 2) (oddAbove (N + 2))
+  limit := primeLambda
+  limit_le_approx := primeLambda_le_shiftedTrunc
+  approx_sub_tail_le_limit := shiftedTrunc_sub_tail_le_primeLambda
+
+end LeanCert.QProduct

--- a/LeanCert/QProduct/PrimeLambda.lean
+++ b/LeanCert/QProduct/PrimeLambda.lean
@@ -15,10 +15,11 @@ This file introduces the finite prime truncations and the directed prime limit a
 an infimum over the truncation values.  The tail-sandwich certificates live on
 top of these definitions.
 
-`primeLambda` is defined as the infimum of the finite-truncation values, and
-the theorems in this development are about that object. The identification of
-the infimum with the infinite prime-product integral `∫₀¹ ∏_p (1 - u^p) du`
-is not formalized here; see the `primeLambda` docstring.
+`primeLambda` is defined as the infimum of the finite-truncation values. The
+identification with the infinite prime-product integral
+`∫₀¹ ∏'_p (1 - u^p) du` is proved in `QProduct.InfiniteProduct`
+(`primeLambda_eq_integral_tprod`), so certified enclosures of `primeLambda`
+are enclosures of the analytic constant.
 -/
 
 namespace LeanCert.QProduct
@@ -56,10 +57,9 @@ noncomputable def primeSandwichLowerFun (N m : Nat) (u : ℝ) : ℝ :=
 finite-truncation values `primeFRat N`.
 
 The truncations are antitone (`primeFRat_antitone`) and bounded below by `0`,
-so this infimum coincides with the limit of the truncation sequence. The
-identification of that limit with the infinite prime-product integral
-`∫₀¹ ∏_p (1 - u^p) du` is not formalized; theorems about `primeLambda` are
-theorems about the truncation infimum. -/
+so this infimum coincides with the limit of the truncation sequence, and by
+`primeLambda_eq_integral_tprod` (in `QProduct.InfiniteProduct`) it equals the
+integral of the infinite prime product `∫₀¹ ∏'_p (1 - u^p) du`. -/
 noncomputable def primeLambda : ℝ :=
   sInf (Set.range fun N : Nat => (primeFRat N : ℝ))
 

--- a/LeanCert/Validity.lean
+++ b/LeanCert/Validity.lean
@@ -13,6 +13,7 @@ import LeanCert.Validity.CertificateIntegration
 import LeanCert.Validity.IntegrationDyadic
 import LeanCert.Validity.AffineBounds
 import LeanCert.Validity.Monotonicity
+import LeanCert.Validity.DirectedLimit
 
 /-!
 # Validity Layer

--- a/LeanCert/Validity/DirectedLimit.lean
+++ b/LeanCert/Validity/DirectedLimit.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Mathlib.Topology.Order.Basic
+import Mathlib.Topology.Instances.Real.Lemmas
+import Mathlib.Data.Rat.Cast.Order
+
+/-!
+# Directed-limit certificates
+
+A recurring proof shape in verified numerics: a real limit object `x`
+(an infinite series, an infinite product integral, a directed `sInf`/`sSup`)
+is approximated by computable rational truncations `approx N`, with
+
+* every truncation an upper bound: `x ≤ approx N`, and
+* a computable tail majorant: `approx N - tail N ≤ x`.
+
+Given these two inequality families, a two-sided rational enclosure of `x`
+is a boolean check at a single index `N`. This module provides the checker,
+the golden theorem, a packaging structure, and the convergence corollary
+(`approx N → x` whenever `tail N → 0`).
+
+Existing instances of this shape in the library include the prime q-product
+sandwich (`LeanCert.QProduct.primeLambda_sandwich`, packaged as a
+`DirectedLimitCert` in `LeanCert.QProduct.LimitCert`) and the tail-interval
+decompositions in the Li2 and BKLNW developments. The symmetric (monotone
+from below) variant is obtained by negation and is not duplicated here.
+
+## Main definitions
+
+* `checkLimitInterval` — boolean enclosure check at one truncation index
+* `verify_limit_interval` — golden theorem: check ⟹ real enclosure
+* `DirectedLimitCert` — packaging of the two inequality families
+* `DirectedLimitCert.approx_tendsto_limit` — vanishing tails ⟹ convergence
+-/
+
+namespace LeanCert.Validity
+
+open Filter Topology
+
+/-- Boolean enclosure check for a directed limit at truncation index `N`:
+the lower endpoint is cleared by the tail-corrected truncation and the upper
+endpoint by the truncation itself. -/
+def checkLimitInterval (approx tail : ℕ → ℚ) (N : ℕ) (lo hi : ℚ) : Bool :=
+  decide (lo ≤ approx N - tail N) && decide (approx N ≤ hi)
+
+/-- Golden theorem for directed-limit certificates: a successful
+`checkLimitInterval` at any single index yields a two-sided real enclosure
+of the limit object. -/
+theorem verify_limit_interval {x : ℝ} {approx tail : ℕ → ℚ}
+    (hupper : ∀ N, x ≤ (approx N : ℝ))
+    (hlower : ∀ N, (approx N : ℝ) - (tail N : ℝ) ≤ x)
+    (N : ℕ) (lo hi : ℚ)
+    (hcheck : checkLimitInterval approx tail N lo hi = true) :
+    (lo : ℝ) ≤ x ∧ x ≤ (hi : ℝ) := by
+  unfold checkLimitInterval at hcheck
+  rw [Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq] at hcheck
+  constructor
+  · calc (lo : ℝ) ≤ ((approx N - tail N : ℚ) : ℝ) := by exact_mod_cast hcheck.1
+      _ = (approx N : ℝ) - (tail N : ℝ) := by push_cast; ring
+      _ ≤ x := hlower N
+  · calc x ≤ (approx N : ℝ) := hupper N
+      _ ≤ (hi : ℝ) := by exact_mod_cast hcheck.2
+
+/-- A directed-limit certificate: a real limit object enclosed from above by
+computable rational truncations and from below by truncation minus a
+computable tail majorant. -/
+structure DirectedLimitCert where
+  /-- Computable rational truncation values. -/
+  approx : ℕ → ℚ
+  /-- Computable tail majorant at each truncation index. -/
+  tail : ℕ → ℚ
+  /-- The semantic limit object. -/
+  limit : ℝ
+  /-- Every truncation bounds the limit from above. -/
+  limit_le_approx : ∀ N, limit ≤ (approx N : ℝ)
+  /-- The tail-corrected truncation bounds the limit from below. -/
+  approx_sub_tail_le_limit : ∀ N, (approx N : ℝ) - (tail N : ℝ) ≤ limit
+
+namespace DirectedLimitCert
+
+/-- Golden theorem, packaged form. -/
+theorem verify_interval (C : DirectedLimitCert) {approx tail : ℕ → ℚ}
+    (hA : C.approx = approx) (hT : C.tail = tail)
+    (N : ℕ) (lo hi : ℚ)
+    (hcheck : checkLimitInterval approx tail N lo hi = true) :
+    (lo : ℝ) ≤ C.limit ∧ C.limit ≤ (hi : ℝ) :=
+  verify_limit_interval (hA ▸ C.limit_le_approx)
+    (by rw [← hA, ← hT]; exact C.approx_sub_tail_le_limit) N lo hi hcheck
+
+/-- Vanishing tails imply convergence of the truncations to the limit. -/
+theorem approx_tendsto_limit (C : DirectedLimitCert)
+    (htail : Tendsto (fun N => (C.tail N : ℝ)) atTop (𝓝 0)) :
+    Tendsto (fun N => (C.approx N : ℝ)) atTop (𝓝 C.limit) := by
+  have hupper : ∀ N, (C.approx N : ℝ) ≤ C.limit + (C.tail N : ℝ) := by
+    intro N
+    have := C.approx_sub_tail_le_limit N
+    linarith
+  have hconst : Tendsto (fun _ : ℕ => C.limit) atTop (𝓝 C.limit) :=
+    tendsto_const_nhds
+  have hplus : Tendsto (fun N => C.limit + (C.tail N : ℝ)) atTop
+      (𝓝 (C.limit + 0)) := hconst.add htail
+  rw [add_zero] at hplus
+  exact tendsto_of_tendsto_of_tendsto_of_le_of_le hconst hplus
+    C.limit_le_approx hupper
+
+end DirectedLimitCert
+
+end LeanCert.Validity

--- a/docs/proof-templates/directed-limits.md
+++ b/docs/proof-templates/directed-limits.md
@@ -1,0 +1,59 @@
+# Directed-Limit Certificates
+
+Module: `LeanCert.Validity.DirectedLimit`
+
+Use this template when a real limit object — an infinite series, an infinite
+product integral, a directed `sInf`/`sSup` — is approximated by computable
+rational truncations with a computable tail majorant:
+
+```text
+x ≤ approx N                 (every truncation bounds the limit from above)
+approx N - tail N ≤ x        (tail-corrected truncation bounds it from below)
+```
+
+Given these two inequality families (supplied once, as mathematics), any
+two-sided rational enclosure of `x` becomes a single boolean evaluation:
+
+```lean
+theorem verify_limit_interval {x : ℝ} {approx tail : ℕ → ℚ}
+    (hupper : ∀ N, x ≤ (approx N : ℝ))
+    (hlower : ∀ N, (approx N : ℝ) - (tail N : ℝ) ≤ x)
+    (N : ℕ) (lo hi : ℚ)
+    (hcheck : checkLimitInterval approx tail N lo hi = true) :
+    (lo : ℝ) ≤ x ∧ x ≤ (hi : ℝ)
+```
+
+Tightening a bound is a change of the index `N` and the endpoints — no new
+mathematics at the use site.
+
+`DirectedLimitCert` packages the two families as a structure, and
+`DirectedLimitCert.approx_tendsto_limit` derives convergence of the
+truncations to the limit whenever the tails vanish.
+
+## Worked instance: the prime q-product limit
+
+`LeanCert.QProduct.LimitCert` packages the prime sandwich
+(`primeLambda_sandwich`) as `primeLambdaLimitCert`, with shifted truncations
+`approx N = primeFRat (N + 2)` and tails
+`tail N = primeSandwichErrorRat (N + 2) (oddAbove (N + 2))`, so all side
+conditions (truncation size, tail parity, tail dominance) are discharged
+uniformly. Bounds then read:
+
+```lean
+example : ((19 / 36 : ℚ) : ℝ) ≤ primeLambda ∧ primeLambda ≤ ((7 / 12 : ℚ) : ℝ) :=
+  LeanCert.Validity.verify_limit_interval
+    primeLambda_le_shiftedTrunc
+    shiftedTrunc_sub_tail_le_primeLambda
+    1 (19 / 36) (7 / 12)
+    (by native_decide)
+```
+
+Compare `LeanCert.QProduct.verify_primeLambda_interval_of_forall`, which
+requires a per-use `∀ M` tail hypothesis: this template factors that
+hypothesis out into the certificate, once.
+
+## Other candidate instances
+
+The Li2 tail-interval decomposition and the BKLNW tail bounds follow the same
+truncation-plus-tail shape and can be repackaged as `DirectedLimitCert`
+values; the monotone-from-below variant is obtained by negation.

--- a/docs/proof-templates/overview.md
+++ b/docs/proof-templates/overview.md
@@ -27,3 +27,5 @@ that must be supplied by project-specific mathematics.
 | [ConstantFactory](constant-factory.md) | a base object with reusable moments and finite perturbations |
 | [QProduct finite integrals](qproduct-finite-integrals.md) | exact finite product-integral identities |
 | [Contour-shift certificates](contour-shift.md) | rectangle identities, horizontal vanishing, vertical limits, and residue data |
+| [Directed-limit certificates](directed-limits.md) | a limit object enclosed by computable truncations with a computable tail majorant |
+| [Wall quotients](wall-quotients.md) | a `0/0` removable singularity whose enclosure must come from derivative data |

--- a/docs/proof-templates/wall-quotients.md
+++ b/docs/proof-templates/wall-quotients.md
@@ -25,15 +25,26 @@ enclosure problem into a regular one.
 Model instance (`expm1_div_self_mem`): `(eˣ − 1)/x ∈ [1, e]` on `(0, 1)`,
 with the wall at `x = 0` and the regular data `1 ≤ eˣ ≤ e`.
 
+## Order-k walls
+
+For numerator and denominator vanishing to order `k`, the derivative data is
+packaged as a `DerivLadder k w b`: explicit functions `f 0, …, f k` with each
+`f (i+1)` the derivative of `f i` on `(w, b)`, all levels below the top
+vanishing at the wall. `quotient_mem_of_derivLadder` traps the bottom-level
+quotient by ratio bounds on the top level, by induction through the order-1
+core; positivity propagates down the denominator ladder by the mean value
+theorem (`DerivLadder.pos_of_top`).
+
+Order-2 model instance (`expm1_sub_self_div_sq_mem`):
+`(eᵗ − t − 1)/t² ∈ [1/2, e/2]` on `(0, 1)`.
+
 ## Status and roadmap
 
-This is the order-1 core. Planned extensions:
+Remaining extensions:
 
-* order-`k` walls (numerator and denominator vanishing to higher order), via
-  iterated Cauchy MVT or Taylor remainders — the case needed by integrands
-  like the symmetric log combination in the Li2 development, whose wall data
-  currently uses bespoke tail lemmas;
 * a left-of-wall variant and a two-sided wrapper;
+* ladders for the symmetric log integrand of the Li2 development (an order-2
+  wall at `t = 0`), replacing its bespoke tail lemmas;
 * engine hookup: a wall-aware partition step for `interval_integrate` that
   evaluates jets at singular endpoints and the standard interval engine
   elsewhere.

--- a/docs/proof-templates/wall-quotients.md
+++ b/docs/proof-templates/wall-quotients.md
@@ -1,0 +1,39 @@
+# Wall Quotients (Removable Singularities)
+
+Module: `LeanCert.Analysis.WallQuotient`
+
+Interval evaluation degenerates at a point `w` where an expression has the
+form `num/den` with `num w = den w = 0`: the order-0 data is `0/0` and a naive
+enclosure is vacuous. The information lives one jet order up. The order-1
+enclosure is the Cauchy mean value theorem in certificate form:
+
+```lean
+theorem quotient_mem_of_deriv_ratio_bounds
+    {num den num' den' : ℝ → ℝ} {w b lo hi : ℝ}
+    (hnum0 : num w = 0) (hden0 : den w = 0)
+    -- continuity on [w, b], HasDerivAt on (w, b), den' > 0 on (w, b)
+    (hlo : ∀ x ∈ Ioo w b, lo * den' x ≤ num' x)
+    (hhi : ∀ x ∈ Ioo w b, num' x ≤ hi * den' x)
+    {t : ℝ} (ht : t ∈ Ioo w b) :
+    num t / den t ∈ Icc lo hi
+```
+
+The derivative-ratio bounds `lo · den′ ≤ num′ ≤ hi · den′` are ordinary,
+wall-free interval-evaluation targets, so the theorem converts a singular
+enclosure problem into a regular one.
+
+Model instance (`expm1_div_self_mem`): `(eˣ − 1)/x ∈ [1, e]` on `(0, 1)`,
+with the wall at `x = 0` and the regular data `1 ≤ eˣ ≤ e`.
+
+## Status and roadmap
+
+This is the order-1 core. Planned extensions:
+
+* order-`k` walls (numerator and denominator vanishing to higher order), via
+  iterated Cauchy MVT or Taylor remainders — the case needed by integrands
+  like the symmetric log combination in the Li2 development, whose wall data
+  currently uses bespoke tail lemmas;
+* a left-of-wall variant and a two-sided wrapper;
+* engine hookup: a wall-aware partition step for `interval_integrate` that
+  evaluates jets at singular endpoints and the standard interval engine
+  elsewhere.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,8 @@ nav:
     - ConstantFactory: proof-templates/constant-factory.md
     - Exact Product-Integral Certificates: proof-templates/qproduct-finite-integrals.md
     - Contour Shift: proof-templates/contour-shift.md
+    - Directed Limits: proof-templates/directed-limits.md
+    - Wall Quotients: proof-templates/wall-quotients.md
   - Domain Libraries:
     - Overview: domains/overview.md
     - Analytic Number Theory:


### PR DESCRIPTION
This pull request introduces two new proof-certificate templates to the LeanCert library: directed-limit certificates and wall quotients at removable singularities. It provides both the mathematical infrastructure (theorems, structures, and model instances) and documentation for these templates, and demonstrates their use by packaging the prime q-product limit as a directed-limit certificate. The documentation is updated to reflect these additions, and new modules are imported where needed.

**New proof-certificate templates and infrastructure:**

* **Directed-limit certificates:**
  - Adds `LeanCert.Validity.DirectedLimit`, providing the `DirectedLimitCert` structure, the `checkLimitInterval` boolean checker, and the main theorems for verifying two-sided enclosures and convergence for real limits approximated by rational truncations and computable tails.
  - Packages the prime q-product limit as `primeLambdaLimitCert` in `LeanCert.QProduct.LimitCert`, using shifted truncations and uniform tail bounds, and demonstrates its use in `LeanCert/Examples/QProduct/PrimeLambda.lean`. [[1]](diffhunk://#diff-e3a401bb1cef9a0caaefb0dea79e79d4103b6b4f1d9d293b4890aa9dcb7f9048R1-R64) [[2]](diffhunk://#diff-062f7c25a0e2b3c6bd85eaf475a4146e5b96fc4f1988fedb07828f8f59e7c16fR11) [[3]](diffhunk://#diff-841a260dd1a138473f63042ec665ed0e0c0537f4ea5841267eaa7c2f27ebe254R50-R59)
  - Updates imports and documentation to reference the new directed-limit certificate template. [[1]](diffhunk://#diff-49f4bddaa2aaf9be2664900cf8780a3e068a8146a109ca0f66938d87b5ebec57R16) [[2]](diffhunk://#diff-6676a8ea786098c28842971c20af527d7fc04e2da5835524b4d460ad87b022f1R1-R59) [[3]](diffhunk://#diff-520c02bc7ac54282bc237a38cf29297ee2c065da429e25f326b1e999b364517dR30-R31) [[4]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R73-R74)

* **Wall quotients at removable singularities:**
  - Adds `LeanCert.Analysis.WallQuotient`, providing the `quotient_mem_of_deriv_ratio_bounds` theorem (Cauchy mean value theorem for `0/0` removable singularities) and a model instance for `(exp(x) - 1)/x` on `(0, 1)`.
  - Documents the wall quotient template and its intended roadmap. [[1]](diffhunk://#diff-e44a4154a38055434fdd750c5b5a9f7899373e23da993da77716405ca6db21a9R1-R39) [[2]](diffhunk://#diff-520c02bc7ac54282bc237a38cf29297ee2c065da429e25f326b1e999b364517dR30-R31) [[3]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R73-R74)
  - Updates imports to include the new module.

These changes extend the LeanCert library's proof-certificate repertoire, streamline enclosure proofs for limits and removable singularities, and improve documentation and discoverability.