### PR TITLE
Migrate optimization reporting to typed outcomes

### DIFF
--- a/LeanCert/Tactic/Discovery.lean
+++ b/LeanCert/Tactic/Discovery.lean
@@ -263,7 +263,6 @@ structure DiscoveryOutcome where
 inductive DiscoveryFailure where
   | unsupported (expression detail : String)
   | inconclusive (detail : String)
-  | rejected (checker : Option Name) (detail : String)
   | transportFailure (detail : String)
   deriving Inhabited, Repr
 
@@ -278,8 +277,6 @@ private def throwDiscoveryFailure (tacticName : String) : DiscoveryFailure → T
       throwError "{tacticName}: unsupported expression {expression}:\n{detail}"
   | .inconclusive detail =>
       throwError "{tacticName}: {detail}"
-  | .rejected checker detail =>
-      throwError "{tacticName}: certificate {checker} was rejected:\n{detail}"
   | .transportFailure detail =>
       throwError "{tacticName}: proof transport failed:\n{detail}"
 

--- a/LeanCert/Tactic/Discovery.lean
+++ b/LeanCert/Tactic/Discovery.lean
@@ -236,26 +236,81 @@ private def tryConvertSetIcc (interval : Lean.Expr) : MetaM (Option Lean.Expr) :
 
 /-! ## Minimization Tactic -/
 
-/-- The interval_minimize tactic implementation -/
-unsafe def intervalMinimizeCore (taylorDepth : Nat) : TacticM Unit := do
-  LeanCert.Tactic.Auto.intervalNormCore
+/-- Whether discovery searched for a lower or upper extremum. -/
+inductive DiscoveryDirection where
+  | minimum
+  | maximum
+  deriving DecidableEq, Repr, Inhabited
+
+/-- Runtime facts retained from the single successful discovery/certification run. -/
+structure DiscoveryOutcome where
+  direction : DiscoveryDirection
+  witness : ℚ
+  lowerBound : ℚ
+  upperBound : ℚ
+  iterations : Nat
+  configuredLimit : Nat
+  remainingBoxes : Nat
+  tolerance : ℚ
+  checker : Option Name
+  verifier : Option Name
+  verification : LeanCert.Tactic.VerificationUsage
+  dyadic : Option Bool := none
+  taylorDepth : Nat
+  deriving Inhabited
+
+/-- Expected and invariant failures from existential optimization discovery. -/
+inductive DiscoveryFailure where
+  | unsupported (expression detail : String)
+  | inconclusive (detail : String)
+  | rejected (checker : Option Name) (detail : String)
+  | transportFailure (detail : String)
+  deriving Inhabited, Repr
+
+private def discoveryFailureOfBound :
+    LeanCert.Tactic.Auto.IntervalBoundFailure → DiscoveryFailure
+  | .unsupported expression detail => .unsupported expression detail
+  | .inconclusive detail => .inconclusive detail
+  | .transportFailure detail => .transportFailure detail
+
+private def throwDiscoveryFailure (tacticName : String) : DiscoveryFailure → TacticM α
+  | .unsupported expression detail =>
+      throwError "{tacticName}: unsupported expression {expression}:\n{detail}"
+  | .inconclusive detail =>
+      throwError "{tacticName}: {detail}"
+  | .rejected checker detail =>
+      throwError "{tacticName}: certificate {checker} was rejected:\n{detail}"
+  | .transportFailure detail =>
+      throwError "{tacticName}: proof transport failed:\n{detail}"
+
+/-- Reporting-aware implementation of `interval_minimize`.
+
+The optimizer and certificate checker each run exactly once. Failure restores
+the caller's complete tactic state; success returns facts from the retained run. -/
+unsafe def intervalMinimizeCoreTyped (taylorDepth : Nat) :
+    TacticM (Except DiscoveryFailure DiscoveryOutcome) := do
+  let original ← saveState
+  try LeanCert.Tactic.Auto.intervalNormCore
+  catch e =>
+    original.restore
+    return .error <| .unsupported "goal normalization" (← e.toMessageData.toString)
   let goal ← getMainGoal
   let goalType ← goal.getType
 
   let some (.minimize _varName varType domainExpr funcExpr) ← parseExistentialGoal goalType
-    | let diagReport ← LeanCert.Tactic.Auto.mkDiagnosticReport "interval_minimize" goalType "parse"
-        (some m!"Expected form: ∃ m, ∀ x ∈ I, f(x) ≥ m\n\n\
-                 Where:\n\
-                 • m is a rational bound variable\n\
-                 • x is the quantified variable over interval I\n\
-                 • f(x) is an expression supported by LeanCert")
-      throwError "interval_minimize: Could not parse goal.\n\n{diagReport}"
+    | original.restore
+      return .error <| .unsupported (toString goalType)
+        "expected `∃ m, ∀ x ∈ I, f x ≥ m`"
 
   trace[LeanCert.discovery] "Parsing goal: ∃ m, ∀ x ∈ I, f(x) ≥ m"
   trace[LeanCert.discovery] "Function expression: {funcExpr}"
 
   -- 1. Reify the function (or extract from Expr.eval)
-  let ast := (← getAstFromFuncWithReport funcExpr).expr
+  let ast ←
+    try pure (← getAstFromFuncWithReport funcExpr).expr
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString funcExpr) (← e.toMessageData.toString)
   trace[LeanCert.discovery] "Reified AST: {ast}"
 
   -- 2. Prepare for evaluation with guided optimization
@@ -275,13 +330,21 @@ unsafe def intervalMinimizeCore (taylorDepth : Nat) : TacticM Unit := do
     match ← tryConvertSetIcc domainExpr with
     | some intervalRat => pure intervalRat
     | none => pure domainExpr
-  let domainVal ← evalExpr IntervalRat (mkConst ``IntervalRat) domainExpr
+  let domainVal ←
+    try evalExpr IntervalRat (mkConst ``IntervalRat) domainExpr
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString domainExpr) (← e.toMessageData.toString)
   let boxVal : Box := [domainVal]
   trace[LeanCert.discovery] "Domain: [{domainVal.lo}, {domainVal.hi}]"
 
   -- 3. Run float-guided optimization
   trace[LeanCert.discovery] "Running float-guided optimization (heuristic samples={cfg.heuristicSamples}, maxIters={cfg.maxIterations}, taylorDepth={taylorDepth})..."
-  let astVal ← evalExpr LExpr (mkConst ``LeanCert.Core.Expr) ast
+  let astVal ←
+    try evalExpr LExpr (mkConst ``LeanCert.Core.Expr) ast
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString funcExpr) (← e.toMessageData.toString)
   let result := globalMinimizeGuided astVal boxVal cfg
   let boundVal := result.bound.lo
 
@@ -306,15 +369,46 @@ unsafe def intervalMinimizeCore (taylorDepth : Nat) : TacticM Unit := do
       else if ty.isConstOf ``Real then
         mkAppOptM ``Rat.cast #[mkConst ``Real, none, boundRatExpr]
       else
-        throwError "interval_minimize: Unsupported bound type. Use ℚ or ℝ."
+        original.restore
+        return .error <| .unsupported (toString varType)
+          "bound type must be ℚ or ℝ"
   let boundSyntax ← Term.exprToSyntax boundTerm
   trace[LeanCert.discovery] "Providing witness: m = {boundVal}"
-  evalTactic (← `(tactic| refine ⟨$boundSyntax, ?_⟩))
+  try evalTactic (← `(tactic| refine ⟨$boundSyntax, ?_⟩))
+  catch e =>
+    original.restore
+    return .error <| .transportFailure (← e.toMessageData.toString)
 
   -- 5. Now we have a goal `∀ x ∈ I, f(x) ≥ bound`
   trace[LeanCert.discovery] "Proving universal bound with certify_bound..."
-  LeanCert.Tactic.Auto.intervalBoundCore taylorDepth
+  let certification ←
+    match ← LeanCert.Tactic.Auto.intervalBoundCoreTyped taylorDepth with
+    | .ok certification => pure certification
+    | .error failure =>
+        original.restore
+        return .error (discoveryFailureOfBound failure)
   trace[LeanCert.discovery] "✓ Proof complete"
+  return .ok {
+    direction := .minimum
+    witness := boundVal
+    lowerBound := result.bound.lo
+    upperBound := result.bound.hi
+    iterations := result.bound.iterations
+    configuredLimit := cfg.maxIterations
+    remainingBoxes := result.remainingBoxes.length
+    tolerance := cfg.tolerance
+    checker := certification.checker
+    verifier := certification.verifier
+    verification := certification.verification
+    dyadic := some certification.dyadic
+    taylorDepth := taylorDepth
+  }
+
+/-- Compatibility entry point preserving the dedicated tactic's throwing API. -/
+unsafe def intervalMinimizeCore (taylorDepth : Nat) : TacticM Unit := do
+  match ← intervalMinimizeCoreTyped taylorDepth with
+  | .ok _ => pure ()
+  | .error failure => throwDiscoveryFailure "interval_minimize" failure
 
 /-- The interval_minimize tactic.
 
@@ -336,26 +430,31 @@ unsafe def elabIntervalMinimize : Tactic := fun stx => do
 
 /-! ## Maximization Tactic -/
 
-/-- The interval_maximize tactic implementation -/
-unsafe def intervalMaximizeCore (taylorDepth : Nat) : TacticM Unit := do
-  LeanCert.Tactic.Auto.intervalNormCore
+/-- Reporting-aware implementation of `interval_maximize`. -/
+unsafe def intervalMaximizeCoreTyped (taylorDepth : Nat) :
+    TacticM (Except DiscoveryFailure DiscoveryOutcome) := do
+  let original ← saveState
+  try LeanCert.Tactic.Auto.intervalNormCore
+  catch e =>
+    original.restore
+    return .error <| .unsupported "goal normalization" (← e.toMessageData.toString)
   let goal ← getMainGoal
   let goalType ← goal.getType
 
   let some (.maximize _varName varType domainExpr funcExpr) ← parseExistentialGoal goalType
