### PR TITLE
docs: make leancert the default tactic entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ import LeanCert.Discovery.Commands
 Then turn the discovered estimate into a Lean theorem:
 
 ```lean
-import LeanCert.Tactic.IntervalAuto
+import LeanCert.Tactic
 
 example : forall x in Set.Icc (0 : Real) 1,
     x^2 + Real.sin x <= 2 := by
-  certify_bound
+  leancert
 ```
 
 ## Root Finding
@@ -160,8 +160,9 @@ tactic selected.
 | Goal                                       | Tactic                 |
 | ------------------------------------------ | ---------------------- |
 | Any recognized semantic goal               | `leancert`             |
-| `forall x in I, f x <= c`                  | `certify_bound`        |
-| `forall x in I, c <= f x`                  | `certify_bound`        |
+| `forall x in I, f x <= c`                  | `leancert`             |
+| `forall x in I, c <= f x`                  | `leancert`             |
+| Explicit single-variable bound engine      | `certify_bound`        |
 | Kernel-oriented dyadic bound               | `certify_kernel`       |
 | Multivariate bound                         | `multivariate_bound`   |
 | Root existence                             | `interval_roots`       |

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -644,7 +644,7 @@ theorem log_moneyness_upper :
 -- Gaussian core for vega calculation
 theorem gaussian_core_upper :
     ∀ x ∈ Set.Icc (0:ℝ) 2, Real.exp (-x * x / 2) ≤ (1 : ℚ) := by
-  certify_bound
+  leancert
 ```
 
 ### Physics: Projectile Motion (`examples/Projectile.lean`)
@@ -655,17 +655,17 @@ Proves bounds on projectile dynamics with air resistance:
 -- Drag acceleration: F_drag/m = k·v² ≤ 8.33 m/s²
 theorem drag_accel_upper :
     ∀ v ∈ Set.Icc (0:ℝ) 50, 1/300 * v * v ≤ (25/3 : ℚ) := by
-  certify_bound
+  leancert
 
 -- Net acceleration with gravity and drag
 theorem net_accel_lower :
     ∀ v ∈ Set.Icc (0:ℝ) 50, (7/5 : ℚ) ≤ 49/5 - 1/300 * v * v := by
-  certify_bound
+  leancert
 
 -- Exponential velocity decay
 theorem exp_decay_lower :
     ∀ t ∈ Set.Icc (-1:ℝ) 0, (36/100 : ℚ) ≤ Real.exp t := by
-  certify_bound
+  leancert
 ```
 
 ### Running the Examples

--- a/docs/direct/bounds.md
+++ b/docs/direct/bounds.md
@@ -13,6 +13,7 @@ Typical goals:
 Main tactics and commands:
 
 ```lean
+leancert
 certify_bound
 certify_kernel
 certify_kernel_fallback
@@ -23,7 +24,9 @@ multivariate_bound
 path can close the goal. Use `certify_kernel_fallback` when an explicit
 compiler/runtime fallback is acceptable.
 
-For ergonomic raw Lean goals, start with `leancert` or `certify_bound`.
+For ergonomic raw Lean goals, start with `leancert`. Use `certify_bound` when
+you intentionally want the dedicated single-variable interval engine, including
+explicit Taylor-depth selection.
 The stricter kernel path is best for reflected `Expr.eval` goals or for goals
 whose raw expression bridge is known to be supported. When you want to try that
 kernel path first but still allow the normal raw-expression automation, use
@@ -32,10 +35,10 @@ kernel path first but still allow the normal raw-expression automation, use
 Minimal example:
 
 ```lean
-import LeanCert.Tactic.IntervalAuto
+import LeanCert.Tactic
 
 example : ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.exp x ≤ 3 := by
-  certify_bound
+  leancert
 ```
 
 Discovery commands can help find a candidate bound before formalizing it.  See

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,10 +38,10 @@ LeanCert is organized around proof intent:
 ## Quick Lean Example
 
 ```lean
-import LeanCert.Tactic.IntervalAuto
+import LeanCert.Tactic
 
 example : forall x in Set.Icc (0 : Real) 1, Real.sin x <= 1 := by
