### PR TITLE
Implement affine cover certificates for interval comparisons

### DIFF
--- a/LeanCert/Test/AffineCoverTest.lean
+++ b/LeanCert/Test/AffineCoverTest.lean
@@ -1,0 +1,40 @@
+import LeanCert.Validity.AffineCover
+
+/-!
+Regression test for the affine cover certificate.
+
+The comparison `0.8 + (5/3)·s² ≤ 9.2211·s³·exp(-0.8476·s)` on `s ∈ [0.83, 3.23]`
+is a `polynomial ≤ polynomial·exp` shape with the `s³`/`exp(-0.8476 s)`
+anti-correlation that defeats the plain interval backend even under
+subdivision.  The affine cover closes it: one `native_decide` over a
+width-0.1 partition.
+-/
+
+namespace LeanCert.Test.AffineCover
+
+open LeanCert.Core LeanCert.Validity
+
+-- f(s) = 0.8 + (5/3) s²
+def fE : Expr :=
+  Expr.add (Expr.const (4/5))
+    (Expr.mul (Expr.const (5/3)) (Expr.mul (Expr.var 0) (Expr.var 0)))
+
+-- g(s) = 9.2211 s³ exp(-0.8476 s)
+def gE : Expr :=
+  Expr.mul (Expr.mul (Expr.const (92211/10000))
+      (Expr.mul (Expr.mul (Expr.var 0) (Expr.var 0)) (Expr.var 0)))
+    (Expr.exp (Expr.mul (Expr.const (-2119/2500)) (Expr.var 0)))
+
+def bps : List ℚ := (List.range 24).map (fun k => ((83 + 10*(k+1) : ℚ))/100)
+
+theorem gminusf_supp : ExprSupportedCore (Expr.sub gE fE) := by
+  unfold gE fE Expr.sub; repeat constructor
+
+/-- The comparison holds on `[0.83, 3.23]`, via the affine cover. -/
+example :
+    ∀ x ∈ Set.Icc ((83/100 : ℚ) : ℝ) ((bps.getLast (by decide) : ℚ) : ℝ),
+      Expr.eval (fun _ => x) fE ≤ Expr.eval (fun _ => x) gE :=
+  verify_le_affine_cover fE gE gminusf_supp {} (83/100) bps (by decide)
+    (by native_decide)
+
+end LeanCert.Test.AffineCover

--- a/LeanCert/Validity.lean
+++ b/LeanCert/Validity.lean
@@ -12,6 +12,7 @@ import LeanCert.Validity.Integration
 import LeanCert.Validity.CertificateIntegration
 import LeanCert.Validity.IntegrationDyadic
 import LeanCert.Validity.AffineBounds
+import LeanCert.Validity.AffineCover
 import LeanCert.Validity.Monotonicity
 import LeanCert.Validity.DirectedLimit
 

