### PR TITLE
Add trust story and compiled public showcase

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Build examples
         run: lake build examples
 
+      - name: Build curated public showcase
+        run: lake build Showcase
+
       - name: Build FunctionalTests (full regression suite)
         run: lake build FunctionalTests
 

--- a/LeanCert/Examples/Showcase.lean
+++ b/LeanCert/Examples/Showcase.lean
@@ -26,10 +26,17 @@ open LeanCert.QProduct
 theorem log_two_lt_seven_tenths : Real.log 2 < 7 / 10 := by
   leancert
 
+private example : Real.log 2 < 7 / 10 := by
+  interval_auto 10
+
 /-- One certificate proves the nonlinear bound for every point of `[0, 1]`. -/
 theorem exp_mul_cos_bound :
     ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.exp x * Real.cos x ≤ 3 := by
   leancert
+
+private example :
+    ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.exp x * Real.cos x ≤ 3 := by
+  certify_bound 10
 
 /-- Semantic routing recognizes a two-dimensional box. -/
 theorem two_variable_box_bound :
@@ -37,18 +44,37 @@ theorem two_variable_box_bound :
       x + y ≤ (2 : ℚ) := by
   leancert
 
+private example :
+    ∀ x ∈ Set.Icc (0 : ℝ) 1, ∀ y ∈ Set.Icc (0 : ℝ) 1,
+      x + y ≤ (2 : ℚ) := by
+  multivariate_bound
+
 /-- Interval sign and Newton certificates establish the unique square root. -/
 theorem sqrt_two_unique :
     ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x ^ 2 - 2 = 0 := by
   leancert
+
+private example :
+    ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x ^ 2 - 2 = 0 := by
+  interval_unique_root
 
 /-- Rational-polynomial integration is checked exactly. -/
 theorem square_integral :
     (∫ x in (0 : ℝ)..1, x ^ 2) = 1 / 3 := by
   leancert
 
+private example :
+    (∫ x in (0 : ℝ)..1, x ^ 2) = 1 / 3 := by
+  integral_exact
+
 /-- A checked finite q-product bounds the prime-indexed limiting constant. -/
-theorem prime_lambda_upper : primeLambda ≤ ((133 / 240 : ℚ) : ℝ) := by
-  exact verify_primeLambda_upper 7 (133 / 240) (by native_decide)
+theorem prime_lambda_enclosure :
+    ((19 / 36 : ℚ) : ℝ) ≤ primeLambda ∧
+      primeLambda ≤ ((7 / 12 : ℚ) : ℝ) :=
+  LeanCert.Validity.verify_limit_interval
+    primeLambda_le_shiftedTrunc
+    shiftedTrunc_sub_tail_le_primeLambda
+    1 (19 / 36) (7 / 12)
+    (by native_decide)
 
 end LeanCert.Examples.Showcase

--- a/LeanCert/Examples/Showcase.lean
+++ b/LeanCert/Examples/Showcase.lean
@@ -3,161 +3,52 @@ Copyright (c) 2024 LeanCert Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
-import LeanCert.Tactic.IntervalAuto
-import LeanCert.Tactic.Discovery
+import LeanCert.Tactic
+import LeanCert.QProduct
 
 /-!
 # LeanCert Showcase
 
-Demonstrations of verified numerical computation in Lean 4.
+Six ordinary mathematical statements covering the main public proof shapes.
+Every theorem deliberately uses the semantic `leancert` front door where that
+front door applies. The q-product example demonstrates a domain certificate
+whose Boolean premise is checked natively and lifted by a Golden Theorem.
 
-## What This Library Does
-
-LeanCert proves facts about real-valued functions using **interval arithmetic**.
-The key idea: compute with rational intervals, get proofs about reals.
-
-## Highlights
-
-1. **Transcendental bounds**: exp, sin, cos with Taylor model error bounds
-2. **Root existence**: Prove √2 exists via sign change
-3. **Root absence**: Prove functions stay away from zero
-4. **Composition**: Combine operations freely
-
-## The Golden Theorem Pattern
-
-Each verified result follows this pattern:
-1. Build an `Expr` (expression AST) or use raw Lean syntax
-2. Run interval evaluation → get rational bounds
-3. Use `native_decide` to check the bound
-4. Golden theorem lifts to a proof about reals
+The mirrored guide records the selected strategy, trust boundary, and measured
+runtime for each theorem.
 -/
 
 namespace LeanCert.Examples.Showcase
 
-open LeanCert.Core
-open LeanCert.Engine
+open LeanCert.QProduct
 
-/-! ## Intervals -/
+/-- A closed transcendental inequality. -/
+theorem log_two_lt_seven_tenths : Real.log 2 < 7 / 10 := by
+  leancert
 
-def I01 : IntervalRat := ⟨0, 1, by norm_num⟩
-def I_sym : IntervalRat := ⟨-1, 1, by norm_num⟩
+/-- One certificate proves the nonlinear bound for every point of `[0, 1]`. -/
+theorem exp_mul_cos_bound :
+    ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.exp x * Real.cos x ≤ 3 := by
+  leancert
 
-/-! ## Section 1: Basic Polynomial Bounds
+/-- Semantic routing recognizes a two-dimensional box. -/
+theorem two_variable_box_bound :
+    ∀ x ∈ Set.Icc (0 : ℝ) 1, ∀ y ∈ Set.Icc (0 : ℝ) 1,
+      x + y ≤ (2 : ℚ) := by
+  leancert
 
-Simple examples showing certify_bound on polynomials.
--/
+/-- Interval sign and Newton certificates establish the unique square root. -/
+theorem sqrt_two_unique :
+    ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x ^ 2 - 2 = 0 := by
+  leancert
 
-/-- x² ≤ 1 on [0, 1] -/
-theorem xsq_le_one : ∀ x ∈ I01, x * x ≤ (1 : ℚ) := by
-  certify_bound
+/-- Rational-polynomial integration is checked exactly. -/
+theorem square_integral :
+    (∫ x in (0 : ℝ)..1, x ^ 2) = 1 / 3 := by
+  leancert
 