-  certify_bound
+  leancert
 ```
 
 ## Install

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -75,7 +75,8 @@ example :
 
 ## Notes
 
-- Use `certify_bound` for direct inequality proofs.
+- Start direct inequality proofs with `leancert`; use `certify_bound` when you
+  intentionally want the dedicated interval-bound engine or explicit Taylor-depth control.
 - Use discovery commands to estimate constants before writing the final theorem.
 - Use proof templates when the proof has reusable structure: generated rows,
   main/error envelopes, perturbation observers, product-integral identities, or

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -41,7 +41,7 @@ aliases instead of keeping duplicate entry points:
 
 | Removed | Canonical replacement |
 | --- | --- |
-| `interval_bound` | `certify_bound`, or `leancert` |
+| `interval_bound` | `leancert`, or `certify_bound` for explicit engine control |
 | `fast_bound`, `fast_bound_quick`, `fast_bound_precise` | `certify_kernel_fallback`, `certify_kernel_quick_fallback`, `certify_kernel_precise_fallback` |
 | `interval_integrate` | state an ordinary integral equality/inequality and use `leancert` |
 | `#minimize`, `#maximize` | `#find_min`, `#find_max` |

--- a/docs/tactics/choosing-tactics.md
+++ b/docs/tactics/choosing-tactics.md
@@ -6,12 +6,20 @@ goal.  For the overall proof-shape chooser, start with
 
 > **Having issues?** See the [Troubleshooting Guide](troubleshooting.md) for common errors and solutions.
 
+For ordinary mathematical statements, start with `leancert`. The dedicated
+tactics below remain useful when you want to force a particular solver, select
+engine-specific parameters, or control the verification path.
+
 ## Decision Flowchart
 
 ```
 What do you want to prove?
 │
-├─► "∀ x ∈ I, f(x) ≤ c" or "∀ x ∈ I, f(x) ≥ c"
+├─► A recognized bound, root, extremum, finite-sum, or integral theorem?
+│   └─► leancert
+│       └─► Need to inspect the selected solver? ──► leancert?
+│
+├─► Need explicit control for "∀ x ∈ I, f(x) ≤ c" or "∀ x ∈ I, f(x) ≥ c"?
 │   │
 │   ├─► Single variable? ──► certify_bound
 │   │                        (or certify_kernel for kernel-only trust)
@@ -60,18 +68,18 @@ What do you want to prove?
 
 | I want to prove... | Tactic | Example |
 |-------------------|--------|---------|
-| Upper bound on interval | `certify_bound` | `∀ x ∈ Set.Icc 0 1, exp x ≤ 3` |
-| Lower bound on interval | `certify_bound` | `∀ x ∈ Set.Icc 0 1, 0 ≤ exp x` |
+| Any recognized mathematical goal | `leancert` | Bounds, roots, extrema, sums, and integrals |
+| Upper bound on interval | `leancert` | `∀ x ∈ Set.Icc 0 1, exp x ≤ 3` |
+| Lower bound on interval | `leancert` | `∀ x ∈ Set.Icc 0 1, 0 ≤ exp x` |
+| Bound with explicit Taylor depth | `certify_bound` | Same goals, direct interval-engine control |
 | Bound with kernel-only trust | `certify_kernel` | Same goals, higher trust |
-| Multivariate bound | `multivariate_bound` | `∀ x ∈ I, ∀ y ∈ J, x + y ≤ 2` |
-| Function has no roots | `root_bound` | `∀ x ∈ I, x² + 1 ≠ 0` |
-| Root exists | `interval_roots` | `∃ x ∈ I, x² - 2 = 0` |
-| Unique root exists | `interval_unique_root` | `∃! x ∈ I, x² - 2 = 0` |
-| Minimum exists | `interval_minimize` | `∃ m, ∀ x ∈ I, f x ≥ m` |
-| Maximum exists | `interval_maximize` | `∃ M, ∀ x ∈ I, f x ≤ M` |
-| Find the minimizer | `interval_argmin` | `∃ x ∈ I, ∀ y ∈ I, f x ≤ f y` |
-| Find the maximizer | `interval_argmax` | `∃ x ∈ I, ∀ y ∈ I, f y ≤ f x` |
-| Point inequality | `interval_decide` | `π < 3.15` |
+| Multivariate bound | `leancert` | `∀ x ∈ I, ∀ y ∈ J, x + y ≤ 2` |
+| Function has no roots | `leancert` | `∀ x ∈ I, x² + 1 ≠ 0` |
+| Root exists | `leancert` | `∃ x ∈ I, x² - 2 = 0` |
+| Unique root exists | `leancert` | `∃! x ∈ I, x² - 2 = 0` |
+| Minimum or maximum exists | `leancert` | Existential bound theorem |
+| Find the minimizer or maximizer | `leancert` | Argmin or argmax theorem |
+| Point inequality | `leancert` | `π < 3.15` |
 | Disprove a bound | `interval_refute` | Find counterexample |
 | Simplify vector indexing | `vec_simp` | `![a,b,c] ⟨1, h⟩ = b` |
 | Expand finite sums | `finsum_expand` | `∑ k ∈ Icc 1 3, f k = f 1 + f 2 + f 3` |
@@ -126,16 +134,17 @@ import LeanCert.Discovery.Commands
 Prove them separately and combine:
 
 ```lean