-    | let diagReport ← LeanCert.Tactic.Auto.mkDiagnosticReport "interval_maximize" goalType "parse"
-        (some m!"Expected form: ∃ M, ∀ x ∈ I, f(x) ≤ M\n\n\
-                 Where:\n\
-                 • M is a rational bound variable\n\
-                 • x is the quantified variable over interval I\n\
-                 • f(x) is an expression supported by LeanCert")
-      throwError "interval_maximize: Could not parse goal.\n\n{diagReport}"
+    | original.restore
+      return .error <| .unsupported (toString goalType)
+        "expected `∃ M, ∀ x ∈ I, f x ≤ M`"
 
   trace[LeanCert.discovery] "Parsing goal: ∃ M, ∀ x ∈ I, f(x) ≤ M"
   trace[LeanCert.discovery] "Function expression: {funcExpr}"
 
   -- Use getAstFromFuncWithReport to handle both Expr.eval and raw expressions
-  let ast := (← getAstFromFuncWithReport funcExpr).expr
+  let ast ←
+    try pure (← getAstFromFuncWithReport funcExpr).expr
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString funcExpr) (← e.toMessageData.toString)
   trace[LeanCert.discovery] "Reified AST: {ast}"
 
   let cfg : GuidedOptConfig := {
@@ -373,12 +472,20 @@ unsafe def intervalMaximizeCore (taylorDepth : Nat) : TacticM Unit := do
     match ← tryConvertSetIcc domainExpr with
     | some intervalRat => pure intervalRat
     | none => pure domainExpr
-  let domainVal ← evalExpr IntervalRat (mkConst ``IntervalRat) domainExpr
+  let domainVal ←
+    try evalExpr IntervalRat (mkConst ``IntervalRat) domainExpr
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString domainExpr) (← e.toMessageData.toString)
   let boxVal : Box := [domainVal]
   trace[LeanCert.discovery] "Domain: [{domainVal.lo}, {domainVal.hi}]"
 
   trace[LeanCert.discovery] "Running float-guided optimization (heuristic samples={cfg.heuristicSamples}, maxIters={cfg.maxIterations}, taylorDepth={taylorDepth})..."
-  let astVal ← evalExpr LExpr (mkConst ``LeanCert.Core.Expr) ast
+  let astVal ←
+    try evalExpr LExpr (mkConst ``LeanCert.Core.Expr) ast
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString funcExpr) (← e.toMessageData.toString)
   let result := globalMaximizeGuided astVal boxVal cfg
   let boundVal := result.bound.hi
 
@@ -401,15 +508,46 @@ unsafe def intervalMaximizeCore (taylorDepth : Nat) : TacticM Unit := do
       else if ty.isConstOf ``Real then
         mkAppOptM ``Rat.cast #[mkConst ``Real, none, boundRatExpr]
       else
-        throwError "interval_maximize: Unsupported bound type. Use ℚ or ℝ."
+        original.restore
+        return .error <| .unsupported (toString varType)
+          "bound type must be ℚ or ℝ"
   let boundSyntax ← Term.exprToSyntax boundTerm
   trace[LeanCert.discovery] "Providing witness: M = {boundVal}"
-  evalTactic (← `(tactic| refine ⟨$boundSyntax, ?_⟩))
+  try evalTactic (← `(tactic| refine ⟨$boundSyntax, ?_⟩))
+  catch e =>
+    original.restore
+    return .error <| .transportFailure (← e.toMessageData.toString)
 
   -- Now prove the bound using intervalBoundCore
   trace[LeanCert.discovery] "Proving universal bound with certify_bound..."
-  LeanCert.Tactic.Auto.intervalBoundCore taylorDepth
+  let certification ←
+    match ← LeanCert.Tactic.Auto.intervalBoundCoreTyped taylorDepth with
+    | .ok certification => pure certification
+    | .error failure =>
+        original.restore
+        return .error (discoveryFailureOfBound failure)
   trace[LeanCert.discovery] "✓ Proof complete"
+  return .ok {
+    direction := .maximum
+    witness := boundVal
+    lowerBound := result.bound.lo
+    upperBound := result.bound.hi
+    iterations := result.bound.iterations
+    configuredLimit := cfg.maxIterations
+    remainingBoxes := result.remainingBoxes.length
+    tolerance := cfg.tolerance
+    checker := certification.checker
+    verifier := certification.verifier
+    verification := certification.verification
+    dyadic := some certification.dyadic
+    taylorDepth := taylorDepth
+  }
+
+/-- Compatibility entry point preserving the dedicated tactic's throwing API. -/
+unsafe def intervalMaximizeCore (taylorDepth : Nat) : TacticM Unit := do
+  match ← intervalMaximizeCoreTyped taylorDepth with
+  | .ok _ => pure ()
+  | .error failure => throwDiscoveryFailure "interval_maximize" failure
 
 /-- The interval_maximize tactic.
 

--- a/LeanCert/Tactic/IntervalAuto/Multivariate.lean
+++ b/LeanCert/Tactic/IntervalAuto/Multivariate.lean
@@ -26,7 +26,13 @@ open LeanCert.Validity.GlobalOpt
 open LeanCert.Engine.Optimization
 
 /-- Runtime facts from the retained multivariate global-bound certificate. -/
+inductive MultivariateBoundDirection where
+  | upper
+  | lower
+  deriving DecidableEq, Repr, Inhabited
+
 structure MultivariateBoundOutcome where
+  direction : MultivariateBoundDirection
   checker : Name
   verifier : Name
   verification : LeanCert.Tactic.VerificationUsage
@@ -36,10 +42,16 @@ structure MultivariateBoundOutcome where
   taylorDepth : Nat
   deriving Inhabited
 
-/-- Reporting-aware multivariate-bound implementation. -/
-def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
+inductive MultivariateBoundFailure where
+  | unsupported (expression detail : String)
+  | rejected (checker : Name) (detail : String)
+  | transportFailure (detail : String)
+  deriving Inhabited, Repr
+
+/-- Typed multivariate-bound implementation. -/
+def multivariateBoundCoreTyped (maxIters : Nat) (tolerance : ℚ)
     (useMonotonicity : Bool) (taylorDepth : Nat) :
-    TacticM MultivariateBoundOutcome := do
+    TacticM (Except MultivariateBoundFailure MultivariateBoundOutcome) := do
   intervalNormCore
   let goal ← getMainGoal
   let goalType ← goal.getType
@@ -48,21 +60,16 @@ def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
   -- Parse the multivariate goal
   let parsed ← parseMultivariateBoundGoal goalType
   let some boundGoal := parsed
-    | let diagReport ← mkDiagnosticReport "multivariate_bound" goalType "parse"
-        (some m!"Expected forms:\n\
-                 • ∀ x ∈ I, ∀ y ∈ J, ... f(x,y,...) ≤ c\n\
-                 • ∀ x ∈ I, ∀ y ∈ J, ... c ≤ f(x,y,...)\n\n\
-                 Domain formats accepted:\n\
-                 • x ∈ Set.Icc a b\n\
-                 • a ≤ x ∧ x ≤ b\n\
-                 • a ≤ x → x ≤ b → ...")
-      throwError "multivariate_bound: Could not parse goal as multivariate bound.\n\n{diagReport}"
+    | return .error <| .unsupported (toString goalType)
+        "expected a quantified multivariate upper or lower bound"
 
   match boundGoal with
   | .forallLe vars func bound =>
-    let event ← proveMultivariateLe goal vars func bound maxIters tolerance
-      useMonotonicity taylorDepth
-    return {
+    match ← proveMultivariateLe goal vars func bound maxIters tolerance
+        useMonotonicity taylorDepth with
+    | .error failure => return .error failure
+    | .ok event => return .ok {
+      direction := .upper
       checker := ``checkGlobalUpperBound
       verifier := ``verify_global_upper_bound
       verification := event.toUsage
@@ -72,9 +79,11 @@ def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
       taylorDepth := taylorDepth
     }
   | .forallGe vars func bound =>
-    let event ← proveMultivariateGe goal vars func bound maxIters tolerance
-      useMonotonicity taylorDepth
-    return {
+    match ← proveMultivariateGe goal vars func bound maxIters tolerance
+        useMonotonicity taylorDepth with
+    | .error failure => return .error failure
+    | .ok event => return .ok {
+      direction := .lower
       checker := ``checkGlobalLowerBound
       verifier := ``verify_global_lower_bound
       verification := event.toUsage
@@ -157,14 +166,30 @@ where
   /-- Prove ∀ x₁ ∈ I₁, ..., ∀ xₙ ∈ Iₙ, f(x) ≤ c using verify_global_upper_bound -/
   proveMultivariateLe (goal : MVarId) (vars : Array VarIntervalInfo) (func bound : Lean.Expr)
       (maxIters : Nat) (tolerance : ℚ) (useMonotonicity : Bool)
-      (taylorDepth : Nat) : TacticM LeanCert.Tactic.VerificationEvent := do
+      (taylorDepth : Nat) :
+      TacticM (Except MultivariateBoundFailure LeanCert.Tactic.VerificationEvent) := do
+    let saved ← saveState
     goal.withContext do
-      let boxExpr ← mkBoxExpr vars
-      let ast := (← reifyWithReport func).expr
-      let boundRat ← extractRatBound bound
-      let supportProof ← mkSupportedProof ast
-      let cfgExpr ← mkAppM ``GlobalOptConfig.mk #[toExpr maxIters, toExpr tolerance, toExpr useMonotonicity, toExpr taylorDepth]
-      let proof ← mkAppM ``verify_global_upper_bound #[ast, supportProof, boxExpr, boundRat, cfgExpr]
+      let prepared ←
+        try
+          let boxExpr ← mkBoxExpr vars
+          let ast := (← reifyWithReport func).expr
+          let boundRat ← extractRatBound bound
+          let supportProof ← mkSupportedProof ast
+          let cfgExpr ← mkAppM ``GlobalOptConfig.mk
+            #[toExpr maxIters, toExpr tolerance, toExpr useMonotonicity,
+              toExpr taylorDepth]
+          let proof ← mkAppM ``verify_global_upper_bound
+            #[ast, supportProof, boxExpr, boundRat, cfgExpr]
+          pure <| some (boxExpr, ast, boundRat, cfgExpr, proof)
+        catch e =>
+          saved.restore
+          return .error <| .unsupported (toString func)
+            (← e.toMessageData.toString)
+      let some (boxExpr, ast, boundRat, cfgExpr, proof) := prepared
+        | saved.restore
+          return .error <| .unsupported (toString func)
+            "multivariate preparation produced no expression"
 
       setGoals [goal]
       try
@@ -173,14 +198,24 @@ where
 
       let mainGoalAfterIntro ← getMainGoal
 
-      let (rhoSyntax, varsListSyntax, boxSyntax) ← withMainContext do
-        let varExprs ← getVarExprs vars
-        let varsListExpr ← mkListLit (Lean.mkConst ``Real) varExprs.toList
-        let rhoExpr ← mkEnvExpr varsListExpr
-        let rhoSyntax ← Lean.Elab.Term.exprToSyntax rhoExpr
-        let varsListSyntax ← Lean.Elab.Term.exprToSyntax varsListExpr
-        let boxSyntax ← Lean.Elab.Term.exprToSyntax boxExpr
-        return (rhoSyntax, varsListSyntax, boxSyntax)
+      let syntaxData ←
+        try
+          withMainContext do
+            let varExprs ← getVarExprs vars
+            let varsListExpr ← mkListLit (Lean.mkConst ``Real) varExprs.toList
+            let rhoExpr ← mkEnvExpr varsListExpr
+            let rhoSyntax ← Lean.Elab.Term.exprToSyntax rhoExpr
+            let varsListSyntax ← Lean.Elab.Term.exprToSyntax varsListExpr
+            let boxSyntax ← Lean.Elab.Term.exprToSyntax boxExpr
+            pure <| some (rhoSyntax, varsListSyntax, boxSyntax)
+        catch e =>
+          saved.restore
+          return .error <| .unsupported (toString func)
+            (← e.toMessageData.toString)
+      let some (rhoSyntax, varsListSyntax, boxSyntax) := syntaxData
+        | saved.restore
+          return .error <| .unsupported (toString func)
+            "could not construct the multivariate environment"
 
       let checkExpr ← mkAppM ``checkGlobalUpperBound #[ast, boxExpr, boundRat, cfgExpr]
       let certTy ← mkAppM ``Eq #[checkExpr, Lean.mkConst ``Bool.true]
@@ -192,13 +227,16 @@ where
           (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
           (tacticName := "multivariate_bound")
       catch e =>
-        throwError "multivariate_bound: Certificate check failed. The bound may be too tight.\n{e.toMessageData}"
+        saved.restore
+        return .error <| .rejected ``checkGlobalUpperBound
+          (← e.toMessageData.toString)
 
       let conclusionProof ← mkAppM' proof #[certGoal]
       let conclusionTerm ← Lean.Elab.Term.exprToSyntax conclusionProof
 
       setGoals [mainGoalAfterIntro]
-      evalTactic (← `(tactic| exact (by
+      try
+        evalTactic (← `(tactic| exact (by
         have hmem : Box.envMem $rhoSyntax $boxSyntax := by
           intro i
           fin_cases i <;>
@@ -217,21 +255,39 @@ where
           simp [List.getD, LeanCert.Core.Expr.eval, Rat.divInt_eq_div,
             sq, pow_two, sub_eq_add_neg, div_eq_mul_inv] <;>
           ring
-      )))
-      return event
+        )))
+      catch e =>
+        saved.restore
+        return .error <| .transportFailure (← e.toMessageData.toString)
+      return .ok event
 
   /-- Prove ∀ x₁ ∈ I₁, ..., ∀ xₙ ∈ Iₙ, c ≤ f(x) using verify_global_lower_bound -/
   proveMultivariateGe (goal : MVarId) (vars : Array VarIntervalInfo) (func bound : Lean.Expr)
       (maxIters : Nat) (tolerance : ℚ) (useMonotonicity : Bool)