-/-- 0 ≤ x² on [0, 1] -/
-theorem zero_le_xsq : ∀ x ∈ I01, (0 : ℚ) ≤ x * x := by
-  certify_bound
-
-/-- x² ≤ 1 on [-1, 1] -/
-theorem xsq_le_one_sym : ∀ x ∈ I_sym, x * x ≤ (1 : ℚ) := by
-  certify_bound
-
-/-! ## Section 2: Transcendental Functions
-
-exp, sin, cos with verified Taylor series bounds.
--/
-
-/-- sin(x) ≤ 1 on [0, 1] -/
-theorem sin_le_one : ∀ x ∈ I01, Real.sin x ≤ (1 : ℚ) := by
-  certify_bound
-
-/-- -1 ≤ sin(x) on [0, 1] -/
-theorem neg_one_le_sin : ∀ x ∈ I01, (-1 : ℚ) ≤ Real.sin x := by
-  certify_bound
-
-/-- cos(x) ≤ 1 on [0, 1] -/
-theorem cos_le_one : ∀ x ∈ I01, Real.cos x ≤ (1 : ℚ) := by
-  certify_bound
-
-/-- exp(x) ≤ 3 on [0, 1] -/
-theorem exp_le_three : ∀ x ∈ I01, Real.exp x ≤ (3 : ℚ) := by
-  certify_bound 15
-
-/-- 1 ≤ exp(x) on [0, 1] - boundary case with monotonicity -/
-theorem one_le_exp : ∀ x ∈ I01, (1 : ℚ) ≤ Real.exp x := by
-  certify_bound 15
-
-/-! ## Section 3: Combined Expressions
-
-Mixing polynomials with transcendentals.
--/
-
-/-- x² + sin(x) ≤ 2 on [0, 1] -/
-theorem xsq_plus_sin_le_two : ∀ x ∈ I01, x * x + Real.sin x ≤ (2 : ℚ) := by
-  certify_bound
-
-/-- x² - 2 < 0 on [0, 1] (since √2 > 1) -/
-theorem xsq_minus_two_neg : ∀ x ∈ I01,
-    Expr.eval (fun _ => x) (Expr.add (Expr.mul (Expr.var 0) (Expr.var 0))
-                                     (Expr.neg (Expr.const 2))) < (0 : ℚ) := by
-  certify_bound
-
-/-! ## Section 4: Root Absence
-
-Prove functions have no roots by showing they stay strictly positive/negative.
--/
-
-/-- x² + 1 ≠ 0 on [0, 1] (always positive) -/
-theorem xsq_plus_one_no_root : ∀ x ∈ I01,
-    Expr.eval (fun _ => x) (Expr.add (Expr.mul (Expr.var 0) (Expr.var 0))
-                                     (Expr.const 1)) ≠ (0 : ℝ) := by
-  root_bound
-
-/-- exp(x) ≠ 0 on [0, 1] (always positive) -/
-theorem exp_no_root : ∀ x ∈ I01,
-    Expr.eval (fun _ => x) (Expr.exp (Expr.var 0)) ≠ (0 : ℝ) := by
-  root_bound 15
-
-/-- x + 2 ≠ 0 on [0, 1] (always positive) -/
-theorem x_plus_two_no_root : ∀ x ∈ I01,
-    Expr.eval (fun _ => x) (Expr.add (Expr.var 0) (Expr.const 2)) ≠ (0 : ℝ) := by
-  root_bound
-
-/-- x² - 2 ≠ 0 on [0, 1] (√2 ≈ 1.41 is outside [0,1]) -/
-theorem xsq_minus_two_no_root : ∀ x ∈ I01,
-    Expr.eval (fun _ => x) (Expr.add (Expr.mul (Expr.var 0) (Expr.var 0))
-                                     (Expr.neg (Expr.const 2))) ≠ (0 : ℝ) := by
-  root_bound
-
-/-! ## Section 5: Root Existence
-
-Prove roots exist via sign change (Intermediate Value Theorem).
--/
-
-def I12 : IntervalRat := ⟨1, 2, by norm_num⟩
-
-/-- √2 exists: there is an x ∈ [1, 2] with x² = 2 -/
-theorem sqrt2_exists : ∃ x ∈ I12,
-    Expr.eval (fun _ => x) (Expr.add (Expr.mul (Expr.var 0) (Expr.var 0))
-                                     (Expr.neg (Expr.const 2))) = 0 := by
-  interval_roots
-
-/-- π/2 exists: there is an x ∈ [1, 2] with cos(x) = 0 -/
-theorem pi_half_exists : ∃ x ∈ I12,
-    Expr.eval (fun _ => x) (Expr.cos (Expr.var 0)) = 0 := by
-  interval_roots
-
-/-- ln(2) exists: there is an x ∈ [0, 1] with exp(x) = 2 -/
-theorem ln2_exists : ∃ x ∈ I01,
-    Expr.eval (fun _ => x) (Expr.add (Expr.exp (Expr.var 0))
-                                     (Expr.neg (Expr.const 2))) = 0 := by
-  interval_roots 15
-
-/-! ## Why This Matters
-
-1. **Verified**: Every bound is machine-checked by Lean's kernel
-2. **Computational**: Bounds computed at compile time via `native_decide`
-3. **Composable**: Build complex proofs from simple pieces
-4. **Automated**: Tactics handle boilerplate
-
-The library automates numerical verification where symbolic methods are tedious.
--/
+/-- A checked finite q-product bounds the prime-indexed limiting constant. -/
+theorem prime_lambda_upper : primeLambda ≤ ((133 / 240 : ℚ) : ℝ) := by
+  exact verify_primeLambda_upper 7 (133 / 240) (by native_decide)
 
 end LeanCert.Examples.Showcase

--- a/LeanCert/Tactic/IntervalAuto/Bound.lean
+++ b/LeanCert/Tactic/IntervalAuto/Bound.lean
@@ -134,6 +134,18 @@ structure DyadicBoundOutcome where
   taylorDepth : Nat
   deriving Inhabited
 
+/-- Runtime facts from the retained direct-bound proof. A Rational fallback is
+observed by first running the checked Dyadic attempt in an isolated state; the
+legacy Rational adapter does not yet expose its individual checker event. -/
+structure IntervalBoundOutcome where
+  dyadic : Bool
+  checker : Option Name := none
+  verifier : Option Name := none
+  verification : LeanCert.Tactic.VerificationUsage := {}
+  precision : Option Int := none
+  taylorDepth : Nat
+  deriving Inhabited
+
 /-- Try to prove a forall-bound goal using the Dyadic backend.
     Returns metadata if the entire goal was closed, `none` otherwise.
     Uses the checked Dyadic evaluator for arbitrary expressions. -/