-theorem exp_lower : ∀ x ∈ Set.Icc (0:ℝ) 1, 1 ≤ Real.exp x := by certify_bound
-theorem exp_upper : ∀ x ∈ Set.Icc (0:ℝ) 1, Real.exp x ≤ 3 := by certify_bound
+theorem exp_lower : ∀ x ∈ Set.Icc (0:ℝ) 1, 1 ≤ Real.exp x := by leancert
+theorem exp_upper : ∀ x ∈ Set.Icc (0:ℝ) 1, Real.exp x ≤ 3 := by leancert
 
 theorem exp_bounded : ∀ x ∈ Set.Icc (0:ℝ) 1, 1 ≤ Real.exp x ∧ Real.exp x ≤ 3 :=
   fun x hx => ⟨exp_lower x hx, exp_upper x hx⟩
 ```
 
-### "Native syntax vs Expr AST"
+### "Dedicated tactic syntax vs Expr AST"
 
-Most tactics support native syntax, but some require Expr AST:
+When selecting a dedicated tactic directly, most support native syntax, but
+some also expose or require the reflected Expr AST:
 
 | Tactic | Native Syntax | Expr AST |
 |--------|---------------|----------|
@@ -179,4 +188,4 @@ example (a : Fin 3 → ℝ) :
 Common combinations:
 - `finsum_expand; ring` — expand sum, simplify arithmetic
 - `finsum_expand; vec_simp; ring` — expand sum, reduce vector indexing, simplify
-- `vec_simp; certify_bound` — simplify indexing, then prove bounds
+- `vec_simp; leancert` — simplify indexing, then prove the resulting mathematical goal

--- a/docs/tactics/discovery.md
+++ b/docs/tactics/discovery.md
@@ -31,7 +31,9 @@ example : exists M : Rat, forall x in Set.Icc (0 : Real) 1, Real.sin x <= M := b
 
 1. Use `#find_min` / `#bounds` to inspect behavior.
 2. Pick a clean rational target bound.
-3. Prove with `certify_bound` or existential tactics (`interval_minimize`, `interval_maximize`).
+3. Prove the final mathematical statement with `leancert`. Use a dedicated
+   tactic such as `certify_bound`, `interval_minimize`, or `interval_maximize`
+   when you need explicit strategy or configuration control.
 4. Keep the proof script minimal and reproducible.
 
 ## Split Repositories

--- a/docs/tactics/end-to-end-example.md
+++ b/docs/tactics/end-to-end-example.md
@@ -21,10 +21,10 @@ Suppose discovery reports an upper enclosure below `2`. That gives a safe theore
 ## Step 2: Write the Theorem
 
 ```lean
-import LeanCert.Tactic.IntervalAuto
+import LeanCert.Tactic
 
 example : forall x in Set.Icc (0 : Real) 1, x^2 + Real.sin x <= 2 := by
-  certify_bound
+  leancert
 ```
 
 ## Step 3: Add Root Evidence (Optional)
@@ -45,7 +45,8 @@ example : exists x in I12, Expr.eval (fun _ => x)
 
 1. Explore with discovery commands.
 2. Choose theorem constants with margin.
-3. Commit short proof scripts using `certify_bound` and related tactics.
+3. Commit short proof scripts using `leancert`; select a dedicated tactic only
+   when you need explicit engine or configuration control.
 
 ## Split Repositories
 

--- a/docs/tactics/tactics.md
+++ b/docs/tactics/tactics.md
@@ -134,7 +134,8 @@ example : Real.sin 1 + Real.cos 1 < 1.5 := by interval_decide
 example : Real.sqrt 2 < 1.42 := by interval_decide
 ```
 
-Use this for concrete values. For universally quantified bounds, use `certify_bound`.
+Use this for concrete values. For universally quantified mathematical bounds,
+start with `leancert`; use `certify_bound` for explicit interval-engine control.
 
 ---
 
@@ -701,9 +702,12 @@ certificate-generating paths. It recognizes `Finset.Icc`, `Finset.Ico`,
 ### Proving a function is bounded
 
 ```lean