-      (taylorDepth : Nat) : TacticM LeanCert.Tactic.VerificationEvent := do
+      (taylorDepth : Nat) :
+      TacticM (Except MultivariateBoundFailure LeanCert.Tactic.VerificationEvent) := do
+    let saved ← saveState
     goal.withContext do
-      let boxExpr ← mkBoxExpr vars
-      let ast := (← reifyWithReport func).expr
-      let boundRat ← extractRatBound bound
-      let supportProof ← mkSupportedProof ast
-      let cfgExpr ← mkAppM ``GlobalOptConfig.mk #[toExpr maxIters, toExpr tolerance, toExpr useMonotonicity, toExpr taylorDepth]
-
-      let proof ← mkAppM ``verify_global_lower_bound #[ast, supportProof, boxExpr, boundRat, cfgExpr]
+      let prepared ←
+        try
+          let boxExpr ← mkBoxExpr vars
+          let ast := (← reifyWithReport func).expr
+          let boundRat ← extractRatBound bound
+          let supportProof ← mkSupportedProof ast
+          let cfgExpr ← mkAppM ``GlobalOptConfig.mk
+            #[toExpr maxIters, toExpr tolerance, toExpr useMonotonicity,
+              toExpr taylorDepth]
+          let proof ← mkAppM ``verify_global_lower_bound
+            #[ast, supportProof, boxExpr, boundRat, cfgExpr]
+          pure <| some (boxExpr, ast, boundRat, cfgExpr, proof)
+        catch e =>
+          saved.restore
+          return .error <| .unsupported (toString func)
+            (← e.toMessageData.toString)
+      let some (boxExpr, ast, boundRat, cfgExpr, proof) := prepared
+        | saved.restore
+          return .error <| .unsupported (toString func)
+            "multivariate preparation produced no expression"
 
       setGoals [goal]
       try
@@ -240,14 +296,24 @@ where
 
       let mainGoalAfterIntro ← getMainGoal
 
-      let (rhoSyntax, varsListSyntax, boxSyntax) ← withMainContext do
-        let varExprs ← getVarExprs vars
-        let varsListExpr ← mkListLit (Lean.mkConst ``Real) varExprs.toList
-        let rhoExpr ← mkEnvExpr varsListExpr
-        let rhoSyntax ← Lean.Elab.Term.exprToSyntax rhoExpr
-        let varsListSyntax ← Lean.Elab.Term.exprToSyntax varsListExpr
-        let boxSyntax ← Lean.Elab.Term.exprToSyntax boxExpr
-        return (rhoSyntax, varsListSyntax, boxSyntax)
+      let syntaxData ←
+        try
+          withMainContext do
+            let varExprs ← getVarExprs vars
+            let varsListExpr ← mkListLit (Lean.mkConst ``Real) varExprs.toList
+            let rhoExpr ← mkEnvExpr varsListExpr
+            let rhoSyntax ← Lean.Elab.Term.exprToSyntax rhoExpr
+            let varsListSyntax ← Lean.Elab.Term.exprToSyntax varsListExpr
+            let boxSyntax ← Lean.Elab.Term.exprToSyntax boxExpr
+            pure <| some (rhoSyntax, varsListSyntax, boxSyntax)
+        catch e =>
+          saved.restore
+          return .error <| .unsupported (toString func)
+            (← e.toMessageData.toString)
+      let some (rhoSyntax, varsListSyntax, boxSyntax) := syntaxData
+        | saved.restore
+          return .error <| .unsupported (toString func)
+            "could not construct the multivariate environment"
 
       let checkExpr ← mkAppM ``checkGlobalLowerBound #[ast, boxExpr, boundRat, cfgExpr]
       let certTy ← mkAppM ``Eq #[checkExpr, Lean.mkConst ``Bool.true]
@@ -259,13 +325,16 @@ where
           (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
           (tacticName := "multivariate_bound")
       catch e =>
-        throwError "multivariate_bound: Certificate check failed. The bound may be too tight.\n{e.toMessageData}"
+        saved.restore
+        return .error <| .rejected ``checkGlobalLowerBound
+          (← e.toMessageData.toString)
 
       let conclusionProof ← mkAppM' proof #[certGoal]
       let conclusionTerm ← Lean.Elab.Term.exprToSyntax conclusionProof
 
       setGoals [mainGoalAfterIntro]
-      evalTactic (← `(tactic| exact (by
+      try
+        evalTactic (← `(tactic| exact (by
         have hmem : Box.envMem $rhoSyntax $boxSyntax := by
           intro i
           fin_cases i <;>
@@ -284,8 +353,25 @@ where
           simp [List.getD, LeanCert.Core.Expr.eval, Rat.divInt_eq_div,
             sq, pow_two, sub_eq_add_neg, div_eq_mul_inv] <;>
           ring
-      )))
-      return event
+        )))
+      catch e =>
+        saved.restore
+        return .error <| .transportFailure (← e.toMessageData.toString)
+      return .ok event
+
+/-- Reporting compatibility wrapper preserving the historical throwing API. -/
+def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
+    (useMonotonicity : Bool) (taylorDepth : Nat) :
+    TacticM MultivariateBoundOutcome := do
+  match ← multivariateBoundCoreTyped maxIters tolerance useMonotonicity
+      taylorDepth with
+  | .ok outcome => return outcome
+  | .error (.unsupported expression detail) =>
+      throwError "multivariate_bound: unsupported expression {expression}:\n{detail}"
+  | .error (.rejected _ detail) =>
+      throwError "multivariate_bound: global-bound certificate was rejected:\n{detail}"
+  | .error (.transportFailure detail) =>
+      throwError "multivariate_bound: proof transport failed:\n{detail}"
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
 def multivariateBoundCore (maxIters : Nat) (tolerance : ℚ)

--- a/LeanCert/Tactic/IntervalAuto/Multivariate.lean
+++ b/LeanCert/Tactic/IntervalAuto/Multivariate.lean
@@ -44,15 +44,19 @@ structure MultivariateBoundOutcome where
 
 inductive MultivariateBoundFailure where
   | unsupported (expression detail : String)
-  | rejected (checker : Name) (detail : String)
   | transportFailure (detail : String)
+  | internalFailure (detail : String)
   deriving Inhabited, Repr
 
 /-- Typed multivariate-bound implementation. -/
-def multivariateBoundCoreTyped (maxIters : Nat) (tolerance : ℚ)
+unsafe def multivariateBoundCoreTyped (maxIters : Nat) (tolerance : ℚ)
     (useMonotonicity : Bool) (taylorDepth : Nat) :
     TacticM (Except MultivariateBoundFailure MultivariateBoundOutcome) := do
-  intervalNormCore
+  let original ← saveState
+  try intervalNormCore
+  catch e =>
+    original.restore
+    return .error <| .unsupported "goal normalization" (← e.toMessageData.toString)
   let goal ← getMainGoal
   let goalType ← goal.getType
   trace[LeanCert.discovery] "multivariate_bound goal: {goalType}"
@@ -60,14 +64,17 @@ def multivariateBoundCoreTyped (maxIters : Nat) (tolerance : ℚ)
   -- Parse the multivariate goal
   let parsed ← parseMultivariateBoundGoal goalType
   let some boundGoal := parsed