@@ -876,6 +888,70 @@ where
                 evalTactic (← `(tactic| norm_cast))
               catch _ =>
                 evalTactic (← `(tactic| simp only [Rat.cast_zero, Rat.cast_one, Rat.cast_intCast, Rat.cast_natCast]))
+
+/-- Reporting-aware direct-bound entry point.
+
+The checked Dyadic attempt already returns complete telemetry. If that attempt
+does not close the goal, the original state is restored and the compatibility
+core runs its checked Rational fallback. This makes the winning arithmetic
+backend observable without allowing failed Dyadic metadata to leak into the
+Rational result. -/
+def intervalBoundCoreReported (taylorDepth : Nat) : TacticM IntervalBoundOutcome := do
+  let original ← saveState
+  try
+    intervalNormCore
+    try
+      evalTactic (← `(tactic|
+        intro _x _hx
+        simp only [ge_iff_le, gt_iff_lt]
+        revert _x _hx))
+    catch _ =>
+      try evalTactic (← `(tactic| simp only [ge_iff_le, gt_iff_lt]))
+      catch _ => pure ()
+    try
+      evalTactic (← `(tactic|
+        simp only [pow_zero, pow_one, one_mul, mul_one] at *))
+    catch _ => pure ()
+    let goal ← getMainGoal
+    let goalType ← goal.getType
+    let some boundGoal ← parseBoundGoal goalType
+      | throwError "reported direct bound: goal normalization did not produce a bound"
+    let attempt (intervalInfo : IntervalInfo) (func bound : Lean.Expr)
+        (isStrict isLower : Bool) : TacticM (Option DyadicBoundOutcome) := do
+      goal.withContext do
+        discard <| tryNormalizeGoalToIcc
+        let normalizedGoal ← getMainGoal
+        let ast := (← getAstWithReport func).expr
+        let boundRat ← extractRatBound bound
+        tryDyadicBoundReported normalizedGoal ast boundRat intervalInfo taylorDepth
+          isStrict isLower
+    let dyadic? ←
+      match boundGoal with
+      | .forallLe _ intervalInfo func bound =>
+          attempt intervalInfo func bound false false
+      | .forallGe _ intervalInfo func bound =>
+          attempt intervalInfo func bound false true
+      | .forallLt _ intervalInfo func bound =>
+          attempt intervalInfo func bound true false
+      | .forallGt _ intervalInfo func bound =>
+          attempt intervalInfo func bound true true
+    if let some outcome := dyadic? then
+      return {
+        dyadic := true
+        checker := some outcome.checker
+        verifier := some outcome.verifier
+        verification := outcome.verification
+        precision := some outcome.precision
+        taylorDepth := outcome.taylorDepth
+      }
+  catch error =>
+    trace[interval_decide] "reported Dyadic direct-bound attempt failed: {error.toMessageData}"
+  original.restore
+  intervalBoundCore taylorDepth
+  return {
+    dyadic := false
+    taylorDepth
+  }
 
 
 /-! ## Tactic Syntax -/

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -871,6 +871,25 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
             require rational endpoints"
         ]
     rejectUnsupportedPreparedFunctions prepared verbosity
+    -- Domain validity is an executable precondition of the checked Rational
+    -- evaluator. Diagnose its failure before treating a rejected certificate
+    -- as mere numerical imprecision. This evaluation influences diagnostics
+    -- only; proof acceptance still goes through the checked tactic core.
+    for function in prepared.functions do
+      let source := match function with
+        | .ready source .. | .unsupported source .. | .deferred source .. => source
+      let ast := (← LeanCert.Meta.reifyWithReport source).expr
+      for domain in prepared.domains do
+        if let .closedRat _ interval _ := domain then
+          let cfgExpr ← mkAppM ``LeanCert.Engine.EvalConfig.mk
+            #[toExpr cfg.taylorDepth]
+          let check ← mkAppM ``LeanCert.Engine.checkDomainValid1
+            #[ast, interval, cfgExpr]
+          let valid ← unsafe evalExpr Bool (mkConst ``Bool) check
+          unless valid do
+            throwRouterFailure verbosity <|
+              Diagnostic.RouterFailure.domainObstruction .intervalBound
+                "the checked evaluator rejected a partial operation on this interval"
 
   if let .root spec := semantic then
     if prepared.domains.any (fun domain => domain.isProvablyEmpty) then

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -122,6 +122,39 @@ private def pointAttempt (depth : Nat) : TacticM Unit := do
   let depth := numSyntax depth
   evalTactic (← `(tactic| interval_auto $depth:num))
 
+private def pointAttemptReported (depth : Nat) : TacticM SolverExecution := do
+  Auto.intervalNormCore
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+  let outcome ← Auto.proveClosedExpressionBoundReported goal goalType depth
+  let mut notes := #[s!"Taylor depth: {outcome.taylorDepth}"]
+  if let some precision := outcome.precision then
+    notes := notes.push s!"precision: {precision}"
+  return {
+    backend := .used <|
+      if outcome.dyadic then .dyadicInterval else .rationalInterval
+    verificationUsage :=
+      Solver.VerificationUsage.ofEvents outcome.verification
+    checker := some outcome.checker
+    verifier := some outcome.verifier
+    notes
+  }
+
+private def directBoundAttemptReported (depth : Nat) : TacticM SolverExecution := do
+  let outcome ← Auto.intervalBoundCoreReported depth
+  let mut notes := #[s!"Taylor depth: {outcome.taylorDepth}"]
+  if let some precision := outcome.precision then
+    notes := notes.push s!"precision: {precision}"
+  return {
+    backend := .used <|
+      if outcome.dyadic then .dyadicInterval else .rationalInterval
+    verificationUsage :=
+      Solver.VerificationUsage.ofEvents outcome.verification
+    checker := outcome.checker
+    verifier := outcome.verifier
+    notes
+  }
+
 private def finSumAttemptReported (precision : Int) (depth : Nat) :
     TacticM SolverExecution := do
   let outcome ← finSumBoundCoreReported precision depth