--- Upper and lower bound
-example : ∀ x ∈ Set.Icc (0 : ℝ) 1, 0 ≤ Real.sin x ∧ Real.sin x ≤ 1 := by
-  constructor <;> certify_bound
+-- Upper and lower bounds with explicit interval-engine control
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, -1 ≤ Real.sin x := by
+  certify_bound
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.sin x ≤ 1 := by
+  certify_bound
 ```
 
 ### Proving a root exists and is unique

--- a/docs/tactics/troubleshooting.md
+++ b/docs/tactics/troubleshooting.md
@@ -4,6 +4,11 @@ Common issues and how to fix them.
 
 ## Tactic Failures
 
+For ordinary mathematical statements, try `leancert` first. The
+engine-specific recipes below apply when `leancert` reports that its bound
+portfolio was inconclusive or when you intentionally invoked a dedicated
+tactic for more control.
+
 ### "native_decide evaluated that the proposition is false"
 
 ```
@@ -29,7 +34,7 @@ is false
    ```lean
    -- exp(1) ≈ 2.718, so 2.72 may be too tight
    -- Try 2.75 or 3 instead
-   example : ∀ x ∈ I, Real.exp x ≤ 3 := by certify_bound
+   example : ∀ x ∈ I, Real.exp x ≤ 3 := by leancert
    ```
 
 3. **Use subdivision for tight bounds:**
@@ -65,12 +70,12 @@ with the goal
 
 **Solutions:**
 
-1. **First, just try it** - most expressions now work:
+1. **First, use the semantic front door** - most expressions now work:
    ```lean
    -- These all work now:
-   example : ∀ x ∈ I, 2 * x * x + 3 * x + 1 ≤ 6 := by certify_bound  -- ✓
-   example : ∀ x ∈ I, x * x - x + 1 ≤ 2 := by certify_bound           -- ✓
-   example : ∀ x ∈ I, 2 * Real.sin x + x * x ≤ 3 := by certify_bound  -- ✓
+   example : ∀ x ∈ I, 2 * x * x + 3 * x + 1 ≤ 6 := by leancert
+   example : ∀ x ∈ I, x * x - x + 1 ≤ 2 := by leancert
+   example : ∀ x ∈ I, 2 * Real.sin x + x * x ≤ 3 := by leancert
    ```
 
 2. **If it still fails, build the Expr AST explicitly:**
@@ -104,14 +109,18 @@ a✝ : x✝ ∈ I01
 ⊢ ∀ (y : ℝ), ↑I01.lo ≤ y → y ≤ ↑I01.hi → x✝ + y ≤ 2
 ```
 
-**Cause:** You used `certify_bound` for a multivariate goal, but it only handles single-variable bounds.
+**Cause:** You forced `certify_bound` on a multivariate goal, but that
+dedicated tactic only handles single-variable bounds.
 
-**Solution:** Use `multivariate_bound`:
+**Solution:** Use `leancert`, or select `multivariate_bound` explicitly:
 ```lean
 -- Instead of
 example : ∀ x ∈ I, ∀ y ∈ J, x + y ≤ 2 := by certify_bound  -- Fails
 
--- Use
+-- Preferred
+example : ∀ x ∈ I, ∀ y ∈ J, x + y ≤ 2 := by leancert
+
+-- Explicit dedicated solver
 example : ∀ x ∈ I, ∀ y ∈ J, x + y ≤ 2 := by multivariate_bound
 ```
 
@@ -302,7 +311,7 @@ example : ∀ x ∈ Set.Icc (-2 : ℝ) 2, x * x ≤ 3 := by
 
 -- Step 3: Prove
 example : ∀ x ∈ Set.Icc (0:ℝ) 1, Real.exp x + Real.sin x ≤ 4 := by
-  certify_bound 15
+  leancert
 ```
 
 ### Let LeanCert find bounds for you


### PR DESCRIPTION
Align landing pages, quickstarts, workflow guides, decision tables, and application examples around the semantic router. Retain dedicated tactics where explicit engine configuration, trust selection, reflected syntax, tracing, or troubleshooting is the subject.