-    | return .error <| .unsupported (toString goalType)
+    | original.restore
+      return .error <| .unsupported (toString goalType)
         "expected a quantified multivariate upper or lower bound"
 
   match boundGoal with
   | .forallLe vars func bound =>
     match ← proveMultivariateLe goal vars func bound maxIters tolerance
         useMonotonicity taylorDepth with
-    | .error failure => return .error failure
+    | .error failure =>
+      original.restore
+      return .error failure
     | .ok event => return .ok {
       direction := .upper
       checker := ``checkGlobalUpperBound
@@ -81,7 +88,9 @@ def multivariateBoundCoreTyped (maxIters : Nat) (tolerance : ℚ)
   | .forallGe vars func bound =>
     match ← proveMultivariateGe goal vars func bound maxIters tolerance
         useMonotonicity taylorDepth with
-    | .error failure => return .error failure
+    | .error failure =>
+      original.restore
+      return .error failure
     | .ok event => return .ok {
       direction := .lower
       checker := ``checkGlobalLowerBound
@@ -228,8 +237,7 @@ where
           (tacticName := "multivariate_bound")
       catch e =>
         saved.restore
-        return .error <| .rejected ``checkGlobalUpperBound
-          (← e.toMessageData.toString)
+        return .error <| .internalFailure (← e.toMessageData.toString)
 
       let conclusionProof ← mkAppM' proof #[certGoal]
       let conclusionTerm ← Lean.Elab.Term.exprToSyntax conclusionProof
@@ -326,8 +334,7 @@ where
           (tacticName := "multivariate_bound")
       catch e =>
         saved.restore
-        return .error <| .rejected ``checkGlobalLowerBound
-          (← e.toMessageData.toString)
+        return .error <| .internalFailure (← e.toMessageData.toString)
 
       let conclusionProof ← mkAppM' proof #[certGoal]
       let conclusionTerm ← Lean.Elab.Term.exprToSyntax conclusionProof
@@ -360,7 +367,7 @@ where
       return .ok event
 
 /-- Reporting compatibility wrapper preserving the historical throwing API. -/
-def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
+unsafe def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
     (useMonotonicity : Bool) (taylorDepth : Nat) :
     TacticM MultivariateBoundOutcome := do
   match ← multivariateBoundCoreTyped maxIters tolerance useMonotonicity
@@ -368,13 +375,13 @@ def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
   | .ok outcome => return outcome
   | .error (.unsupported expression detail) =>
       throwError "multivariate_bound: unsupported expression {expression}:\n{detail}"
-  | .error (.rejected _ detail) =>
-      throwError "multivariate_bound: global-bound certificate was rejected:\n{detail}"
   | .error (.transportFailure detail) =>
       throwError "multivariate_bound: proof transport failed:\n{detail}"
+  | .error (.internalFailure detail) =>
+      throwError "multivariate_bound: internal verification failure:\n{detail}"
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-def multivariateBoundCore (maxIters : Nat) (tolerance : ℚ)
+unsafe def multivariateBoundCore (maxIters : Nat) (tolerance : ℚ)
     (useMonotonicity : Bool) (taylorDepth : Nat) : TacticM Unit := do
   discard <| multivariateBoundCoreReported maxIters tolerance useMonotonicity taylorDepth
 
@@ -390,11 +397,17 @@ def multivariateBoundCore (maxIters : Nat) (tolerance : ℚ)
     - `∀ x ∈ I, ∀ y ∈ J, f(x,y) ≤ c`
     - `∀ x ∈ I, ∀ y ∈ J, c ≤ f(x,y)`
 -/
-elab "multivariate_bound" iters:(num)? t:(leancertTrustItem)? : tactic => do
+syntax (name := multivariateBoundTac) "multivariate_bound" (num)?
+  (leancertTrustItem)? : tactic
+
+@[tactic multivariateBoundTac]
+unsafe def elabMultivariateBound : Tactic := fun stx => do
+  let iters := stx[1].getOptional?
+  let t := stx[2].getOptional?.map (⟨·⟩)
   let trust? ← LeanCert.Tactic.elabTrustItem? t
   LeanCert.Tactic.withTrustMode trust? do
     let maxIters := match iters with
-      | some n => n.getNat
+      | some n => n.toNat
       | none => 1000
     multivariateBoundCore maxIters (1/1000) false 10
 

--- a/LeanCert/Tactic/IntervalAuto/OptBound.lean
+++ b/LeanCert/Tactic/IntervalAuto/OptBound.lean
@@ -47,53 +47,82 @@ structure OptBoundOutcome where
 
 inductive OptBoundFailure where
   | unsupported (expression detail : String)
-  | rejected (checker : Name) (detail : String)
   | transportFailure (detail : String)
+  | internalFailure (detail : String)
   deriving Inhabited, Repr
 
 /-- Typed `opt_bound` implementation. The upper and lower theorem
 interpretations are transactional, and only the retained certificate
 contributes verification telemetry. -/
-def optBoundCoreTyped (maxIters : Nat) (useMonotonicity : Bool)
+unsafe def optBoundCoreTyped (maxIters : Nat) (useMonotonicity : Bool)
     (taylorDepth : Nat) : TacticM (Except OptBoundFailure OptBoundOutcome) := do
   let tolerance : ℚ := 1 / 1000
   let cfgExpr ← mkGlobalOptConfigExpr maxIters tolerance useMonotonicity taylorDepth
   let cfgSyntax ← Term.exprToSyntax cfgExpr
-  let goal ← getMainGoal
+  let goalType ← (← getMainGoal).getType
+  let rec hasBinders (count : Nat) (type : Lean.Expr) : MetaM Bool := do
+    if count == 0 then return true
+    match ← whnf type with
+    | .forallE _ _ body _ => hasBinders (count - 1) body
+    | _ => return false
+  unless ← hasBinders 3 goalType do
+    return .error <| .unsupported (toString goalType)
+      "expected three quantified/implication binders before a global bound"
+  let rec stripBinders (count : Nat) (type : Lean.Expr) : MetaM (Option Lean.Expr) := do
+    if count == 0 then return some type
+    match ← whnf type with
+    | .forallE _ _ body _ => stripBinders (count - 1) body
+    | _ => return none
+  let direction ←
+    match ← stripBinders 3 goalType with
+    | none => pure none
+    | some body =>
+        let comparison := body
+        let args := comparison.getAppArgs
+        if comparison.getAppFn.isConstOf ``LE.le && args.size ≥ 4 then
+          let lhs := args[2]!
+          let rhs := args[3]!
+          if isExprEval lhs then pure <| some OptimizationDirection.upper
+          else if isExprEval rhs then pure <| some OptimizationDirection.lower
+          else pure none
+        else pure none
+  let some direction := direction
+    | return .error <| .unsupported (toString (← (← getMainGoal).getType))
+        "expected a checked global upper- or lower-bound theorem shape"
   let tryDirection (direction : OptimizationDirection) (checker verifier : Name) :
-      TacticM (Except OptBoundFailure (Option OptBoundOutcome)) := do
+      TacticM (Except OptBoundFailure OptBoundOutcome) := do
     let saved ← saveState
-    let applied ←
-      try
-        match direction with
-        | .upper =>
-            evalTactic (← `(tactic|
-              apply LeanCert.Validity.GlobalOpt.verify_global_upper_bound
-                (cfg := $cfgSyntax)))
-        | .lower =>
-            evalTactic (← `(tactic|
-              apply LeanCert.Validity.GlobalOpt.verify_global_lower_bound
-                (cfg := $cfgSyntax)))
-        pure true
-      catch _ =>
-        saved.restore
-        return .ok none
-    unless applied do
+    try
+      match direction with
+      | .upper =>
+          evalTactic (← `(tactic|
+            apply LeanCert.Validity.GlobalOpt.verify_global_upper_bound
+              (cfg := $cfgSyntax)))
+      | .lower =>
+          evalTactic (← `(tactic|
+            apply LeanCert.Validity.GlobalOpt.verify_global_lower_bound
+              (cfg := $cfgSyntax)))
+    catch e =>
       saved.restore
-      return .ok none
+      return .error <| .transportFailure (← e.toMessageData.toString)
     let newGoals ← getGoals
     let mut verification : LeanCert.Tactic.VerificationUsage := {}
     for subgoal in newGoals do
       setGoals [subgoal]
       let subgoalType ← subgoal.getType
       if subgoalType.getAppFn.isConstOf ``ADSupported then
-        try
-          proveSupport subgoal
-          pruneSolvedGoals
-        catch e =>
-          saved.restore
-          return .error <| .transportFailure (← e.toMessageData.toString)
+      try
+        proveSupport subgoal
+        pruneSolvedGoals
+      catch e =>
+        saved.restore
+        return .error <| .transportFailure (← e.toMessageData.toString)
       else
+        let args := subgoalType.getAppArgs
+        unless subgoalType.getAppFn.isConstOf ``Eq && args.size == 3 do
+          saved.restore
+          return .error <| .internalFailure
+            s!"expected a Boolean certificate equality, got {subgoalType}"
         let event ←
           try
             LeanCert.Tactic.closeCertificateGoalReported
@@ -101,13 +130,13 @@ def optBoundCoreTyped (maxIters : Nat) (useMonotonicity : Bool)
               (tacticName := "opt_bound")
           catch e =>
             saved.restore
-            return .error <| .rejected checker (← e.toMessageData.toString)
+            return .error <| .internalFailure (← e.toMessageData.toString)
         verification := verification.combine event.toUsage
     unless (← getGoals).isEmpty do
       saved.restore
       return .error <| .transportFailure
         "verified optimization certificate left unresolved proof obligations"
-    return .ok <| some {
+    return .ok {
       direction
       checker
       verifier
@@ -117,20 +146,15 @@ def optBoundCoreTyped (maxIters : Nat) (useMonotonicity : Bool)
       useMonotonicity
       taylorDepth
     }
-  match ← tryDirection .upper
-      ``LeanCert.Validity.GlobalOpt.checkGlobalUpperBound
-      ``LeanCert.Validity.GlobalOpt.verify_global_upper_bound with
-  | .error failure => return .error failure
-  | .ok (some outcome) => return .ok outcome
-  | .ok none => pure ()
-  match ← tryDirection .lower
-      ``LeanCert.Validity.GlobalOpt.checkGlobalLowerBound
-      ``LeanCert.Validity.GlobalOpt.verify_global_lower_bound with
-  | .error failure => return .error failure
-  | .ok (some outcome) => return .ok outcome
-  | .ok none =>
-      return .error <| .unsupported (toString (← goal.getType))
-        "expected a checked global upper- or lower-bound theorem shape"
+  match direction with
+  | .upper =>
+      tryDirection direction
+        ``LeanCert.Validity.GlobalOpt.checkGlobalUpperBound
+        ``LeanCert.Validity.GlobalOpt.verify_global_upper_bound
+  | .lower =>
+      tryDirection direction
+        ``LeanCert.Validity.GlobalOpt.checkGlobalLowerBound
+        ``LeanCert.Validity.GlobalOpt.verify_global_lower_bound
 
 where
   /-- Prove ExprSupportedCore goal by generating the proof -/
@@ -144,19 +168,19 @@ where
         goal.assign proof
 
 /-- Reporting compatibility wrapper preserving the historical throwing API. -/
-def optBoundCoreReported (maxIters : Nat) (useMonotonicity : Bool)
+unsafe def optBoundCoreReported (maxIters : Nat) (useMonotonicity : Bool)
     (taylorDepth : Nat) : TacticM OptBoundOutcome := do
   match ← optBoundCoreTyped maxIters useMonotonicity taylorDepth with
   | .ok outcome => return outcome
   | .error (.unsupported expression detail) =>
       throwError "opt_bound: unsupported goal {expression}:\n{detail}"
-  | .error (.rejected _ detail) =>
-      throwError "opt_bound: global-bound certificate was rejected:\n{detail}"
   | .error (.transportFailure detail) =>
       throwError "opt_bound: proof transport failed:\n{detail}"
+  | .error (.internalFailure detail) =>
+      throwError "opt_bound: internal verification failure:\n{detail}"
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-def optBoundCore (maxIters : Nat) (useMonotonicity : Bool)
+unsafe def optBoundCore (maxIters : Nat) (useMonotonicity : Bool)
     (taylorDepth : Nat) : TacticM Unit := do
   discard <| optBoundCoreReported maxIters useMonotonicity taylorDepth
 
@@ -174,14 +198,20 @@ def optBoundCore (maxIters : Nat) (useMonotonicity : Bool)
     - `∀ ρ, Box.envMem ρ B → (∀ i, i ≥ B.length → ρ i = 0) → c ≤ Expr.eval ρ e`
     - `∀ ρ, Box.envMem ρ B → (∀ i, i ≥ B.length → ρ i = 0) → Expr.eval ρ e ≤ c`
 -/
-elab "opt_bound" iters:(num)? mono:("mono")?
-    t:(leancertTrustItem)? : tactic => do
+syntax (name := optBoundTac) "opt_bound" (num)? ("mono")?
+  (leancertTrustItem)? : tactic
+
+@[tactic optBoundTac]
+unsafe def elabOptBound : Tactic := fun stx => do
+  let iters := stx[1].getOptional?
+  let monoOpt := stx[2].getOptional?
+  let t := stx[3].getOptional?.map (⟨·⟩)
   let trust? ← LeanCert.Tactic.elabTrustItem? t
   LeanCert.Tactic.withTrustMode trust? do
     let maxIters := match iters with
-      | some n => n.getNat
+      | some n => n.toNat
       | none => 1000
-    let useMonotonicity := mono.isSome
+    let useMonotonicity := monoOpt.isSome
     optBoundCore maxIters useMonotonicity 10
 
 end LeanCert.Tactic.Auto

--- a/LeanCert/Tactic/IntervalAuto/OptBound.lean
+++ b/LeanCert/Tactic/IntervalAuto/OptBound.lean
@@ -29,78 +29,108 @@ def mkGlobalOptConfigExpr (maxIters : Nat) (tolerance : ℚ) (useMonotonicity : 
   mkAppM ``GlobalOptConfig.mk #[toExpr maxIters, toExpr tolerance, toExpr useMonotonicity, toExpr taylorDepth]
 
 /-- Runtime facts from the retained global-optimization certificate. -/
+inductive OptimizationDirection where
+  | upper
+  | lower
+  deriving DecidableEq, Repr, Inhabited
+
 structure OptBoundOutcome where
+  direction : OptimizationDirection
   checker : Name
   verifier : Name
   verification : LeanCert.Tactic.VerificationUsage
   maxIterations : Nat
+  tolerance : ℚ
   useMonotonicity : Bool
   taylorDepth : Nat
   deriving Inhabited
 
-/-- The reporting-aware `opt_bound` implementation. Candidate search is an
-implementation detail; this reports only the checker that closed the proof. -/
-def optBoundCoreReported (maxIters : Nat) (useMonotonicity : Bool)
-    (taylorDepth : Nat) : TacticM OptBoundOutcome := do
-  let cfgExpr ← mkGlobalOptConfigExpr maxIters ((1 : ℚ)/1000) useMonotonicity taylorDepth
+inductive OptBoundFailure where
+  | unsupported (expression detail : String)
+  | rejected (checker : Name) (detail : String)
+  | transportFailure (detail : String)
+  deriving Inhabited, Repr
 
-  -- First try applying upper bound theorem (for f(ρ) ≤ c goals)
+/-- Typed `opt_bound` implementation. The upper and lower theorem
+interpretations are transactional, and only the retained certificate
+contributes verification telemetry. -/
+def optBoundCoreTyped (maxIters : Nat) (useMonotonicity : Bool)
+    (taylorDepth : Nat) : TacticM (Except OptBoundFailure OptBoundOutcome) := do
+  let tolerance : ℚ := 1 / 1000
+  let cfgExpr ← mkGlobalOptConfigExpr maxIters tolerance useMonotonicity taylorDepth
+  let cfgSyntax ← Term.exprToSyntax cfgExpr
   let goal ← getMainGoal
-  let upperState ← saveState
-  try
-    let proof ← mkAppOptM ``LeanCert.Validity.GlobalOpt.verify_global_upper_bound
-      #[none, none, none, none, some cfgExpr]
-    let newGoals ← goal.apply proof
-    setGoals newGoals
-    let goals ← getGoals
+  let tryDirection (direction : OptimizationDirection) (checker verifier : Name) :
+      TacticM (Except OptBoundFailure (Option OptBoundOutcome)) := do
+    let saved ← saveState
+    let applied ←
+      try
+        match direction with
+        | .upper =>
+            evalTactic (← `(tactic|
+              apply LeanCert.Validity.GlobalOpt.verify_global_upper_bound
+                (cfg := $cfgSyntax)))
+        | .lower =>
+            evalTactic (← `(tactic|
+              apply LeanCert.Validity.GlobalOpt.verify_global_lower_bound
+                (cfg := $cfgSyntax)))
+        pure true
+      catch _ =>
+        saved.restore
+        return .ok none
+    unless applied do
+      saved.restore
+      return .ok none
+    let newGoals ← getGoals
     let mut verification : LeanCert.Tactic.VerificationUsage := {}
-    for g in goals do
-      setGoals [g]
-      let gType ← g.getType
-      if gType.getAppFn.isConstOf ``ExprSupportedCore then
-        proveSupport g
+    for subgoal in newGoals do
+      setGoals [subgoal]
+      let subgoalType ← subgoal.getType
+      if subgoalType.getAppFn.isConstOf ``ADSupported then
+        try
+          proveSupport subgoal
+          pruneSolvedGoals
+        catch e =>
+          saved.restore
+          return .error <| .transportFailure (← e.toMessageData.toString)
       else
-        let event ← LeanCert.Tactic.closeCertificateGoalReported
-          (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
-          (tacticName := "opt_bound")
+        let event ←
+          try
+            LeanCert.Tactic.closeCertificateGoalReported
+              (← LeanCert.Tactic.VerificationConfig.current) subgoal
+              (tacticName := "opt_bound")
+          catch e =>
+            saved.restore
+            return .error <| .rejected checker (← e.toMessageData.toString)
         verification := verification.combine event.toUsage
-    return {
-      checker := ``LeanCert.Validity.GlobalOpt.checkGlobalUpperBound
-      verifier := ``LeanCert.Validity.GlobalOpt.verify_global_upper_bound
-      verification, maxIterations := maxIters, useMonotonicity, taylorDepth
+    unless (← getGoals).isEmpty do
+      saved.restore
+      return .error <| .transportFailure
+        "verified optimization certificate left unresolved proof obligations"
+    return .ok <| some {
+      direction
+      checker
+      verifier
+      verification
+      maxIterations := maxIters
+      tolerance
+      useMonotonicity
+      taylorDepth
     }
-  catch _ => upperState.restore
-
-  -- Try lower bound theorem (for c ≤ f(ρ) goals)
-  let goal ← getMainGoal
-  let lowerState ← saveState
-  try
-    let proof ← mkAppOptM ``LeanCert.Validity.GlobalOpt.verify_global_lower_bound
-      #[none, none, none, none, some cfgExpr]
-    let newGoals ← goal.apply proof
-    setGoals newGoals
-    let goals ← getGoals
-    let mut verification : LeanCert.Tactic.VerificationUsage := {}
-    for g in goals do
-      setGoals [g]
-      let gType ← g.getType
-      if gType.getAppFn.isConstOf ``ExprSupportedCore then
-        proveSupport g
-      else
-        let event ← LeanCert.Tactic.closeCertificateGoalReported
-          (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
-          (tacticName := "opt_bound")
-        verification := verification.combine event.toUsage
-    return {
-      checker := ``LeanCert.Validity.GlobalOpt.checkGlobalLowerBound
-      verifier := ``LeanCert.Validity.GlobalOpt.verify_global_lower_bound
-      verification, maxIterations := maxIters, useMonotonicity, taylorDepth
-    }
-  catch _ => lowerState.restore
-
-  throwError "opt_bound: Could not apply global bound theorem. Check that goal has form:\n\
-              • ∀ ρ, Box.envMem ρ B → (∀ i ≥ B.length, ρ i = 0) → c ≤ Expr.eval ρ e\n\
-              • ∀ ρ, Box.envMem ρ B → (∀ i ≥ B.length, ρ i = 0) → Expr.eval ρ e ≤ c"
+  match ← tryDirection .upper
+      ``LeanCert.Validity.GlobalOpt.checkGlobalUpperBound
+      ``LeanCert.Validity.GlobalOpt.verify_global_upper_bound with
+  | .error failure => return .error failure
+  | .ok (some outcome) => return .ok outcome
+  | .ok none => pure ()
+  match ← tryDirection .lower
+      ``LeanCert.Validity.GlobalOpt.checkGlobalLowerBound
+      ``LeanCert.Validity.GlobalOpt.verify_global_lower_bound with
+  | .error failure => return .error failure
+  | .ok (some outcome) => return .ok outcome
+  | .ok none =>
+      return .error <| .unsupported (toString (← goal.getType))
+        "expected a checked global upper- or lower-bound theorem shape"
 
 where
   /-- Prove ExprSupportedCore goal by generating the proof -/
@@ -109,9 +139,21 @@ where
       let gType ← goal.getType
       let args := gType.getAppArgs
       if args.size ≥ 1 then
-        let expr := args[0]!
-        let proof ← mkSupportedCoreProof expr
+        let expr ← withTransparency .all <| whnf args[0]!
+        let proof ← mkSupportedProof expr
         goal.assign proof
+
+/-- Reporting compatibility wrapper preserving the historical throwing API. -/
+def optBoundCoreReported (maxIters : Nat) (useMonotonicity : Bool)
+    (taylorDepth : Nat) : TacticM OptBoundOutcome := do
+  match ← optBoundCoreTyped maxIters useMonotonicity taylorDepth with
+  | .ok outcome => return outcome
+  | .error (.unsupported expression detail) =>
+      throwError "opt_bound: unsupported goal {expression}:\n{detail}"
+  | .error (.rejected _ detail) =>
+      throwError "opt_bound: global-bound certificate was rejected:\n{detail}"
+  | .error (.transportFailure detail) =>
+      throwError "opt_bound: proof transport failed:\n{detail}"
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
 def optBoundCore (maxIters : Nat) (useMonotonicity : Bool)

--- a/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
+++ b/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
@@ -233,6 +233,21 @@ private def renderChildren (children : Array ChildReport) : String :=
       s!"  {index + 1}. {intentLabel child.intent} — {child.strategy}{backend}"
     s!"\n\nChild theorems:\n{String.intercalate "\n" rows}"
 
+private def renderOptimization (statistics : Option OptimizationStatistics) : String :=
+  match statistics with
+  | none => ""
+  | some statistics =>
+      let actual := statistics.iterations.map
+        (fun value => s!"\n  Iterations used: {value}") |>.getD ""
+      let gap := statistics.gap.map
+        (fun value => s!"\n  Final certified gap: {value}") |>.getD ""
+      let converged := statistics.converged.map
+        (fun value => s!"\n  Within requested tolerance: {value}") |>.getD ""
+      let remaining := statistics.remainingBoxes.map
+        (fun value => s!"\n  Remaining boxes: {value}") |>.getD ""
+      s!"\n\nOptimization:\n  Configured iteration limit: {statistics.configuredLimit}\n  \
+        Tolerance: {statistics.tolerance}{actual}{gap}{converged}{remaining}"
+
 def successReport (report : SolverReport) : String :=
   let plan := report.plan
   let detail := plan.strategyDetail.map (fun value => s!"\n  {value}") |>.getD ""
@@ -254,12 +269,13 @@ def successReport (report : SolverReport) : String :=
   let verifier :=
     (report.execution.verifier <|> plan.verifier).map
       (fun value => s!"\nVerifier: {value}") |>.getD ""
+  let optimization := renderOptimization report.execution.optimization
   let advanced :=
     plan.dedicatedProof.map (fun proof =>
       s!"\n\nAdvanced control:\n  {renderProof proof}") |>.getD ""
   s!"LeanCert recognized: {intentLabel plan.intent}\n\n\
     Selected strategy:\n  {plan.strategy}{detail}{executionNotes}{backend}{verification}\
-    {checker}{verifier}\n\nSuggested proof:\n  {renderProof plan.primaryProof}\
+    {checker}{verifier}{optimization}\n\nSuggested proof:\n  {renderProof plan.primaryProof}\
     {advanced}{renderChildren report.execution.children}"
 
 end LeanCert.Tactic.Diagnostic

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -194,6 +194,52 @@ private unsafe def directBoundAttemptTyped (depth : Nat) :
   | .error (.transportFailure detail) =>
       return .error <| .internalError `LeanCert.Tactic.Auto.certify_bound detail
 
+private def discoveryExecution (outcome : DiscoveryOutcome) : SolverExecution := {
+  backend := outcome.dyadic.map fun dyadic =>
+    if dyadic then .dyadicInterval else .rationalInterval
+  verificationUsage := Solver.VerificationUsage.ofEvents outcome.verification
+  checker := outcome.checker
+  verifier := outcome.verifier
+  optimization := some {
+    iterations := some outcome.iterations
+    configuredLimit := outcome.configuredLimit
+    tolerance := outcome.tolerance
+    gap := some (outcome.upperBound - outcome.lowerBound)
+    converged := some (outcome.upperBound - outcome.lowerBound ≤ outcome.tolerance)
+    remainingBoxes := some outcome.remainingBoxes
+  }
+  notes := #[
+    s!"discovered witness: {outcome.witness}",
+    s!"certified search interval: [{outcome.lowerBound}, {outcome.upperBound}]",
+    s!"Taylor depth: {outcome.taylorDepth}"
+  ]
+}
+
+private def discoveryFailure (solver : Name) :
+    DiscoveryFailure → AttemptFailure
+  | .unsupported expression detail =>
+      .unsupported { expression, detail := some detail }
+  | .inconclusive detail =>
+      .inconclusive { detail }
+  | .rejected checker detail =>
+      .rejected { checker, detail }
+  | .transportFailure detail =>
+      .internalError solver detail
+
+private unsafe def minimizeAttemptTyped (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← intervalMinimizeCoreTyped depth with
+  | .ok outcome => return .ok (discoveryExecution outcome)
+  | .error failure =>
+      return .error (discoveryFailure `LeanCert.Tactic.Discovery.interval_minimize failure)
+
+private unsafe def maximizeAttemptTyped (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← intervalMaximizeCoreTyped depth with
+  | .ok outcome => return .ok (discoveryExecution outcome)
+  | .error failure =>
+      return .error (discoveryFailure `LeanCert.Tactic.Discovery.interval_maximize failure)
+
 private def finSumAttemptReported (precision : Int) (depth : Nat) :
     TacticM SolverExecution := do
   let outcome ← finSumBoundCoreReported precision depth
@@ -258,30 +304,71 @@ private def noRootAttemptReported (depth : Nat) : TacticM SolverExecution := do
     outcome.verification outcome.checker outcome.verifier
     #[s!"Taylor depth: {outcome.taylorDepth}"]
 
-private def optimizationAttemptReported (maxIterations : Nat)
-    (useMonotonicity : Bool) (depth : Nat) : TacticM SolverExecution := do
-  let outcome ← Auto.optBoundCoreReported maxIterations useMonotonicity depth
-  return checkedExecution
-    none
-    outcome.verification outcome.checker outcome.verifier #[
-      s!"maximum iterations: {outcome.maxIterations}",
-      s!"Taylor depth: {outcome.taylorDepth}",
-      s!"monotonicity pruning: {outcome.useMonotonicity}"
-    ]
+private def optimizationAttemptTyped (maxIterations : Nat)
+    (useMonotonicity : Bool) (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← Auto.optBoundCoreTyped maxIterations useMonotonicity depth with
+  | .ok outcome =>
+      return .ok {
+        verificationUsage := Solver.VerificationUsage.ofEvents outcome.verification
+        checker := some outcome.checker
+        verifier := some outcome.verifier
+        optimization := some {
+          configuredLimit := outcome.maxIterations
+          tolerance := outcome.tolerance
+        }
+        notes := #[
+          s!"Taylor depth: {outcome.taylorDepth}",
+          s!"monotonicity pruning: {outcome.useMonotonicity}"
+        ]
+      }
+  | .error (.unsupported expression detail) =>
+      return .error <| .unsupported {
+        expression
+        detail := some detail
+      }
+  | .error (.rejected checker detail) =>
+      trace[LeanCert.router] "optimization certificate rejected:\n{detail}"
+      return .error <| .rejected {
+        checker := some checker
+        detail := "The global-optimization certificate was rejected."
+      }
+  | .error (.transportFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.opt_bound detail
 
-private def multivariateAttemptReported (maxIterations : Nat)
+private def multivariateAttemptTyped (maxIterations : Nat)
     (tolerance : ℚ) (useMonotonicity : Bool) (depth : Nat) :
-    TacticM SolverExecution := do
-  let outcome ← Auto.multivariateBoundCoreReported maxIterations tolerance
-    useMonotonicity depth
-  return checkedExecution
-    none
-    outcome.verification outcome.checker outcome.verifier #[
-      s!"maximum iterations: {outcome.maxIterations}",
-      s!"tolerance: {outcome.tolerance}",
-      s!"Taylor depth: {outcome.taylorDepth}",
-      s!"monotonicity pruning: {outcome.useMonotonicity}"
-    ]
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← Auto.multivariateBoundCoreTyped maxIterations tolerance
+      useMonotonicity depth with
+  | .ok outcome =>
+      return .ok {
+        verificationUsage := Solver.VerificationUsage.ofEvents outcome.verification
+        checker := some outcome.checker
+        verifier := some outcome.verifier
+        optimization := some {
+          configuredLimit := outcome.maxIterations
+          tolerance := outcome.tolerance
+        }
+        notes := #[
+          s!"Taylor depth: {outcome.taylorDepth}",
+          s!"monotonicity pruning: {outcome.useMonotonicity}"
+        ]
+      }
+  | .error (.unsupported expression detail) =>
+      return .error <| .unsupported {
+        expression
+        detail := some detail
+      }
+  | .error (.rejected checker detail) =>
+      trace[LeanCert.router] "multivariate certificate rejected:\n{detail}"
+      return .error <| .rejected {
+        checker := some checker
+        detail := "The multivariate optimization certificate was rejected."
+      }
+  | .error (.transportFailure detail) =>
+      return .error <| .internalError
+        `LeanCert.Tactic.Auto.multivariate_bound detail
 
 /-- The deterministic strategy portfolio for a recognized goal intent. -/
 private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
@@ -327,7 +414,7 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
       { report := report intent
           (if cfg.useMonotonicity then s!"opt_bound {cfg.maxIterations} mono"
            else s!"opt_bound {cfg.maxIterations}") cfg mode
-          (.policy "legacy checked global-optimization certificate")
+          (.policy "checked global-optimization certificate")
           (if cfg.taylorDepth == 10 then
             some (suggestion "opt_bound"
               (if cfg.useMonotonicity then #[toString cfg.maxIterations, "mono"]
@@ -335,33 +422,30 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
            else none)
           (strategyId := .globalOptimization),
         solve := Auto.optBoundCore cfg.maxIterations cfg.useMonotonicity d
-        solveReported := some
-          (optimizationAttemptReported cfg.maxIterations cfg.useMonotonicity d)
-        legacyExceptionAdapter := true
+        solveReportedResult := some
+          (optimizationAttemptTyped cfg.maxIterations cfg.useMonotonicity d)
         cost := 3 }]
   | .multivariateBound => #[
       { report := report intent s!"multivariate_bound {cfg.maxIterations}"
-          cfg mode (.policy "legacy checked global-optimization certificate")
+          cfg mode (.policy "checked global-optimization certificate")
           (if !cfg.useMonotonicity && d == 10 then
             some (suggestion "multivariate_bound" #[toString cfg.maxIterations])
            else none)
           (strategyId := .globalOptimization),
         solve := Auto.multivariateBoundCore cfg.maxIterations (1 / 1000)
           cfg.useMonotonicity d
-        solveReported := some <|
-          multivariateAttemptReported cfg.maxIterations (1 / 1000)
+        solveReportedResult := some <|
+          multivariateAttemptTyped cfg.maxIterations (1 / 1000)
             cfg.useMonotonicity d
-        legacyExceptionAdapter := true
         cost := 3 },
       { report := report intent s!"multivariate_bound {2 * cfg.maxIterations}"
-          cfg mode (.policy "legacy checked global-optimization certificate")
+          cfg mode (.policy "checked global-optimization certificate")
           none (strategyId := .globalOptimization),
         solve := Auto.multivariateBoundCore (2 * cfg.maxIterations) (1 / 10000)
           cfg.useMonotonicity d2
-        solveReported := some <|
-          multivariateAttemptReported (2 * cfg.maxIterations) (1 / 10000)
+        solveReportedResult := some <|
+          multivariateAttemptTyped (2 * cfg.maxIterations) (1 / 10000)
             cfg.useMonotonicity d2
-        legacyExceptionAdapter := true
         cost := 4 }]
   | .rootExists => #[
       { report := report intent "endpoint sign-change certificate" cfg mode
@@ -422,24 +506,32 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
         legacyExceptionAdapter := true }]
   | .existentialMinimum => #[
       { report := report intent "guided lower-bound discovery and certification" cfg mode
-          (.policy "legacy optimization followed by checked interval certification")
-          (some (suggestion "interval_minimize" #[toString d])), solve := intervalMinimizeCore d },
+          (.policy "guided optimization followed by checked interval certification")
+          (some (suggestion "interval_minimize" #[toString d]))
+        solve := intervalMinimizeCore d
+        solveReportedResult := some (minimizeAttemptTyped d) },
       { report := report intent "multivariate lower-bound discovery and certification" cfg mode
           (.policy "legacy optimization followed by checked certification")
           (some (suggestion "interval_minimize_mv" #[toString d])), solve := intervalMinimizeMvCore d },
       { report := report intent "guided lower-bound discovery and certification" cfg mode
-          (.policy "legacy optimization followed by checked interval certification")
-          (some (suggestion "interval_minimize" #[toString d2])), solve := intervalMinimizeCore d2 }]
+          (.policy "guided optimization followed by checked interval certification")
+          (some (suggestion "interval_minimize" #[toString d2]))
+        solve := intervalMinimizeCore d2
+        solveReportedResult := some (minimizeAttemptTyped d2) }]
   | .existentialMaximum => #[
       { report := report intent "guided upper-bound discovery and certification" cfg mode
-          (.policy "legacy optimization followed by checked interval certification")
-          (some (suggestion "interval_maximize" #[toString d])), solve := intervalMaximizeCore d },
+          (.policy "guided optimization followed by checked interval certification")
+          (some (suggestion "interval_maximize" #[toString d]))
+        solve := intervalMaximizeCore d
+        solveReportedResult := some (maximizeAttemptTyped d) },
       { report := report intent "multivariate upper-bound discovery and certification" cfg mode
           (.policy "legacy optimization followed by checked certification")
           (some (suggestion "interval_maximize_mv" #[toString d])), solve := intervalMaximizeMvCore d },
       { report := report intent "guided upper-bound discovery and certification" cfg mode
-          (.policy "legacy optimization followed by checked interval certification")
-          (some (suggestion "interval_maximize" #[toString d2])), solve := intervalMaximizeCore d2 }]
+          (.policy "guided optimization followed by checked interval certification")
+          (some (suggestion "interval_maximize" #[toString d2]))
+        solve := intervalMaximizeCore d2
+        solveReportedResult := some (maximizeAttemptTyped d2) }]
   | .argmin => #[
       { report := report intent "attained minimum certification" cfg mode
           (.policy "candidate search followed by checked bounds")

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -195,8 +195,7 @@ private unsafe def directBoundAttemptTyped (depth : Nat) :
       return .error <| .internalError `LeanCert.Tactic.Auto.certify_bound detail
 
 private def discoveryExecution (outcome : DiscoveryOutcome) : SolverExecution := {
-  backend := outcome.dyadic.map fun dyadic =>
-    if dyadic then .dyadicInterval else .rationalInterval
+  backend := some .rationalInterval
   verificationUsage := Solver.VerificationUsage.ofEvents outcome.verification
   checker := outcome.checker
   verifier := outcome.verifier
@@ -211,6 +210,8 @@ private def discoveryExecution (outcome : DiscoveryOutcome) : SolverExecution :=
   notes := #[
     s!"discovered witness: {outcome.witness}",
     s!"certified search interval: [{outcome.lowerBound}, {outcome.upperBound}]",
+    s!"bound certification backend: {
+      if outcome.dyadic.getD false then "Dyadic interval" else "Rational interval"}",
     s!"Taylor depth: {outcome.taylorDepth}"
   ]
 }
@@ -221,8 +222,6 @@ private def discoveryFailure (solver : Name) :
       .unsupported { expression, detail := some detail }
   | .inconclusive detail =>
       .inconclusive { detail }
-  | .rejected checker detail =>
-      .rejected { checker, detail }
   | .transportFailure detail =>
       .internalError solver detail
 
@@ -304,7 +303,7 @@ private def noRootAttemptReported (depth : Nat) : TacticM SolverExecution := do
     outcome.verification outcome.checker outcome.verifier
     #[s!"Taylor depth: {outcome.taylorDepth}"]
 
-private def optimizationAttemptTyped (maxIterations : Nat)
+private unsafe def optimizationAttemptTyped (maxIterations : Nat)
     (useMonotonicity : Bool) (depth : Nat) :
     TacticM (Except AttemptFailure SolverExecution) := do
   match ← Auto.optBoundCoreTyped maxIterations useMonotonicity depth with
@@ -327,16 +326,12 @@ private def optimizationAttemptTyped (maxIterations : Nat)
         expression
         detail := some detail
       }
-  | .error (.rejected checker detail) =>
-      trace[LeanCert.router] "optimization certificate rejected:\n{detail}"
-      return .error <| .rejected {
-        checker := some checker
-        detail := "The global-optimization certificate was rejected."
-      }
   | .error (.transportFailure detail) =>
       return .error <| .internalError `LeanCert.Tactic.Auto.opt_bound detail
+  | .error (.internalFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.opt_bound detail
 
-private def multivariateAttemptTyped (maxIterations : Nat)
+private unsafe def multivariateAttemptTyped (maxIterations : Nat)
     (tolerance : ℚ) (useMonotonicity : Bool) (depth : Nat) :
     TacticM (Except AttemptFailure SolverExecution) := do
   match ← Auto.multivariateBoundCoreTyped maxIterations tolerance
@@ -360,13 +355,10 @@ private def multivariateAttemptTyped (maxIterations : Nat)
         expression
         detail := some detail
       }
-  | .error (.rejected checker detail) =>
-      trace[LeanCert.router] "multivariate certificate rejected:\n{detail}"
-      return .error <| .rejected {
-        checker := some checker
-        detail := "The multivariate optimization certificate was rejected."
-      }
   | .error (.transportFailure detail) =>
+      return .error <| .internalError
+        `LeanCert.Tactic.Auto.multivariate_bound detail
+  | .error (.internalFailure detail) =>
       return .error <| .internalError
         `LeanCert.Tactic.Auto.multivariate_bound detail
 

--- a/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
+++ b/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
@@ -94,6 +94,18 @@ structure ChildReport where
   verificationUsage : VerificationUsage := {}
   deriving Inhabited
 
+/-- Structured facts from an optimization or optimization-guided discovery
+run. Fields unavailable from Boolean-only certificate APIs remain `none`
+rather than being reconstructed by rerunning the optimizer. -/
+structure OptimizationStatistics where
+  iterations : Option Nat := none
+  configuredLimit : Nat
+  tolerance : ℚ
+  gap : Option ℚ := none
+  converged : Option Bool := none
+  remainingBoxes : Option Nat := none
+  deriving Inhabited, Repr
+
 /-- Stable algorithm identity for reporting and failure classification.
 User-facing `strategy` text may be polished without changing control flow. -/
 inductive StrategyId where
@@ -140,6 +152,7 @@ structure SolverExecution where
   checker : Option Name := none
   verifier : Option Name := none
   enclosure : Option LeanCert.Core.IntervalRat := none
+  optimization : Option OptimizationStatistics := none
   notes : Array String := #[]
   children : Array ChildReport := #[]
   deriving Inhabited

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -91,7 +91,10 @@ unsafe def elabExpectRationalPointReport : Tactic := fun _ => do
     throwError "point Rational checker/Golden-Theorem identity was not retained: \
       checker={result.execution.checker}, verifier={result.execution.verifier}"
 
-elab "expect_optimization_report" : tactic => do
+syntax (name := expectOptimizationReport) "expect_optimization_report" : tactic
+
+@[tactic expectOptimizationReport]
+unsafe def elabExpectOptimizationReport : Tactic := fun _ => do
   let outcome ←
     match ← Auto.optBoundCoreTyped 64 false 10 with
     | .ok outcome => pure outcome
@@ -99,8 +102,10 @@ elab "expect_optimization_report" : tactic => do
         throwError "typed optimization route unexpectedly failed: {repr failure}"
   unless outcome.maxIterations == 64 do
     throwError "optimization outcome lost its configured iteration limit"
-  unless outcome.checker != Name.anonymous && outcome.verifier != Name.anonymous do
-    throwError "optimization report lost checker/Golden-Theorem identity"
+  unless outcome.direction == .upper &&
+      outcome.checker == ``LeanCert.Validity.GlobalOpt.checkGlobalUpperBound &&
+      outcome.verifier == ``LeanCert.Validity.GlobalOpt.verify_global_upper_bound do
+    throwError "optimization report retained the wrong direction/checker/Golden Theorem"
 
 syntax (name := expectDiscoveryReport) "expect_discovery_report" : tactic
 
@@ -114,18 +119,62 @@ unsafe def elabExpectDiscoveryReport : Tactic := fun _ => do
     throwError "discovery report did not retain actual optimizer results"
   unless result.execution.checker.isSome && result.execution.verifier.isSome do
     throwError "discovery report lost certification identity"
+  unless result.execution.backend == some .rationalInterval do
+    throwError "discovery search backend was conflated with witness certification"
 
-private def optimizationTestBox : LeanCert.Engine.Optimization.Box :=
-  [⟨0, 1, by norm_num⟩]
+syntax (name := expectTypedOptimizationRollback)
+  "expect_typed_optimization_rollback" : tactic
 
-example : ∀ ρ, LeanCert.Engine.Optimization.Box.envMem ρ optimizationTestBox →
-    (∀ i, i ≥ optimizationTestBox.length → ρ i = 0) →
+@[tactic expectTypedOptimizationRollback]
+unsafe def elabExpectTypedOptimizationRollback : Tactic := fun _ => do
+  let goal ← getMainGoal
+  let before ← goal.getType
+  match ← Auto.optBoundCoreTyped 8 false 10 with
+  | .error (.unsupported ..) =>
+      let after ← (← getMainGoal).getType
+      unless ← isDefEq before after do
+        throwError "unsupported opt_bound mutated the caller's goal"
+  | .error failure =>
+      throwError "unsupported opt_bound had wrong classification: {repr failure}"
+  | .ok _ =>
+      throwError "unsupported opt_bound unexpectedly succeeded"
+
+syntax (name := expectTypedMultivariateRollback)
+  "expect_typed_multivariate_rollback" : tactic
+
+@[tactic expectTypedMultivariateRollback]
+unsafe def elabExpectTypedMultivariateRollback : Tactic := fun _ => do
+  let goal ← getMainGoal
+  let before ← goal.getType
+  match ← Auto.multivariateBoundCoreTyped 8 (1 / 1000) false 10 with
+  | .error (.unsupported ..) =>
+      let after ← (← getMainGoal).getType
+      unless ← isDefEq before after do
+        throwError "unsupported multivariate bound mutated the caller's goal"
+  | .error failure =>
+      throwError "unsupported multivariate bound had wrong classification: {repr failure}"
+  | .ok _ =>
+      throwError "unsupported multivariate bound unexpectedly succeeded"
+
+example : ∀ ρ, LeanCert.Engine.Optimization.Box.envMem ρ
+      ([⟨0, 1, by norm_num⟩] : LeanCert.Engine.Optimization.Box) →
+    (∀ i, i ≥
+      ([⟨0, 1, by norm_num⟩] : LeanCert.Engine.Optimization.Box).length →
+      ρ i = 0) →
     LeanCert.Core.Expr.eval ρ
       (.mul (.var 0) (.var 0)) ≤ (1 : ℚ) := by
   expect_optimization_report
 
 example : ∃ m : ℚ, ∀ x ∈ Set.Icc (-1 : ℝ) 1, x * x ≥ m := by
   expect_discovery_report
+
+example : True := by
+  expect_typed_optimization_rollback
+  trivial
+
+example : True := by
+  expect_typed_multivariate_rollback
+  trivial
 
 syntax (name := expectKernelBoundReport) "expect_kernel_bound_report" : tactic
 

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -91,6 +91,42 @@ unsafe def elabExpectRationalPointReport : Tactic := fun _ => do
     throwError "point Rational checker/Golden-Theorem identity was not retained: \
       checker={result.execution.checker}, verifier={result.execution.verifier}"
 
+elab "expect_optimization_report" : tactic => do
+  let outcome ←
+    match ← Auto.optBoundCoreTyped 64 false 10 with
+    | .ok outcome => pure outcome
+    | .error failure =>
+        throwError "typed optimization route unexpectedly failed: {repr failure}"
+  unless outcome.maxIterations == 64 do
+    throwError "optimization outcome lost its configured iteration limit"
+  unless outcome.checker != Name.anonymous && outcome.verifier != Name.anonymous do
+    throwError "optimization report lost checker/Golden-Theorem identity"
+
+syntax (name := expectDiscoveryReport) "expect_discovery_report" : tactic
+
+@[tactic expectDiscoveryReport]
+unsafe def elabExpectDiscoveryReport : Tactic := fun _ => do
+  let result ← runLeanCert {} .compact
+  let some statistics := result.execution.optimization
+    | throwError "discovery route returned no structured statistics"
+  unless statistics.iterations.isSome && statistics.gap.isSome &&
+      statistics.remainingBoxes.isSome do
+    throwError "discovery report did not retain actual optimizer results"
+  unless result.execution.checker.isSome && result.execution.verifier.isSome do
+    throwError "discovery report lost certification identity"
+
+private def optimizationTestBox : LeanCert.Engine.Optimization.Box :=
+  [⟨0, 1, by norm_num⟩]
+
+example : ∀ ρ, LeanCert.Engine.Optimization.Box.envMem ρ optimizationTestBox →
+    (∀ i, i ≥ optimizationTestBox.length → ρ i = 0) →
+    LeanCert.Core.Expr.eval ρ
+      (.mul (.var 0) (.var 0)) ≤ (1 : ℚ) := by
+  expect_optimization_report
+
+example : ∃ m : ℚ, ∀ x ∈ Set.Icc (-1 : ℝ) 1, x * x ≥ m := by
+  expect_discovery_report
+
 syntax (name := expectKernelBoundReport) "expect_kernel_bound_report" : tactic
 
 @[tactic expectKernelBoundReport]

--- a/docs/direct/optimization-discovery.md
+++ b/docs/direct/optimization-discovery.md
@@ -47,6 +47,12 @@ and checker are not rerun to produce this report. For a direct `opt_bound`
 certificate, only configured limits are reported because that checked API does
 not expose an execution trace.
 
+A gap larger than the configured tolerance is reported as
+`Within requested tolerance: false`. It does not invalidate an existential
+bound: the discovered witness is still accepted only after its bound is
+independently certified. The tolerance measures discovery quality, not proof
+soundness or tactic success.
+
 Discovery mode is useful when you do not yet know the bound or extremum.  See
 the existing [Discovery Mode](../tactics/discovery.md) reference for command
 syntax and examples.

--- a/docs/direct/optimization-discovery.md
+++ b/docs/direct/optimization-discovery.md
@@ -39,6 +39,14 @@ not the optimization arithmetic. Until runtime telemetry identifies a concrete
 backend, a report should describe the selected strategy or backend policy
 rather than infer one.
 
+`leancert?` reports discovery and certification separately. Discovery reports
+the iterations actually used, final certified gap, tolerance, and remaining
+boxes from the retained optimizer run. Certification reports the checker,
+Golden Theorem, and verification route used to close the bound. The optimizer
+and checker are not rerun to produce this report. For a direct `opt_bound`
+certificate, only configured limits are reported because that checked API does
+not expose an execution trace.
+
 Discovery mode is useful when you do not yet know the bound or extremum.  See
 the existing [Discovery Mode](../tactics/discovery.md) reference for command
 syntax and examples.

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -563,6 +563,10 @@ opt_bound <maxIterations> mono (trust := kernel)
 a strategy choice, not a
 numerical-backend or trust selection.
 
+Reported execution includes the exact checker, Golden Theorem, verification
+route, configured iteration limit, and tolerance. The Boolean certificate API
+does not expose actual iteration counts, so reports do not infer them.
+
 ---
 
 ### `root_bound`


### PR DESCRIPTION
## Summary

This PR migrates the first optimization and discovery solver families to LeanCert’s typed reporting protocol.

It:

- adds direct typed outcomes for `opt_bound` and `multivariate_bound`;
- adds typed univariate `interval_minimize` and `interval_maximize` discovery;
- preserves checker, Golden Theorem, verification route, and winning-branch metadata;
- reports structured optimization statistics, including iterations, certified gap, tolerance, convergence, and remaining boxes where available;
- restores the complete tactic state after failed speculative attempts;
- treats theorem transport and verification infrastructure failures as terminal internal errors;
- preserves existing dedicated tactic syntax through compatibility wrappers;
- avoids rerunning optimization or certificate computation solely to produce reports.

## Reporting semantics

Discovery and final bound certification are reported separately:

- the guided search uses the Rational optimization engine;
- the selected witness may subsequently be certified by either the Dyadic or Rational direct-bound path;
- a discovery gap above tolerance is reported as `Within requested tolerance: false`;
- a wide gap does not invalidate a successfully certified existential bound—the tolerance measures discovery quality, not proof soundness.

Direct Boolean optimization certificates currently expose their configured iteration limit and tolerance, but not actual runtime iteration counts. The report therefore does not fabricate those values.

## Failure handling

The migrated paths distinguish:

- unsupported goal or expression shape;
- certificate/proof transport failure;
- verification infrastructure or invariant failure.

Verification failures are handled conservatively as terminal internal errors. The current shared verification API cannot distinguish a false Boolean checker from infrastructure failure without rerunning the checker, and this PR preserves the no-duplicate-computation invariant. A typed verification-layer result is deferred to a focused follow-up.

## Scope

Included:

- direct `opt_bound`;
- direct `multivariate_bound`;
- univariate `interval_minimize`;
- univariate `interval_maximize`;
- router integration, diagnostics, tests, and documentation.

Deliberately deferred:

- `interval_argmin` and `interval_argmax`;
- multivariate existential discovery wrappers;
- engine-level termination reasons;
- the shared typed verification API;
- unrelated roots, integration, finite-sum, and subdivision migrations.

## Compatibility

Existing dedicated tactic syntax and behavior remain available:

```lean
opt_bound
multivariate_bound
interval_minimize
interval_maximize