@@ -225,20 +258,24 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
       { report := report intent s!"direct point enclosure (Taylor depth {d})" cfg mode
           (.policy "checked interval tactic portfolio")
           (some (suggestion "interval_auto" #[toString d])),
-        solve := pointAttempt d },
+        solve := pointAttempt d
+        solveReported := some (pointAttemptReported d) },
       { report := report intent s!"direct point enclosure (Taylor depth {d2})" cfg mode
           (.policy "checked interval tactic portfolio")
           (some (suggestion "interval_auto" #[toString d2])),
-        solve := pointAttempt d2 }]
+        solve := pointAttempt d2
+        solveReported := some (pointAttemptReported d2) }]
   | .intervalBound => #[
       { report := report intent s!"direct interval enclosure (Taylor depth {d})" cfg mode
           (.policy "Dyadic-first, then checked Rational fallback")
           (some (suggestion "certify_bound" #[toString d])),
-        solve := Auto.intervalBoundCore d },
+        solve := Auto.intervalBoundCore d
+        solveReported := some (directBoundAttemptReported d) },
       { report := report intent s!"direct interval enclosure (Taylor depth {d2})" cfg mode
           (.policy "Dyadic-first, then checked Rational fallback")
           (some (suggestion "certify_bound" #[toString d2])),
-        solve := Auto.intervalBoundCore d2 },
+        solve := Auto.intervalBoundCore d2
+        solveReported := some (directBoundAttemptReported d2) },
       { report := report intent "recursive interval subdivision" cfg mode
           (.used .rationalInterval)
           (some (suggestion "interval_bound_subdiv"

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -60,6 +60,60 @@ Advanced control:
 example : (1 : ℝ) < 2 := by
   leancert?
 
+/--
+info: LeanCert recognized: closed numerical comparison
+
+Selected strategy:
+  direct point enclosure (Taylor depth 10)
+  Taylor depth: 10
+  precision: -80
+
+Numerical computation:
+  Dyadic interval evaluation
+
+Certificate verification:
+  requested native → used native
+Checker: LeanCert.Validity.checkStrictUpperBoundDyadicChecked
+Verifier: LeanCert.Validity.verify_strict_upper_bound_dyadic_checked
+
+Suggested proof:
+  by
+    leancert
+
+Advanced control:
+  by
+    interval_auto 10
+-/
+#guard_msgs in
+example : Real.log 2 < 7 / 10 := by
+  leancert?
+
+/--
+info: LeanCert recognized: univariate interval bound
+
+Selected strategy:
+  direct interval enclosure (Taylor depth 10)
+  Taylor depth: 10
+
+Numerical computation:
+  Rational interval evaluation
+
+Certificate verification:
+  requested native; actual route not observed by the legacy adapter
+
+Suggested proof:
+  by
+    leancert
+
+Advanced control:
+  by
+    certify_bound 10
+-/
+#guard_msgs in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp x * Real.cos x ≤ 3 := by
+  leancert?
+
 example : ∀ x ∈ Set.Icc (0 : ℝ) 1, x ^ 2 ≤ 1 := by
   leancert
 

--- a/LeanCert/Test/PublicAPI/DomainUmbrellas.lean
+++ b/LeanCert/Test/PublicAPI/DomainUmbrellas.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.ANT
+import LeanCert.QProduct
+
+/-!
+Compile-time contract for the selected stable domain umbrellas.
+-/
+
+#check LeanCert.ANT.StepFn
+#check LeanCert.ANT.verify_stepSum_interval
+#check LeanCert.QProduct.primeLambda
+#check LeanCert.QProduct.verify_primeLambda_upper
+#check LeanCert.QProduct.primeLambda_sandwich

--- a/LeanCert/Test/ShowcaseFailures.lean
+++ b/LeanCert/Test/ShowcaseFailures.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic
+
+/-!
+# Executable failure showcase
+
+These tests pin searchable public diagnostics without snapshotting incidental
+internal exception text.
+-/
+
+open Lean Meta Elab Tactic
+
+private unsafe def expectFailureContaining (fragments : Array String) :
+    TacticM Unit := do
+  let saved ← saveState
+  try
+    discard <| LeanCert.Tactic.runLeanCert {} .explain
+    saved.restore
+    throwError "expected `leancert?` to fail"
+  catch exception =>
+    saved.restore
+    let message ← exception.toMessageData.toString
+    for fragment in fragments do
+      unless message.contains fragment do
+        throwError "expected diagnostic fragment {fragment}, got:\n{message}"
+
+syntax (name := expectUnsupportedShowcase) "expect_unsupported_showcase" : tactic
+syntax (name := expectDomainObstructionShowcase) "expect_domain_obstruction_showcase" : tactic
+syntax (name := expectResolutionAdviceShowcase) "expect_resolution_advice_showcase" : tactic
+syntax (name := expectCertifiedCounterexampleShowcase)
+  "expect_certified_counterexample_showcase" : tactic
+syntax (name := expectAutoNativeShowcase) "expect_auto_native_showcase" : tactic
+
+@[tactic expectUnsupportedShowcase]
+unsafe def evalExpectUnsupportedShowcase : Tactic := fun _ =>
+  expectFailureContaining #["Unsupported expression:", "Head symbol:", "Suggestions:"]
+
+@[tactic expectDomainObstructionShowcase]
+unsafe def evalExpectDomainObstructionShowcase : Tactic := fun _ =>
+  expectFailureContaining #[
+    "Domain obstruction:",
+    "checked evaluator rejected a partial operation",
+    "Increasing numerical precision does not repair an invalid domain"
+  ]
+
+@[tactic expectResolutionAdviceShowcase]
+unsafe def evalExpectResolutionAdviceShowcase : Tactic := fun _ =>
+  expectFailureContaining #[
+    "Subdivision reached its configured depth",
+    "Increase `(taylorDepth := ...)`, `(subdivisions := ...)`"
+  ]
+
+@[tactic expectCertifiedCounterexampleShowcase]
+unsafe def evalExpectCertifiedCounterexampleShowcase : Tactic := fun _ => do
+  let saved ← saveState
+  try
+    evalTactic (← `(tactic| interval_refute))
+    saved.restore
+    throwError "expected a certified counterexample"
+  catch exception =>
+    saved.restore
+    let message ← exception.toMessageData.toString
+    unless message.contains "Counter-example FOUND" do
+      throwError "expected a certified counterexample, got:\n{message}"
+
+@[tactic expectAutoNativeShowcase]
+unsafe def evalExpectAutoNativeShowcase : Tactic := fun _ => do
+  let report ← LeanCert.Tactic.withTrustMode (some .auto) do
+    LeanCert.Tactic.runLeanCert { trust := some .auto } .explain
+  unless report.execution.verificationUsage.nativeChecks > 0 do
+    throwError "expected auto verification to retain a native check"
+  unless report.execution.verificationUsage.autoGateReasons.any
+      (·.contains "exceeds autoMaxSumTerms") do
+    throwError "expected the finite-sum auto-gate reason"
+
+opaque unsupportedShowcase : ℝ → ℝ
+
+set_option linter.unusedTactic false in
+example (h : ∀ x ∈ Set.Icc (-2 : ℝ) 2, x * x ≤ 3) :
+    ∀ x ∈ Set.Icc (-2 : ℝ) 2, x * x ≤ 3 := by
+  expect_certified_counterexample_showcase
+  exact h
+
+set_option linter.unusedTactic false in
+example (h : ∃ x ∈ Set.Icc (0 : ℝ) 1, unsupportedShowcase x = 0) :
+    ∃ x ∈ Set.Icc (0 : ℝ) 1, unsupportedShowcase x = 0 := by
+  expect_unsupported_showcase
+  exact h
+
+set_option linter.unusedTactic false in
+example (h : ∀ x ∈ Set.Icc (-1 : ℝ) 1, Real.log x ≤ 1) :
+    ∀ x ∈ Set.Icc (-1 : ℝ) 1, Real.log x ≤ 1 := by
+  expect_domain_obstruction_showcase
+  exact h
+
+set_option linter.unusedTactic false in
+example (h : ∀ x ∈ Set.Icc (0 : ℝ) 1, x * (1 - x) ≤ (1 / 4 : ℚ)) :
+    ∀ x ∈ Set.Icc (0 : ℝ) 1, x * (1 - x) ≤ (1 / 4 : ℚ) := by
+  expect_resolution_advice_showcase
+  exact h
+
+private def largeSumBody : LeanCert.Core.Expr := .var 0
+
+example : LeanCert.Engine.checkFinSumUpperBoundFull
+    largeSumBody 1 5000 12502500 = true := by
+  expect_auto_native_showcase

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LeanCert
 
 [![Lean Action CI](https://github.com/alerad/leancert/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/alerad/leancert/actions/workflows/lean_action_ci.yml)
+[![Soundness Guard](https://github.com/alerad/leancert/actions/workflows/soundness-guard.yml/badge.svg)](https://github.com/alerad/leancert/actions/workflows/soundness-guard.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-leancert.io-brightgreen.svg)](https://docs.leancert.io)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21681348.svg)](https://doi.org/10.5281/zenodo.21681348)
@@ -123,6 +124,9 @@ example : Real.log 2 < 7 / 10 := by
 Or set it for a section or file with
 `set_option leancert.trust "kernel"`. Numerical backend selection
 (Rational/Dyadic/Affine) is independent of this verification choice.
+
+See the authoritative [trust model](https://docs.leancert.io/architecture/trust-model/)
+and the compiled [curated showcase](https://docs.leancert.io/showcase/).
 
 ## Why not `norm_num`, `positivity`, or a basic interval tactic?
 

--- a/docs/architecture/trust-model.md
+++ b/docs/architecture/trust-model.md
@@ -1,0 +1,70 @@
+# Trust model
+
+LeanCert separates numerical computation from proof verification:
+
+```text
+mathematical goal
+→ semantic classification
+→ certified numerical checker
+→ Boolean/result certificate
+→ Golden Theorem
+→ Lean proof
+```
+
+Search and candidate generation may be untrusted. They cannot establish a
+theorem by themselves: the retained result must pass an executable checker,
+and a proved Golden Theorem connects that check to the user's proposition.
+
+## Kernel, native, and auto
+
+`leancert.trust` controls how LeanCert proves a closed certificate proposition
+such as `check certificate = true`. It does **not** choose Rational, Dyadic, or
+Affine arithmetic.
+
+| Mode | Verification | Additional trust |
+| --- | --- | --- |
+| `kernel` | kernel reduction through `decide +kernel` | none beyond Lean's kernel and foundations |
+| `native` | compiled evaluation through `native_decide` | Lean compiler and runtime |
+| `auto` | kernel when practical, otherwise native | exactly the route reported by `leancert?` |
+
+```lean
+import LeanCert.Tactic
+
+example : Real.log 2 < 7 / 10 := by
+  leancert (trust := kernel)
+```
+
+`auto` reports whether it used kernel or native verification and, when known,
+why native execution was selected. Multiple retained checks are aggregated.
+
+## Arithmetic backends
+
+Rational, Dyadic, and Affine describe numerical representation and enclosure
+algorithms. Kernel and native describe how a resulting proposition is
+evaluated. A Dyadic certificate may be checked through either route.
+
+`leancert?` distinguishes a backend observed at runtime from a portfolio
+policy. A policy is not presented as the backend that actually ran.
+
+## Qualifications
+
+Primary tactic paths and checked APIs use checker/Golden-Theorem boundaries.
+Some historical adapters are still being migrated to expose complete runtime
+metadata; their reports say that a route is unobserved instead of inferring it.
+Exact polynomial integration constructs an ordinary kernel proof, so its trust
+selection is not applicable.
+
+The lightweight downstream Li₂ interface preserves a historical separation
+between its statement module and the expensive verification target. CI builds
+that target and checks statement identity. See the
+[production verification table](verification-status.md) for all subsystem
+qualifications.
+
+## Continuous audit
+
+The [Soundness Guard workflow](https://github.com/alerad/leancert/actions/workflows/soundness-guard.yml)
+runs on every push and pull request. It rejects unauthorized axioms, `sorry`
+uses, and synthetic proof holes, then checks the exported trust manifest and
+representative Golden Theorems. Its README badge links to public run history;
+reviewers do not need to recreate CI locally.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@ proof-producing certificate workflows.
 
 For theorem proving, begin with [`leancert`](direct/leancert.md). For
 programmatic use, see the [supported public API](reference/public-api.md).
+For a compact evaluation path, build the [curated showcase](showcase.md) and
+read the [trust model](architecture/trust-model.md).
 
 LeanCert is organized around proof intent:
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -1,5 +1,19 @@
 # Supported downstream API
 
+Public modules are grouped by support level:
+
+| Level | Meaning |
+| --- | --- |
+| **Stable** | compatibility promise, covered by import and behavioral tests |
+| **Advanced** | supported expert interface whose lower-level details may evolve |
+| **Compatibility** | forwarding surface with a documented canonical replacement |
+| **Internal** | implementation module with no downstream stability promise |
+
+The stable front doors are `LeanCert`, `LeanCert.Tactic`,
+`LeanCert.API.Eval`, `LeanCert.API.Backend`, `LeanCert.API.Bounds`,
+`LeanCert.API.Optimization`, and selected domain umbrellas including
+`LeanCert.ANT` and `LeanCert.QProduct`.
+
 LeanCert provides three stable umbrella imports for downstream developments:
 
 ```lean

--- a/docs/showcase-failures.md
+++ b/docs/showcase-failures.md
@@ -3,6 +3,10 @@
 Good automation distinguishes false mathematics from unsupported syntax and
 insufficient numerical resolution:
 
+All five rows are executable regressions in
+`LeanCert.Test.ShowcaseFailures`, built by both `Showcase` and
+`FunctionalTests`.
+
 | Situation | Diagnostic | Action |
 | --- | --- | --- |
 | false theorem | certified counterexample | inspect the witness and repair the statement |
@@ -18,6 +22,15 @@ import LeanCert.Tactic
 
 example : ∀ x ∈ Set.Icc (-2 : ℝ) 2, x * x ≤ 3 := by
   interval_refute
+```
+
+Domain failures are distinguished from precision failures:
+
+```lean expect-error: Domain obstruction
+import LeanCert.Tactic
+
+example : ∀ x ∈ Set.Icc (-1 : ℝ) 1, Real.log x ≤ 1 := by
+  leancert?
 ```
 
 Question mode exposes the successful decision:

--- a/docs/showcase-failures.md
+++ b/docs/showcase-failures.md
@@ -1,0 +1,33 @@
+# Failure showcase
+
+Good automation distinguishes false mathematics from unsupported syntax and
+insufficient numerical resolution:
+
+| Situation | Diagnostic | Action |
+| --- | --- | --- |
+| false theorem | certified counterexample | inspect the witness and repair the statement |
+| unsupported expression | specific unsupported feature | unfold/rewrite or use a checked API |
+| invalid `log`/inverse domain | domain obstruction | repair the domain; precision is not the remedy |
+| enclosure too wide | depth/subdivision recommendation | inspect with `leancert?`, then tune that control |
+| kernel route too expensive | `auto → native` and gate reason | accept native trust or explicitly require kernel |
+
+The counterexample path is executable:
+
+```lean expect-error: Counter-example FOUND
+import LeanCert.Tactic
+
+example : ∀ x ∈ Set.Icc (-2 : ℝ) 2, x * x ≤ 3 := by
+  interval_refute
+```
+
+Question mode exposes the successful decision:
+
+```lean
+import LeanCert.Tactic
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.exp x ≤ 3 := by
+  leancert? (trust := auto)
+```
+
+See [Troubleshooting](direct/troubleshooting.md) for the complete
+diagnostic-to-remedy map.

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -30,23 +30,32 @@ import LeanCert.QProduct
 
 open LeanCert.QProduct
 
-example : primeLambda ≤ ((133 / 240 : ℚ) : ℝ) := by
-  exact verify_primeLambda_upper 7 (133 / 240) (by native_decide)
+example : ((19 / 36 : ℚ) : ℝ) ≤ primeLambda ∧
+    primeLambda ≤ ((7 / 12 : ℚ) : ℝ) :=
+  LeanCert.Validity.verify_limit_interval
+    primeLambda_le_shiftedTrunc shiftedTrunc_sub_tail_le_primeLambda
+    1 (19 / 36) (7 / 12) (by native_decide)
 ```
 
-| Example | Selected method | Trust story |
-| --- | --- | --- |
-| `log 2 < 0.7` | direct point enclosure | checked Dyadic certificate |
-| nonlinear quantified bound | direct enclosure | Dyadic-first/Rational-fallback checked portfolio |
-| two-variable box | branch-and-bound | checked global-bound certificate |
-| unique square root | interval Newton | checked root certificate |
-| polynomial integral | exact rational integration | ordinary kernel proof |
-| prime q-product limit | finite truncation | Golden Theorem with native-checked premise |
+Every displayed advanced proof is also compiled privately in the showcase
+module.
 
-On the reference development machine, a warm direct compilation of the whole
-module took approximately 21 seconds on Lean/Mathlib v4.32.2. Runtime depends
-on hardware, cache state, and verification mode.
+| Example | Exact advanced control | Certificate/trust story | Median |
+| --- | --- | --- | ---: |
+| `log 2 < 0.7` | `interval_auto 10` | observed Dyadic checker; native default | 6.056 s |
+| nonlinear quantified bound | `certify_bound 10` | observed Rational fallback; legacy route unobserved | 6.198 s |
+| two-variable box | `multivariate_bound` | checked branch-and-bound certificate | 6.311 s |
+| unique square root | `interval_unique_root` | checked interval-Newton certificate | 7.044 s |
+| polynomial integral | `integral_exact` | exact rational kernel proof | 6.149 s |
+| q-product enclosure | explicit limit Golden Theorem | native-checked finite truncation and tail | 4.476 s |
+
+These are medians of three isolated warm `lake env lean` processes on an
+Apple-arm64 development machine, Lean/Mathlib v4.32.2. They include roughly
+4–6 seconds of Lean process/import overhead and therefore measure the complete
+copy-paste user experience, not tactic execution alone. The
+[machine-readable baseline](https://github.com/alerad/leancert/blob/main/scripts/bench-showcase/baselines/v4.32.2.json)
+records every sample and environment metadata. Runtime depends on hardware,
+cache state, and verification mode.
 
 Use `leancert?` to inspect the recognized shape, strategy, numerical backend or
 policy, verification route, and advanced control.
-

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,0 +1,52 @@
+# Curated showcase
+
+The `LeanCert.Showcase` target contains six examples chosen to show distinct
+proof shapes:
+
+```bash
+lake build Showcase
+```
+
+```lean
+import LeanCert.Tactic
+
+example : Real.log 2 < 7 / 10 := by leancert
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp x * Real.cos x ≤ 3 := by leancert
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, ∀ y ∈ Set.Icc (0 : ℝ) 1,
+    x + y ≤ (2 : ℚ) := by leancert
+
+example : ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x ^ 2 - 2 = 0 := by leancert
+
+example : (∫ x in (0 : ℝ)..1, x ^ 2) = 1 / 3 := by leancert
+```
+
+The domain-specific sixth theorem is:
+
+```lean
+import LeanCert.QProduct
+
+open LeanCert.QProduct
+
+example : primeLambda ≤ ((133 / 240 : ℚ) : ℝ) := by
+  exact verify_primeLambda_upper 7 (133 / 240) (by native_decide)
+```
+
+| Example | Selected method | Trust story |
+| --- | --- | --- |
+| `log 2 < 0.7` | direct point enclosure | checked Dyadic certificate |
+| nonlinear quantified bound | direct enclosure | Dyadic-first/Rational-fallback checked portfolio |
+| two-variable box | branch-and-bound | checked global-bound certificate |
+| unique square root | interval Newton | checked root certificate |
+| polynomial integral | exact rational integration | ordinary kernel proof |
+| prime q-product limit | finite truncation | Golden Theorem with native-checked premise |
+
+On the reference development machine, a warm direct compilation of the whole
+module took approximately 21 seconds on Lean/Mathlib v4.32.2. Runtime depends
+on hardware, cache state, and verification mode.
+
+Use `leancert?` to inspect the recognized shape, strategy, numerical backend or
+policy, verification route, and advanced control.
+

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -29,7 +29,7 @@ precompileModules = false
 # Build explicitly with: lake build Showcase
 [[lean_lib]]
 name = "Showcase"
-roots = ["LeanCert.Examples.Showcase"]
+roots = ["LeanCert.Examples.Showcase", "LeanCert.Test.ShowcaseFailures"]
 precompileModules = false
 
 # Heavy numerical verification - for CI validation. Proves the bounds stated
@@ -150,6 +150,7 @@ roots = [
   "LeanCert.Test.PublicAPI.TrustAxes",
   "LeanCert.Test.ReadmeTest",
   "LeanCert.Test.ReleaseTest",
+  "LeanCert.Test.ShowcaseFailures",
   "LeanCert.Test.SqrtTest",
   "LeanCert.Test.Support",
   "LeanCert.Test.TestDyadicEval",

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -25,6 +25,13 @@ name = "examples"
 roots = ["LeanCert.Examples"]
 precompileModules = false
 
+# Public announcement examples. Keep this small, quick, and presentation-ready.
+# Build explicitly with: lake build Showcase
+[[lean_lib]]
+name = "Showcase"
+roots = ["LeanCert.Examples.Showcase"]
+precompileModules = false
+
 # Heavy numerical verification - for CI validation. Proves the bounds stated
 # (with `sorry`) in the Li2Bounds interface and statement-identity-checks them.
 # Build explicitly with: lake build Li2Verified
@@ -139,6 +146,7 @@ roots = [
   "LeanCert.Test.PublicAPI.Isolation",
   "LeanCert.Test.PublicAPI.Bounds",
   "LeanCert.Test.PublicAPI.CertifiedBoundsImport",
+  "LeanCert.Test.PublicAPI.DomainUmbrellas",
   "LeanCert.Test.PublicAPI.TrustAxes",
   "LeanCert.Test.ReadmeTest",
   "LeanCert.Test.ReleaseTest",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,8 @@ nav:
   - Getting Started:
     - Quickstart: quickstart.md
     - Choosing A Proof Shape: choosing-proof-shape.md
+    - Curated Showcase: showcase.md
+    - Failure Showcase: showcase-failures.md
   - Direct Automation:
     - Using leancert: direct/leancert.md
     - Bounds and Inequalities: direct/bounds.md
@@ -98,6 +100,7 @@ nav:
     - Verification: ml/neural-networks.md
     - Distillation: ml/distillation.md
   - Architecture and Trust:
+    - Trust Model: architecture/trust-model.md
     - Golden Theorems: architecture/golden-theorems.md
     - Interval Backend Selection: architecture/backend-selection.md
     - Table Certificates: architecture/table-certificates.md

--- a/scripts/bench-showcase/README.md
+++ b/scripts/bench-showcase/README.md
@@ -1,0 +1,22 @@
+# Showcase benchmark
+
+This harness measures each public showcase theorem in a separate warm Lean
+process. It intentionally includes import and elaboration overhead because it
+models a reviewer copying one example into a downstream file.
+
+Run:
+
+```bash
+python3 scripts/bench-showcase/run.py --runs 3
+```
+
+To refresh the checked-in toolchain baseline:
+
+```bash
+python3 scripts/bench-showcase/run.py --runs 3 \
+  --output scripts/bench-showcase/baselines/v4.32.2.json
+```
+
+The baseline records all samples, the median/range, platform, toolchain,
+commit, and dirty-worktree status. It is orientation data rather than a
+cross-machine performance guarantee.

--- a/scripts/bench-showcase/baselines/v4.32.2.json
+++ b/scripts/bench-showcase/baselines/v4.32.2.json
@@ -1,0 +1,85 @@
+{
+  "schema": 1,
+  "metric": "isolated warm end-to-end `lake env lean` wall time",
+  "lean_toolchain": "leanprover/lean4:v4.32.2",
+  "mathlib_revision": "v4.32.2",
+  "git_commit": "2e02c0b9c2ab9e9673f3bacd98a5107514a6aa73",
+  "git_dirty": true,
+  "platform": "macOS-14.5-arm64-arm-64bit",
+  "machine": "arm64",
+  "processor": "arm",
+  "cases": [
+    {
+      "case": "point_log",
+      "runs": 3,
+      "seconds": [
+        8.229,
+        6.056,
+        6.033
+      ],
+      "median_seconds": 6.056,
+      "min_seconds": 6.033,
+      "max_seconds": 8.229
+    },
+    {
+      "case": "quantified_nonlinear",
+      "runs": 3,
+      "seconds": [
+        6.126,
+        6.198,
+        6.239
+      ],
+      "median_seconds": 6.198,
+      "min_seconds": 6.126,
+      "max_seconds": 6.239
+    },
+    {
+      "case": "multivariate_box",
+      "runs": 3,
+      "seconds": [
+        6.311,
+        6.276,
+        6.357
+      ],
+      "median_seconds": 6.311,
+      "min_seconds": 6.276,
+      "max_seconds": 6.357
+    },
+    {
+      "case": "unique_root",
+      "runs": 3,
+      "seconds": [
+        7.065,
+        7.036,
+        7.044
+      ],
+      "median_seconds": 7.044,
+      "min_seconds": 7.036,
+      "max_seconds": 7.065
+    },
+    {
+      "case": "exact_integral",
+      "runs": 3,
+      "seconds": [
+        6.094,
+        6.149,
+        6.163
+      ],
+      "median_seconds": 6.149,
+      "min_seconds": 6.094,
+      "max_seconds": 6.163
+    },
+    {
+      "case": "qproduct_limit",
+      "runs": 3,
+      "seconds": [
+        4.542,
+        4.474,
+        4.476
+      ],
+      "median_seconds": 4.476,
+      "min_seconds": 4.474,
+      "max_seconds": 4.542
+    }
+  ]
+}

--- a/scripts/bench-showcase/run.py
+++ b/scripts/bench-showcase/run.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Measure each curated showcase proof in an isolated Lean process."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+from pathlib import Path
+import statistics
+import subprocess
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CASES = {
+    "point_log": """import LeanCert.Tactic
+example : Real.log 2 < 7 / 10 := by leancert
+""",
+    "quantified_nonlinear": """import LeanCert.Tactic
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.exp x * Real.cos x ≤ 3 := by leancert
+""",
+    "multivariate_box": """import LeanCert.Tactic
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, ∀ y ∈ Set.Icc (0 : ℝ) 1,
+    x + y ≤ (2 : ℚ) := by leancert
+""",
+    "unique_root": """import LeanCert.Tactic
+example : ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x ^ 2 - 2 = 0 := by leancert
+""",
+    "exact_integral": """import LeanCert.Tactic
+example : (∫ x in (0 : ℝ)..1, x ^ 2) = 1 / 3 := by leancert
+""",
+    "qproduct_limit": """import LeanCert.QProduct
+open LeanCert.QProduct
+example : ((19 / 36 : ℚ) : ℝ) ≤ primeLambda ∧
+    primeLambda ≤ ((7 / 12 : ℚ) : ℝ) :=
+  LeanCert.Validity.verify_limit_interval
+    primeLambda_le_shiftedTrunc shiftedTrunc_sub_tail_le_primeLambda
+    1 (19 / 36) (7 / 12) (by native_decide)
+""",
+}
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=ROOT, text=True, capture_output=True, check=True
+    ).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.runs < 1:
+        parser.error("--runs must be positive")
+
+    rows = []
+    with tempfile.TemporaryDirectory(prefix="leancert-showcase-bench-") as tmp:
+        directory = Path(tmp)
+        for name, source in CASES.items():
+            path = directory / f"{name}.lean"
+            path.write_text(source, encoding="utf-8")
+            samples = []
+            for _ in range(args.runs):
+                started = time.perf_counter()
+                subprocess.run(
+                    ["lake", "env", "lean", str(path)],
+                    cwd=ROOT,
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                samples.append(time.perf_counter() - started)
+            rows.append(
+                {
+                    "case": name,
+                    "runs": args.runs,
+                    "seconds": [round(value, 3) for value in samples],
+                    "median_seconds": round(statistics.median(samples), 3),
+                    "min_seconds": round(min(samples), 3),
+                    "max_seconds": round(max(samples), 3),
+                }
+            )
+
+    payload = {
+        "schema": 1,
+        "metric": "isolated warm end-to-end `lake env lean` wall time",
+        "lean_toolchain": (ROOT / "lean-toolchain").read_text().strip(),
+        "mathlib_revision": "v4.32.2",
+        "git_commit": git("rev-parse", "HEAD"),
+        "git_dirty": bool(git("status", "--porcelain")),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "cases": rows,
+    }
+    rendered = json.dumps(payload, indent=2) + "\n"
+    if args.output:
+        destination = args.output
+        if not destination.is_absolute():
+            destination = ROOT / destination
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Makes LeanCert’s trust story and public evaluation path concise, executable, and presentation-ready.

This PR adds an authoritative trust model, a compiled six-theorem showcase, failure-quality documentation, clearer public API stability levels, and more precise runtime reporting for the headline `leancert?` workflows.

## Highlights

- Adds a dedicated `Showcase` target with six curated examples:
  - transcendental point inequality;
  - quantified nonlinear bound;
  - multivariate bound;
  - unique root;
  - exact integral;
  - certified q-product theorem.
- Adds documentation for:
  - the kernel/native trust boundary;
  - numerical backends versus verification routes;
  - the curated showcase and approximate runtime;
  - representative failure modes and remedies.
- Exposes the existing Soundness Guard prominently through the README.
- Classifies public modules as stable, advanced, compatibility, or internal.
- Adds compile-time contract coverage for the stable ANT and QProduct umbrellas.
- Adds the showcase to CI.

## Reporting improvements

`leancert?` can now report observed execution metadata for prominent paths:

- closed point inequalities report the winning Rational/Dyadic backend, checker, verifier, and verification route;
- direct interval bounds report whether Dyadic or Rational arithmetic actually succeeded;
- failed Dyadic attempts are isolated and cannot leak telemetry into Rational fallback reports.

The remaining Rational compatibility adapter does not yet expose its individual checker event. Reports state that the verification route was not observed instead of inferring one.

## Trust model

The documentation now clearly separates:

- strategy: direct enclosure, subdivision, branch-and-bound, Newton contraction, etc.;
- numerical backend: Rational, Dyadic, or Affine;
- certificate verification: kernel, native, or auto.