--- a/LeanCert/Validity/AffineCover.lean
+++ b/LeanCert/Validity/AffineCover.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Validity.AffineBounds
+
+/-!
+# Affine cover certificates for interval lower bounds
+
+`interval_bound_subdiv` uses the plain interval backend and only handles bounds
+against a rational constant.  For dependency-heavy transcendental comparisons
+(e.g. `error term ≤ admissible curve`, where the curve is `polynomial · exp`),
+the plain interval product is too loose even under subdivision, but the affine
+backend — which tracks linear correlations between subterms — is tight on each
+small piece.
+
+This module packages "subdivide, check each piece with the affine backend" as a
+single boolean cover checker plus a golden theorem, in the same checker +
+soundness style as the rest of LeanCert.  The intended consumer is a comparison
+`∀ x ∈ [a,b], f x ≤ g x`, reduced to `0 ≤ (g - f) x` and covered.
+-/
+
+namespace LeanCert.Validity
+
+open LeanCert.Core LeanCert.Engine
+
+/-- Check that `c ≤ e` on every consecutive piece `[lo, b₀], [b₀, b₁], …` of a
+partition, using the strict affine single-interval backend.  Pieces with a
+non-ordered endpoint are rejected. -/
+def checkLowerAffineCover (e : Expr) (c : ℚ) (cfg : AffineConfig) :
+    ℚ → List ℚ → Bool
+  | _, [] => true
+  | lo, hi :: rest =>
+      (if h : lo ≤ hi then checkLowerBoundAffine1Strict e ⟨lo, hi, h⟩ c cfg
+        else false)
+      && checkLowerAffineCover e c cfg hi rest
+
+/-- Golden theorem: a successful affine cover proves `c ≤ e` on the whole
+interval `[lo, last]`, where `last` is the final breakpoint. -/
+theorem verify_lower_affine_cover (e : Expr) (hsupp : ExprSupportedCore e)
+    (c : ℚ) (cfg : AffineConfig) :
+    ∀ (lo : ℚ) (bps : List ℚ) (hbps : bps ≠ []),
+      checkLowerAffineCover e c cfg lo bps = true →
+      ∀ x ∈ Set.Icc (lo : ℝ) ((bps.getLast hbps : ℚ) : ℝ),
+        (c : ℝ) ≤ Expr.eval (fun _ => x) e := by
+  intro lo bps
+  induction bps generalizing lo with
+  | nil => intro hbps; exact absurd rfl hbps
+  | cons hi rest ih =>
+    intro _ hcheck
+    simp only [checkLowerAffineCover, Bool.and_eq_true] at hcheck
+    obtain ⟨hpiece, hrest⟩ := hcheck
+    -- the piece [lo, hi] must be ordered and pass the affine check
+    have hle : lo ≤ hi := by
+      by_contra h; simp [h] at hpiece
+    rw [dif_pos hle] at hpiece
+    have hleft := verify_lower_bound_affine1_strict e hsupp ⟨lo, hi, hle⟩ c cfg hpiece
+    cases rest with
+    | nil =>
+      -- getLast [hi] = hi; goal is exactly [lo, hi]
+      intro x hx
+      simp only [List.getLast_singleton] at hx
+      exact hleft x ((IntervalRat.mem_iff_mem_Icc _ _).mpr hx)
+    | cons hd tl =>
+      have hrestne : (hd :: tl) ≠ [] := by simp
+      have hih := ih hi hrestne hrest
+      intro x hx
+      rw [List.getLast_cons hrestne] at hx
+      obtain ⟨hxlo, hxhi⟩ := hx
+      by_cases hxm : x ≤ (hi : ℝ)
+      · exact hleft x ((IntervalRat.mem_iff_mem_Icc _ _).mpr ⟨hxlo, hxm⟩)
+      · exact hih x ⟨le_of_lt (not_le.mp hxm), hxhi⟩
+
+/-- Cover checker for a comparison `f ≤ g`: covers `g - f` against `0`. -/
+def checkLeAffineCover (f g : Expr) (cfg : AffineConfig) (lo : ℚ) (bps : List ℚ) :
+    Bool :=
+  checkLowerAffineCover (Expr.sub g f) 0 cfg lo bps
+
+/-- Golden theorem for affine comparison covers: a successful cover of `g - f`
+proves `f ≤ g` on the whole interval `[lo, last]`.  This closes
+dependency-heavy transcendental comparisons (e.g. `error ≤ admissible curve`)
+that the plain interval backend is too loose for even under subdivision. -/
+theorem verify_le_affine_cover (f g : Expr)
+    (hsupp : ExprSupportedCore (Expr.sub g f)) (cfg : AffineConfig)
+    (lo : ℚ) (bps : List ℚ) (hbps : bps ≠ [])
+    (hcheck : checkLeAffineCover f g cfg lo bps = true) :
+    ∀ x ∈ Set.Icc (lo : ℝ) ((bps.getLast hbps : ℚ) : ℝ),
+      Expr.eval (fun _ => x) f ≤ Expr.eval (fun _ => x) g := by
+  intro x hx
+  have h := verify_lower_affine_cover (Expr.sub g f) hsupp 0 cfg lo bps hbps hcheck x hx
+  simp only [Expr.sub, Expr.eval_add, Expr.eval_neg, Rat.cast_zero] at h
+  linarith
+
+end LeanCert.Validity


### PR DESCRIPTION
This pull request introduces support for affine cover certificates in the LeanCert library, enabling tighter verification of inequalities involving transcendental and correlated polynomial-exponential expressions. The main addition is a new module that implements the affine cover approach, along with a regression test and integration into the core library.

**Affine cover certificate support:**

* Added new module `LeanCert/Validity/AffineCover.lean` implementing affine cover certificates, including:
  - Functions to check inequalities on subdivided intervals using the affine backend (`checkLowerAffineCover`, `checkLeAffineCover`).
  - Golden theorems (`verify_lower_affine_cover`, `verify_le_affine_cover`) establishing soundness of the cover approach for verifying inequalities over an interval.

* Integrated the new affine cover module into the main validity library by importing it in `LeanCert/Validity.lean`.

**Testing:**

* Added a regression test in `LeanCert/Test/AffineCoverTest.lean` that demonstrates the effectiveness of the affine cover approach for a nontrivial polynomial-exponential comparison, which is challenging for the plain interval backend.… comparisons

interval_bound_subdiv uses the plain interval backend against a rational constant; for dependency-heavy transcendental comparisons (error term <= admissible curve, where the curve is polynomial * exp) the interval product is too loose even under subdivision, because the polynomial and exponential factors are anti-correlated. The affine backend tracks that correlation and is tight on each small piece.

Packages "subdivide, check each piece with the strict affine backend" as a boolean cover checker plus golden theorems, in the standard checker + soundness style:

- checkLowerAffineCover / verify_lower_affine_cover: c <= e on [lo, last] from one native_decide over a breakpoint partition.
- checkLeAffineCover / verify_le_affine_cover: the f <= g comparison form, covering g - f against 0.

Test (AffineCoverTest) closes 0.8 + (5/3) s^2 <= 9.2211 s^3 exp(-0.8476 s) on [0.83, 3.23] -- the FKS2 Corollary 22 admissible-curve comparison shape, which the plain interval backend cannot close.