### PR TITLE
Auto-mode cost gates + interval_bound compat alias (v4.32.2 prep)

### DIFF
--- a/LeanCert/Tactic/IntervalAuto/Bound.lean
+++ b/LeanCert/Tactic/IntervalAuto/Bound.lean
@@ -930,4 +930,12 @@ elab "certify_bound" depth:(num)? t:(leancertTrustItem)? : tactic => do
   withTrustMode (← elabTrustItem? t) do
     certifyBoundWithDepth (depth.map (·.getNat))
 
+/-- Deprecated alias for `certify_bound`, kept for downstream compatibility
+(PrimeNumberTheoremAnd's IEANTN files predate the rename). Prefer
+`certify_bound`. -/
+elab "interval_bound" depth:(num)? t:(leancertTrustItem)? : tactic => do
+  discard <| VerificationConfig.current
+  withTrustMode (← elabTrustItem? t) do
+    certifyBoundWithDepth (depth.map (·.getNat))
+
 end LeanCert.Tactic.Auto

--- a/LeanCert/Tactic/Verification.lean
+++ b/LeanCert/Tactic/Verification.lean
@@ -57,6 +57,34 @@ register_option leancert.trust.kernelHeartbeats : Nat := {
     leancert.trust = \"auto\" mode (same units as maxHeartbeats)"
 }
 
+register_option leancert.trust.autoGate : Bool := {
+  defValue := true
+  descr := "in leancert.trust = \"auto\" mode, skip the kernel attempt for \
+    certificates whose size predictably exceeds the calibrated kernel/native \
+    crossover (finite-sum term count, integration partition count, \
+    optimization iterations) and go straight to native_decide; see \
+    scripts/bench-trust/README.md for the calibration data"
+}
+
+register_option leancert.trust.autoMaxSumTerms : Nat := {
+  defValue := 2000
+  descr := "auto-mode gate: maximum finite-sum term count for which the \
+    kernel attempt is made (crossover ≈ 10^4 terms at ~35s/+1.5 GiB; \
+    ≤2×10^3 costs under a second)"
+}
+
+register_option leancert.trust.autoMaxPartitions : Nat := {
+  defValue := 500
+  descr := "auto-mode gate: maximum integration partition count for which \
+    the kernel attempt is made (500 partitions ≈ +2.5s)"
+}
+
+register_option leancert.trust.autoMaxOptIterations : Nat := {
+  defValue := 100
+  descr := "auto-mode gate: maximum branch-and-bound iteration limit for \
+    which the kernel attempt is made (25 iterations ≈ +2s)"
+}
+
 namespace LeanCert.Tactic
 
 initialize registerTraceClass `leancert.verification
@@ -137,8 +165,83 @@ private def closeKernelCore (certGoal : MVarId) (tacticName : String) :
       `set_option leancert.trust \"native\"` (or \"auto\") to allow \
       `native_decide`, which additionally trusts the compiler."
 
+/-! ### Auto-mode cost gate
+
+Thresholds come from `scripts/bench-trust/baselines/` (see the README there):
+kernel reduction is essentially free for point/bound/Newton certificates,
+cheap for moderate partition/subdivision counts, and crosses over to
+"markedly worse than native" around 10^4 finite-sum terms (superlinear time,
++1.5 GiB RSS). The gate reads scale parameters syntactically off the
+certificate goal; anything it does not recognize is attempted normally.
+
+The checker names below are unresolved `Name` literals because this module
+deliberately imports only `Lean` (everything in LeanCert imports it back).
+`LeanCert/Test/TrustModes.lean` builds these applications with *resolved*
+names and asserts the gate fires, so a checker rename breaks CI rather than
+silently disabling the gate. -/
+
+/-- First subterm that is a (full enough) application of any of `names`. -/
+private def findAppOfAny? (e : Expr) (names : List Name) (minArgs : Nat) :
+    Option Expr :=
+  e.find? fun sub => names.any (sub.isAppOf ·) && sub.getAppNumArgs ≥ minArgs
+
+/-- Length of a syntactic `List` literal (`List.cons` chain). -/
+private partial def listLitLength (e : Expr) (acc : Nat := 0) : Nat :=
+  if e.isAppOfArity ``List.cons 3 then listLitLength e.appArg! (acc + 1) else acc
+
+/-- If the certificate is predictably past the kernel/native crossover,
+return a human-readable reason to skip the kernel attempt in auto mode.
+`none` means "attempt the kernel". -/
+def autoGateReason? (opts : Options) (certType : Expr) : Option String := Id.run do
+  unless leancert.trust.autoGate.get opts do return none
+  let maxSum := leancert.trust.autoMaxSumTerms.get opts
+  let maxParts := leancert.trust.autoMaxPartitions.get opts
+  let maxIters := leancert.trust.autoMaxOptIterations.get opts
+  -- Finite sums over `Finset.Icc a b`: terms = b + 1 - a.
+  let sumChecks : List Name :=
+    [`LeanCert.Engine.checkFinSumUpperBoundFull, `LeanCert.Engine.checkFinSumLowerBoundFull,
+     `LeanCert.Engine.checkFinSumUpperBound, `LeanCert.Engine.checkFinSumLowerBound]
+  if let some app := findAppOfAny? certType sumChecks 3 then
+    let args := app.getAppArgs
+    if let (some a, some b) := (args[1]!.nat?, args[2]!.nat?) then
+      let terms := b + 1 - a
+      if terms > maxSum then
+        return some s!"finite sum with {terms} terms exceeds autoMaxSumTerms={maxSum}"
+  -- List-indexed finite sums: term count is the index-list literal length.
+  let listChecks : List Name :=
+    [`LeanCert.Engine.checkFinSumUpperBoundListFull,
+     `LeanCert.Engine.checkFinSumLowerBoundListFull]
+  if let some app := findAppOfAny? certType listChecks 3 then
+    if listLitLength app.getAppArgs[2]! > maxSum then
+      return some s!"list-indexed sum with {listLitLength app.getAppArgs[2]!} \
+        terms exceeds autoMaxSumTerms={maxSum}"
+  -- Partitioned integration: third argument is the partition count.
+  if let some app := findAppOfAny? certType
+      [`LeanCert.Validity.Integration.integratePartitionChecked] 3 then
+    if let some n := app.getAppArgs[2]!.nat? then
+      if n > maxParts then
+        return some s!"{n} integration partitions exceed autoMaxPartitions={maxParts}"
+  -- Global optimization: read maxIterations off a GlobalOptConfig literal.
+  let optChecks : List Name :=
+    [`LeanCert.Validity.GlobalOpt.checkGlobalUpperBound,
+     `LeanCert.Validity.GlobalOpt.checkGlobalLowerBound,
+     `LeanCert.Validity.GlobalOpt.checkGlobalBounds]
+  if (findAppOfAny? certType optChecks 4).isSome then
+    if let some cfgApp := findAppOfAny? certType
+        [`LeanCert.Engine.Optimization.GlobalOptConfig.mk] 1 then
+      if let some iters := cfgApp.getAppArgs[0]!.nat? then
+        if iters > maxIters then
+          return some s!"{iters} optimization iterations exceed autoMaxOptIterations={maxIters}"
+  return none
+
 private def closeAutoCore (cfg : VerificationConfig) (certGoal : MVarId)
     (tacticName : String) : TacticM VerificationUsed := do
+  let certType ← instantiateMVars (← certGoal.getType)
+  if let some reason := autoGateReason? (← getOptions) certType then
+    trace[leancert.verification] "{tacticName}: auto gate routed certificate to \
+      native_decide ({reason})"
+    closeNativeCore certGoal tacticName
+    return .native
   let s ← saveState
   try
     withOptions (fun o => o.set `maxHeartbeats cfg.kernelHeartbeats) do

--- a/LeanCert/Test/DownstreamPatterns/Tactics.lean
+++ b/LeanCert/Test/DownstreamPatterns/Tactics.lean
@@ -34,4 +34,10 @@ example : ∀ y ∈ Icc (3914 : ℝ) 3914,
     2 * y ^ 6 * exp (-y) ≤ (1 : ℝ) / 1000000 := by
   certify_bound 20
 
+/-- PNT+ (e.g. `RamanujanCalculations.lean`) still uses the pre-rename
+`interval_bound` spelling; the deprecated alias must keep parsing. -/
+example : ∀ y ∈ Icc (3914 : ℝ) 3914,
+    2 * y ^ 6 * exp (-y) ≤ (1 : ℝ) / 1000000 := by
+  interval_bound 20
+
 end LeanCert.Test.DownstreamPatterns.Tactics

--- a/LeanCert/Test/TrustModes.lean
+++ b/LeanCert/Test/TrustModes.lean
@@ -109,6 +109,49 @@ set_option leancert.trust "kernel" in
 theorem trustKernelUniqueRoot : ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x * x - 2 = 0 := by
   interval_unique_root
 
+/-! ### Auto-mode cost gate (calibrated thresholds; see scripts/bench-trust) -/
+
+-- Unit test with *resolved* checker names: if a checker is renamed, this
+-- breaks CI instead of silently disabling the gate (whose own references
+-- are unresolved Name literals to keep Verification.lean import-free).
+open Lean Meta LeanCert.Tactic in
+run_meta do
+  let body ← mkAppM ``LeanCert.Core.Expr.var #[toExpr (0 : Nat)]
+  let mkSumCheck (a b : Nat) : MetaM Lean.Expr := do
+    let app ← mkAppM ``LeanCert.Engine.checkFinSumUpperBoundFull
+      #[body, toExpr a, toExpr b, toExpr (0 : ℚ)]
+    mkEq app (toExpr true)
+  let opts ← getOptions
+  let bigTy ← mkSumCheck 1 5000
+  unless (autoGateReason? opts bigTy).isSome do
+    throwError "auto gate did not fire on a 5000-term finite sum"
+  let smallTy ← mkSumCheck 1 100
+  unless (autoGateReason? opts smallTy).isNone do
+    throwError "auto gate wrongly fired on a 100-term finite sum"
+  -- disabling the gate must disable the skip
+  let noGate := leancert.trust.autoGate.set opts false
+  unless (autoGateReason? noGate bigTy).isNone do
+    throwError "auto gate fired despite leancert.trust.autoGate=false"
+
+-- End-to-end: past the crossover, auto routes to native (the `native` pin
+-- would fail with a tighten-to-kernel hint if the gate stopped working).
+-- The body must use the index: constant-body sums are closed by a
+-- non-certificate arithmetic strategy and never reach the gate.
+set_option leancert.trust "auto" in
+theorem trustAutoGatedSum :
+    ∑ k ∈ Finset.Icc (1 : ℕ) 5000, (↑k : ℝ) ≤ 12502500 := by
+  finsum_bound
+
+#assert_trust native trustAutoGatedSum
+
+-- …while small sums still get kernel verification.
+set_option leancert.trust "auto" in
+theorem trustAutoSmallSum :
+    ∑ k ∈ Finset.Icc (1 : ℕ) 100, (↑k : ℝ) ≤ 5050 := by
+  finsum_bound
+
+#assert_trust kernel trustAutoSmallSum
+
 /-! ### `#assert_trust`: the CI manifest command -/
 
 #assert_trust kernel trustSyntaxKernel

--- a/docs/architecture/verification-status.md
+++ b/docs/architecture/verification-status.md
@@ -349,7 +349,7 @@ To inspect legacy example placeholders as well, run a repo-wide textual search
 over Lean files and review hits manually; documentation comments can mention the
 word without introducing a proof placeholder.
 
-## Trust Model: Where `native_decide` Is Allowed
+## Trust Model: Explicit Verification Modes
 
 A LeanCert proof has two components with different trust jobs:
 
@@ -357,21 +357,43 @@ A LeanCert proof has two components with different trust jobs:
 user's theorem
   = golden_theorem            -- the lift: check = true → semantic Prop
     applied to
-    h_check : check ... = true  -- usually by native_decide
+    h_check : check ... = true  -- closed by the *verification route*
 ```
 
 - **Library theorems (the lifts) are axiom-free.** Every golden theorem and
   every `mem_*`/`*_correct` theorem is proved from the three standard axioms
   only. This is enforced by the audits above; a regression is a CI failure.
 - **The certificate check is the one place compiler trust may enter — by the
-  user's choice.** Discharging `h_check` with `native_decide` adds exactly one
-  per-declaration compiler-trust axiom to *that* proof, visible in its
-  `#print axioms`. Users who want a compiler-free proof can discharge the same
-  boolean with kernel `decide` where feasible, or re-check it externally; the
-  golden theorem applies unchanged.
+  user's explicit, auditable choice.** Every tactic closes `h_check` through a
+  single choke point (`LeanCert.Tactic.closeCertificateGoal`), selected by:
 
-In short: `native_decide` is the supported engine for *running* certificates,
-never a dependency of the theorems that give certificates their *meaning*.
+| Mode | Closes with | Trusted base |
+|------|-------------|--------------|
+| `native` (default) | `native_decide` | kernel + compiler/runtime (`Lean.ofReduceBool`, one per-declaration axiom) |
+| `kernel` | `decide +kernel` | kernel only — foundational axioms; **never** silently falls back |
+| `auto` | kernel first, native past the calibrated cost gates | fallback is reported |
+
+Selection precedence: per-invocation `(trust := kernel)` syntax
+> `set_option leancert.trust "kernel"` > native default. The auto-mode cost
+gates (finite-sum term count, integration partitions, optimization
+iterations) are calibrated in `scripts/bench-trust/` and tunable via the
+`leancert.trust.auto*` options.
+
+CI can pin a theorem's trust class with the manifest command:
+
+```lean
+#assert_trust kernel my_bound     -- foundational axioms only
+#assert_trust native my_big_table -- native trust allowed AND required
+```
+
+Drift fails in both directions: a kernel-pinned theorem acquiring compiler
+trust is a regression, and a native-pinned theorem losing its native
+dependency means the manifest should be tightened to `kernel`.
+
+In short: native evaluation is the supported engine for *running* large
+certificates, never a dependency of the theorems that give certificates
+their *meaning* — and for point/bound-scale goals, kernel verification now
+costs about the same, so those proofs can carry no compiler trust at all.
 
 ## What This Means
 

--- a/docs/tactics/tactics.md
+++ b/docs/tactics/tactics.md
@@ -2,6 +2,41 @@
 
 Complete reference for all LeanCert tactics.
 
+## Trust Modes
+
+Every LeanCert tactic closes its Boolean certificate through a single
+verification choke point with an explicit trust choice:
+
+```lean
+example : Real.log 2 < 7/10 := by interval_decide (trust := kernel)
+example : ∀ x ∈ Set.Icc (0:ℝ) 1, Real.exp x ≤ 2.72 := by certify_bound (trust := auto)
+
+set_option leancert.trust "kernel" in   -- or file/project-wide
+theorem log2 : Real.log 2 < 7/10 := by interval_decide
+
+#print axioms log2
+-- [propext, Classical.choice, Quot.sound]  ← no compiler trust
+```
+
+| Mode | Certificate closed by | Trusted base | Behavior on failure |
+|------|----------------------|--------------|---------------------|
+| `native` (default) | `native_decide` | kernel + compiler (`Lean.ofReduceBool`) | error |
+| `kernel` | `decide +kernel` | kernel only | hard error — **never** falls back to native |
+| `auto` | kernel, then native | kernel where it succeeds | fallback reported once per process; details under `trace[leancert.verification]` |
+
+Per-invocation `(trust := …)` overrides `set_option leancert.trust`, which
+overrides the native default. `interval_decide`, `certify_bound`,
+`interval_auto`, and `leancert` accept the syntax directly; every other
+tactic (subdivision, adaptive, multivariate, optimization, roots, discovery,
+finite sums) honors the option.
+
+Guidance from the calibration data (`scripts/bench-trust/README.md`): kernel
+verification is essentially free for point inequalities and quantified
+bounds, cheap for moderate partition/subdivision counts, and crosses over
+around 10⁴ finite-sum terms. `auto` encodes exactly this policy — its cost
+gates are tunable via the `leancert.trust.auto*` options. Pin the result in
+CI with `#assert_trust kernel thm` / `#assert_trust native thm`.
+
 ## Semantic Front Door
 
 ### `leancert` and `leancert?`


### PR DESCRIPTION
## What

Release-readiness follow-up to #76, two commits:

**1. `interval_bound` restored as a deprecated alias for `certify_bound`.**
The Phase-8a downstream dry run (PNT+ built against main via path override)
caught that `RamanujanCalculations.lean` still uses the pre-rename spelling,
removed from main after the v4.32.1 tag — the next PNT+ bump would have
broken. Comes with a DownstreamPatterns guard example so the alias cannot
silently disappear again. Accepts the same depth and `(trust := …)` syntax.

**2. Auto-mode cost gates, calibrated from `scripts/bench-trust/` data.**
In `leancert.trust = "auto"`, certificates predictably past the
kernel/native crossover skip the kernel attempt and go straight to
`native_decide` (traced; not a fallback):

| gate | default | calibration |
|---|---|---|
| finite-sum terms | 2000 | crossover ≈ 10⁴ terms (~35s, +1.5 GiB RSS) |
| integration partitions | 500 | 500 ≈ +2.5s |
| optimization iterations | 100 | 25 ≈ +2s |

Tunable via `leancert.trust.auto*` options; `autoGate=false` disables.
Explicit `kernel` mode is never gated. The gate reads scale parameters
syntactically off the certificate goal; unrecognized certificates are
attempted normally.

Anti-rot: the gate references checkers as unresolved `Name` literals (the
module imports only `Lean`), so `TrustModes.lean` builds the same
applications with *resolved* names and asserts firing + non-firing — a
checker rename breaks CI rather than silently disabling the gate.
End-to-end: 5000-term `finsum_bound` under auto is pinned `#assert_trust
native`, 100-term pinned `kernel`.

Also documents the trust modes (mode table, selection precedence,
`#assert_trust`) in `docs/tactics/tactics.md` and
`docs/architecture/verification-status.md`.

Full library build, TrustModes (gate unit + end-to-end pins), FinSumBound,
DownstreamPatterns, edge-bounds suites, and `Tests/AxiomAudit.lean` all green.