### PR TITLE
Return typed certificate verification results

### DIFF
--- a/LeanCert/Tactic/Discovery.lean
+++ b/LeanCert/Tactic/Discovery.lean
@@ -264,6 +264,7 @@ inductive DiscoveryFailure where
   | unsupported (expression detail : String)
   | inconclusive (detail : String)
   | transportFailure (detail : String)
+  | internalFailure (detail : String)
   deriving Inhabited, Repr
 
 private def discoveryFailureOfBound :
@@ -271,6 +272,7 @@ private def discoveryFailureOfBound :
   | .unsupported expression detail => .unsupported expression detail
   | .inconclusive detail => .inconclusive detail
   | .transportFailure detail => .transportFailure detail
+  | .internalFailure detail => .internalFailure detail
 
 private def throwDiscoveryFailure (tacticName : String) : DiscoveryFailure → TacticM α
   | .unsupported expression detail =>
@@ -279,6 +281,8 @@ private def throwDiscoveryFailure (tacticName : String) : DiscoveryFailure → T
       throwError "{tacticName}: {detail}"
   | .transportFailure detail =>
       throwError "{tacticName}: proof transport failed:\n{detail}"
+  | .internalFailure detail =>
+      throwError "{tacticName}: certificate verification failed:\n{detail}"
 
 /-- Reporting-aware implementation of `interval_minimize`.
 

--- a/LeanCert/Tactic/IntervalAuto/Bound.lean
+++ b/LeanCert/Tactic/IntervalAuto/Bound.lean
@@ -151,6 +151,7 @@ inductive IntervalBoundFailure where
   | unsupported (expression detail : String)
   | inconclusive (detail : String)
   | transportFailure (detail : String)
+  | internalFailure (detail : String)
   deriving Inhabited, Repr
 
 private def boundVerifierName (isStrict isLower useChecked fromIcc : Bool) : Name :=
@@ -273,19 +274,21 @@ def tryDyadicBoundReported (goal : MVarId) (reified : LeanCert.Meta.ReifyReport)
       let certTy ← mkAppM ``Eq #[checkExpr, mkConst ``Bool.true]
       let certGoal ← mkFreshExprMVar certTy
       let certGoalId := certGoal.mvarId!
-      let event? ←
-        try
-          some <$> certGoalId.withContext do
-            setGoals [certGoalId]
-            closeCertificateGoalReported (← VerificationConfig.current)
-              (← getMainGoal) (tacticName := "certify_bound")
-        catch e =>
-          trace[interval_decide] "Dyadic certificate rejected in certify_bound: \
-            {e.toMessageData}"
-          pure none
-      let some event := event?
-        | saved.restore
-          return .ok none
+      let verificationResult ← certGoalId.withContext do
+        setGoals [certGoalId]
+        closeCertificateGoalTyped (← VerificationConfig.current)
+          (← getMainGoal) (tacticName := "certify_bound")
+      let event ←
+        match verificationResult with
+        | .accepted event => pure event
+        | .rejected =>
+            trace[interval_decide] "Dyadic certificate rejected in certify_bound"
+            saved.restore
+            return .ok none
+        | .failed failure =>
+            saved.restore
+            return .error <| .internalFailure
+              (failure.message "certify_bound")
       let conclusionProof ← mkAppM' proof #[certGoal]
       -- Retain the event locally until all transport goals have closed.
       setGoals [goal]
@@ -316,6 +319,8 @@ private def tryDyadicBoundCompatibility (goal : MVarId)
       throwError "certify_bound: unsupported expression {expression}:\n{detail}"
   | .error (.inconclusive detail) =>
       throwError "certify_bound: {detail}"
+  | .error (.internalFailure detail) =>
+      throwError "certify_bound: certificate verification failed:\n{detail}"
 
 /-! ## Main Tactic Implementation -/
 
@@ -1072,17 +1077,21 @@ private def rationalBoundAttemptTyped (goal : MVarId)
     let certTy ← mkAppM ``Eq #[checkExpr, mkConst ``Bool.true]
     let certGoal ← mkFreshExprMVar certTy
     let certGoalId := certGoal.mvarId!
+    let verificationResult ← certGoalId.withContext do
+      setGoals [certGoalId]
+      closeCertificateGoalTyped (← VerificationConfig.current)
+        certGoalId (tacticName := "certify_bound")
     let event ←
-      try
-        certGoalId.withContext do
-          setGoals [certGoalId]
-          closeCertificateGoalReported (← VerificationConfig.current)
-            certGoalId (tacticName := "certify_bound")
-      catch e =>
-        saved.restore
-        return .error <| .inconclusive
-          s!"The Rational interval checker rejected the candidate certificate: \
-            {← e.toMessageData.toString}"
+      match verificationResult with
+      | .accepted event => pure event
+      | .rejected =>
+          saved.restore
+          return .error <| .inconclusive
+            "The Rational interval checker rejected the candidate certificate."
+      | .failed failure =>
+          saved.restore
+          return .error <| .internalFailure
+            (failure.message "certify_bound")
     let conclusionProof ←
       try mkAppM' theoremProof #[certGoal]
       catch e =>
@@ -1225,6 +1234,8 @@ def intervalBoundCoreReported (taylorDepth : Nat) :
       throwError "reported direct bound: {detail}"
   | .error (.transportFailure detail) =>
       throwError "reported direct bound: proof transport failed:\n{detail}"
+  | .error (.internalFailure detail) =>
+      throwError "reported direct bound: certificate verification failed:\n{detail}"
 
 
 /-! ## Tactic Syntax -/

--- a/LeanCert/Tactic/IntervalAuto/Multivariate.lean
+++ b/LeanCert/Tactic/IntervalAuto/Multivariate.lean
@@ -44,6 +44,7 @@ structure MultivariateBoundOutcome where
 
 inductive MultivariateBoundFailure where
   | unsupported (expression detail : String)
+  | rejected (detail : String)
   | transportFailure (detail : String)
   | internalFailure (detail : String)
   deriving Inhabited, Repr
@@ -231,13 +232,19 @@ where
       let certGoal ← mkFreshExprMVar certTy
       let certGoalId := certGoal.mvarId!
       setGoals [certGoalId]
-      let event ← try
-        LeanCert.Tactic.closeCertificateGoalReported
-          (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
-          (tacticName := "multivariate_bound")
-      catch e =>
-        saved.restore
-        return .error <| .internalFailure (← e.toMessageData.toString)
+      let event ←
+        match ← LeanCert.Tactic.closeCertificateGoalTyped
+            (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
+            (tacticName := "multivariate_bound") with
+        | .accepted event => pure event
+        | .rejected =>
+            saved.restore
+            return .error <| .rejected
+              "the multivariate upper-bound checker evaluated to false"
+        | .failed failure =>
+            saved.restore
+            return .error <| .internalFailure
+              (failure.message "multivariate_bound")
 
       let conclusionProof ← mkAppM' proof #[certGoal]
       let conclusionTerm ← Lean.Elab.Term.exprToSyntax conclusionProof
@@ -328,13 +335,19 @@ where
       let certGoal ← mkFreshExprMVar certTy
       let certGoalId := certGoal.mvarId!
       setGoals [certGoalId]
-      let event ← try
-        LeanCert.Tactic.closeCertificateGoalReported
-          (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
-          (tacticName := "multivariate_bound")
-      catch e =>
-        saved.restore
-        return .error <| .internalFailure (← e.toMessageData.toString)
+      let event ←
+        match ← LeanCert.Tactic.closeCertificateGoalTyped
+            (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
+            (tacticName := "multivariate_bound") with
+        | .accepted event => pure event
+        | .rejected =>
+            saved.restore
+            return .error <| .rejected
+              "the multivariate lower-bound checker evaluated to false"
+        | .failed failure =>
+            saved.restore
+            return .error <| .internalFailure
+              (failure.message "multivariate_bound")
 
       let conclusionProof ← mkAppM' proof #[certGoal]
       let conclusionTerm ← Lean.Elab.Term.exprToSyntax conclusionProof
@@ -375,6 +388,8 @@ unsafe def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
   | .ok outcome => return outcome
   | .error (.unsupported expression detail) =>
       throwError "multivariate_bound: unsupported expression {expression}:\n{detail}"
+  | .error (.rejected detail) =>
+      throwError "multivariate_bound: certificate rejected:\n{detail}"
   | .error (.transportFailure detail) =>
       throwError "multivariate_bound: proof transport failed:\n{detail}"
   | .error (.internalFailure detail) =>

--- a/LeanCert/Tactic/IntervalAuto/OptBound.lean
+++ b/LeanCert/Tactic/IntervalAuto/OptBound.lean
@@ -47,6 +47,7 @@ structure OptBoundOutcome where
 
 inductive OptBoundFailure where
   | unsupported (expression detail : String)
+  | rejected (detail : String)
   | transportFailure (detail : String)
   | internalFailure (detail : String)
   deriving Inhabited, Repr
@@ -124,13 +125,18 @@ unsafe def optBoundCoreTyped (maxIters : Nat) (useMonotonicity : Bool)
           return .error <| .internalFailure
             s!"expected a Boolean certificate equality, got {subgoalType}"
         let event ←
-          try
-            LeanCert.Tactic.closeCertificateGoalReported
+          match ← LeanCert.Tactic.closeCertificateGoalTyped
               (← LeanCert.Tactic.VerificationConfig.current) subgoal
-              (tacticName := "opt_bound")
-          catch e =>
-            saved.restore
-            return .error <| .internalFailure (← e.toMessageData.toString)
+              (tacticName := "opt_bound") with
+          | .accepted event => pure event
+          | .rejected =>
+              saved.restore
+              return .error <| .rejected
+                "the global optimization checker evaluated to false"
+          | .failed failure =>
+              saved.restore
+              return .error <| .internalFailure
+                (failure.message "opt_bound")
         verification := verification.combine event.toUsage
     unless (← getGoals).isEmpty do
       saved.restore
@@ -174,6 +180,8 @@ unsafe def optBoundCoreReported (maxIters : Nat) (useMonotonicity : Bool)
   | .ok outcome => return outcome
   | .error (.unsupported expression detail) =>
       throwError "opt_bound: unsupported goal {expression}:\n{detail}"
+  | .error (.rejected detail) =>
+      throwError "opt_bound: certificate rejected:\n{detail}"
   | .error (.transportFailure detail) =>
       throwError "opt_bound: proof transport failed:\n{detail}"
   | .error (.internalFailure detail) =>

--- a/LeanCert/Tactic/IntervalAuto/PointIneq.lean
+++ b/LeanCert/Tactic/IntervalAuto/PointIneq.lean
@@ -43,6 +43,7 @@ inductive PointInequalityFailure where
   | rejected (detail : String)
   | inconclusive (detail : String)
   | transportFailure (detail : String)
+  | internalFailure (detail : String)
   deriving Inhabited
 
 /-- Try to prove a closed expression bound directly using certificate verification. -/
@@ -127,11 +128,15 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
       let certGoal ← mkFreshExprMVar certTy
       let certGoalId := certGoal.mvarId!
       let event ←
-        try
-          closeCertificateGoalReported (← VerificationConfig.current) certGoalId
-            (tacticName := "interval_decide")
-        catch e =>
-          return .error <| .rejected (← e.toMessageData.toString)
+        match ← closeCertificateGoalTyped (← VerificationConfig.current) certGoalId
+            (tacticName := "interval_decide") with
+        | .accepted event => pure event
+        | .rejected =>
+            return .error <| .rejected
+              "the Rational point checker evaluated to false"
+        | .failed failure =>
+            return .error <| .internalFailure
+              (failure.message "interval_decide")
 
       let proof ← mkAppM theoremName #[diffAst, supportProof, intervalExpr, toExpr zeroRat, cfgExpr, certGoal]
 
@@ -303,7 +308,8 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
     -- Rational; construction and transport exceptions remain implementation
     -- errors and escape this typed core.
     let dyadicSaved ← saveState
-    let dyadicOutcome? ← do
+    let tryDyadic : TacticM (Except PointInequalityFailure
+        (Option PointInequalityOutcome)) := do
       let prec : Int := -80
       let precExpr := toExpr prec
       let depthExpr := toExpr taylorDepth
@@ -327,16 +333,18 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
       let dyadicCertGoal ← mkFreshExprMVar dyadicCertTy
       let dyadicCertGoalId := dyadicCertGoal.mvarId!
       trace[interval_decide] "Verifying dyadic certificate"
-      let event? ←
-        try
-          some <$> closeCertificateGoalReported (← VerificationConfig.current)
-            dyadicCertGoalId (tacticName := "interval_decide")
-        catch e =>
-          trace[interval_decide] "Dyadic certificate rejected: {e.toMessageData}"
-          pure none
-      let some event := event?
-        | dyadicSaved.restore
-          pure none
+      let event ←
+        match ← closeCertificateGoalTyped (← VerificationConfig.current)
+            dyadicCertGoalId (tacticName := "interval_decide") with
+        | .accepted event => pure event
+        | .rejected =>
+            trace[interval_decide] "Dyadic certificate rejected"
+            dyadicSaved.restore
+            return .ok none
+        | .failed failure =>
+            dyadicSaved.restore
+            return .error <| .internalFailure
+              (failure.message "interval_decide")
       trace[interval_decide] "Dyadic certificate verified"
 
       let dyadicProof ← mkAppM dyadicTheoremName
@@ -353,7 +361,7 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
       let dyadicProofStx : TSyntax `term := ⟨dyadicProofStxRaw⟩
       let closed ← tryCloseWith dyadicProofStx
       if closed then
-        pure <| some {
+        pure <| .ok <| some {
           checker := dyadicCheckName
           verifier := dyadicTheoremName
           verification := event.toUsage
@@ -363,9 +371,13 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
         }
       else
         dyadicSaved.restore
-        pure none
-    if let some outcome := dyadicOutcome? then
-      return .ok outcome
+        pure <| .error <| .transportFailure
+          "certified Dyadic proof did not close the original point inequality"
+    let dyadicResult ← tryDyadic
+    match dyadicResult with
+    | .ok (some outcome) => return .ok outcome
+    | .ok none => pure ()
+    | .error failure => return .error failure
 
     let supportProof ←
       try mkSupportedCoreProof ast
@@ -402,11 +414,15 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
     let certGoalId := certGoal.mvarId!
     trace[interval_decide] "Verifying rational certificate"
     let event ←
-      try
-        closeCertificateGoalReported (← VerificationConfig.current) certGoalId
-          (tacticName := "interval_decide")
-      catch e =>
-        return .error <| .rejected (← e.toMessageData.toString)
+      match ← closeCertificateGoalTyped (← VerificationConfig.current) certGoalId
+          (tacticName := "interval_decide") with
+      | .accepted event => pure event
+      | .rejected =>
+          return .error <| .rejected
+            "the Rational point checker evaluated to false"
+      | .failed failure =>
+          return .error <| .internalFailure
+            (failure.message "interval_decide")
     trace[interval_decide] "Certificate verified"
 
     let proof ← mkAppM theoremName #[ast, supportProof, intervalExpr, toExpr boundRat, cfgExpr, certGoal]
@@ -452,6 +468,8 @@ def proveClosedExpressionBoundReported (goal : MVarId) (goalType : Lean.Expr)
       throwError "proveClosedExpressionBound: inconclusive:\n{detail}"
   | .error (.transportFailure detail) =>
       throwError "proveClosedExpressionBound: proof transport failed:\n{detail}"
+  | .error (.internalFailure detail) =>
+      throwError "proveClosedExpressionBound: certificate verification failed:\n{detail}"
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
 def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr)

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -164,6 +164,8 @@ private def pointAttemptTyped (depth : Nat) :
       return .error <| .inconclusive { detail }
   | .error (.transportFailure detail) =>
       return .error <| .internalError `LeanCert.Tactic.Auto.interval_decide detail
+  | .error (.internalFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.interval_decide detail
 
 private def directBoundExecution (outcome : Auto.IntervalBoundOutcome) :
     SolverExecution := Id.run do
@@ -192,6 +194,8 @@ private unsafe def directBoundAttemptTyped (depth : Nat) :
   | .error (.inconclusive detail) =>
       return .error <| .inconclusive { detail }
   | .error (.transportFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.certify_bound detail
+  | .error (.internalFailure detail) =>
       return .error <| .internalError `LeanCert.Tactic.Auto.certify_bound detail
 
 private def discoveryExecution (outcome : DiscoveryOutcome) : SolverExecution := {
@@ -223,6 +227,8 @@ private def discoveryFailure (solver : Name) :
   | .inconclusive detail =>
       .inconclusive { detail }
   | .transportFailure detail =>
+      .internalError solver detail
+  | .internalFailure detail =>
       .internalError solver detail
 
 private unsafe def minimizeAttemptTyped (depth : Nat) :
@@ -326,6 +332,8 @@ private unsafe def optimizationAttemptTyped (maxIterations : Nat)
         expression
         detail := some detail
       }
+  | .error (.rejected detail) =>
+      return .error <| .rejected { detail }
   | .error (.transportFailure detail) =>
       return .error <| .internalError `LeanCert.Tactic.Auto.opt_bound detail
   | .error (.internalFailure detail) =>
@@ -355,6 +363,8 @@ private unsafe def multivariateAttemptTyped (maxIterations : Nat)
         expression
         detail := some detail
       }
+  | .error (.rejected detail) =>
+      return .error <| .rejected { detail }
   | .error (.transportFailure detail) =>
       return .error <| .internalError
         `LeanCert.Tactic.Auto.multivariate_bound detail

--- a/LeanCert/Tactic/Verification.lean
+++ b/LeanCert/Tactic/Verification.lean
@@ -4,19 +4,21 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
 import Lean
+import Lean.Meta.Native
+import Lean.Meta.Tactic.AuxLemma
 
 /-!
 # Centralized certificate verification (trust choke point)
 
-Every LeanCert reflective tactic ultimately closes a Boolean certificate goal
-of the form `check … = true`. This module is the single place where that goal
+Every LeanCert reflective tactic ultimately closes a decidable certificate
+proposition, normally of the form `check … = true`. This module is the single place where that goal
 gets closed, and therefore the single place where the trusted base of the
 resulting proof is decided:
 
 | Mode      | Closes with         | Trusted base                                    |
 |-----------|---------------------|-------------------------------------------------|
-| `.native` | `native_decide`     | kernel + compiler/runtime (`Lean.ofReduceBool`)  |
-| `.kernel` | `decide +kernel`    | kernel only (foundational axioms)                |
+| `.native` | `nativeEqTrue`      | kernel + compiler/runtime (native auxiliary axiom) |
+| `.kernel` | cached kernel proof | kernel only (foundational axioms)                |
 | `.auto`   | kernel, then native | kernel when it succeeds; fallback is reported    |
 
 Design rules:
@@ -25,10 +27,13 @@ Design rules:
   error telling the user how to opt in to native trust explicitly.
 * `.auto` may fall back, and reports when it does (`trace[leancert.verification]`
   always; one `logInfo` per process on first fallback).
-* The kernel route goes through the `decide +kernel` elaboration path (kernel
-  reduction via `mkAuxLemma`: eager in-tactic error reporting plus per-module
-  caching) — never raw `Lean.Meta.mkDecideProof`, whose failures on a false or
-  stuck certificate surface only at `addDecl` as an unreadable kernel error.
+* The typed boundary reduces the `Decidable` instance first, so a conclusive
+  `false` result is data rather than an exception. Successful kernel proofs
+  still go through `mkAuxLemma` for eager kernel validation and per-module
+  caching.
+* Native mode uses Lean's structured `nativeEqTrue` primitive directly:
+  `.notTrue` is rejection, while compilation/evaluation exceptions are
+  infrastructure failures.
 
 Select the mode globally with `set_option leancert.trust "kernel"` (likewise
 `"native"`, `"auto"`), or per invocation with `(trust := kernel|native|auto)`.
@@ -154,6 +159,35 @@ structure VerificationUsage where
   events : Array VerificationEvent := #[]
   deriving Repr, Inhabited
 
+/-- Infrastructure failures while checking a Boolean certificate.
+
+An ordinary checker result of `false` is deliberately not represented here:
+it is the `.rejected` case of `VerificationResult`. -/
+inductive VerificationFailure where
+  /-- The proposed certificate goal was not a closed decidable proposition. -/
+  | malformedCertificateGoal (detail : String)
+  /-- Kernel reduction could not determine or validate the checker result. -/
+  | kernelFailure (detail : String)
+  /-- Native compilation or evaluation failed before producing a result. -/
+  | nativeFailure (detail : String)
+  /-- The verification protocol itself encountered an unexpected invariant
+  failure. -/
+  | internalError (detail : String)
+  deriving Repr
+
+/-- Typed result of attempting to close one Boolean certificate goal.
+
+Only `.accepted` mutates the retained tactic state. Both `.rejected` and
+`.failed` restore the complete state saved on entry. -/
+inductive VerificationResult where
+  /-- The checker evaluated to `true`; the certificate goal is assigned. -/
+  | accepted (event : VerificationEvent)
+  /-- The checker conclusively evaluated to `false`. -/
+  | rejected
+  /-- The checker could not be evaluated or its proof could not be retained. -/
+  | failed (failure : VerificationFailure)
+  deriving Repr
+
 namespace VerificationEvent
 
 /-- Regard one successful certificate closure as aggregate usage. -/
@@ -220,25 +254,97 @@ def VerificationConfig.current : CoreM VerificationConfig := do
         expected \"native\", \"kernel\", or \"auto\""
   return { mode, kernelHeartbeats := leancert.trust.kernelHeartbeats.get opts }
 
-private def closeNativeCore (certGoal : MVarId) (tacticName : String) :
-    TacticM Unit := do
-  setGoals [certGoal]
-  try
-    evalTactic (← `(tactic| native_decide))
-  catch e =>
-    throwError "{tacticName}: native_decide failed on certificate check:{indentD e.toMessageData}"
+private structure CertificateGoal where
+  type : Expr
+  decision : Expr
 
-private def closeKernelCore (certGoal : MVarId) (tacticName : String) :
-    TacticM Unit := do
-  setGoals [certGoal]
+/-- Validate and unpack a closed decidable certificate proposition.
+
+Most LeanCert certificates have the shape `check = true`; a few low-level
+bridges use decidable propositions such as domain-validity predicates
+directly. Both are represented by the single Boolean expression returned by
+`decide`. -/
+private def parseCertificateGoal (certGoal : MVarId) :
+    TacticM (Except VerificationFailure CertificateGoal) := certGoal.withContext do
+  let certType ← instantiateMVars (← certGoal.getType)
+  if certType.hasMVar then
+    return .error <| .malformedCertificateGoal
+      s!"certificate goal contains unresolved metavariables: {certType}"
+  if certType.hasLooseBVars then
+    return .error <| .malformedCertificateGoal
+      s!"certificate goal contains loose bound variables: {certType}"
+  if certType.hasFVar then
+    return .error <| .malformedCertificateGoal
+      s!"certificate goal contains free variables: {certType}"
+  unless ← isProp certType do
+    return .error <| .malformedCertificateGoal
+      s!"expected a decidable proposition, got: {certType}"
+  let decision ←
+    try mkDecide certType
+    catch e =>
+      return .error <| .malformedCertificateGoal
+        s!"certificate proposition has no executable Decidable instance:\n\
+          {← e.toMessageData.toString}"
+  if decision.hasMVar then
+    return .error <| .malformedCertificateGoal
+      s!"certificate decision procedure contains unresolved metavariables: {decision}"
+  if decision.hasFVar then
+    return .error <| .malformedCertificateGoal
+      s!"certificate decision procedure contains free variables: {decision}"
+  return .ok { type := certType, decision }
+
+private inductive VerificationAttempt where
+  | accepted
+  | rejected
+  | failed (detail : String)
+
+/-- Evaluate the checker once using Lean's native Boolean primitive. On
+success, `nativeEqTrue` returns the exact proof retained by the certificate
+goal; `.notTrue` is a structured negative result rather than an exception. -/
+private def closeNativeTypedCore (certificate : CertificateGoal)
+    (certGoal : MVarId) (_tacticName : String) :
+    TacticM VerificationAttempt := do
   try
-    evalTactic (← `(tactic| decide +kernel))
+    match ← Lean.Meta.nativeEqTrue `native_decide certificate.decision
+        (axiomDeclRange? := (← getRef)) with
+    | .notTrue =>
+        return .rejected
+    | .success proof =>
+        let decidableInst := certificate.decision.appArg!
+        let propositionProof := mkApp3 (mkConst ``of_decide_eq_true)
+          certificate.type decidableInst proof
+        certGoal.assign propositionProof
+        return .accepted
   catch e =>
-    throwError "{tacticName}: kernel verification (decide +kernel) failed on \
-      certificate check:{indentD e.toMessageData}\n\
-      Kernel mode never falls back to native verification. Use \
-      `set_option leancert.trust \"native\"` (or \"auto\") to allow \
-      `native_decide`, which additionally trusts the compiler."
+    return .failed (← e.toMessageData.toString)
+
+/-- Kernel-only certificate closure with a structured Boolean result.
+
+The elaborator first reduces the closed checker to a canonical Boolean so
+`false` is data rather than an exception. For `true`, the equality proof is
+stored through the same auxiliary-lemma cache used by `decide +kernel`, so the
+kernel validates the result eagerly and repeated certificate types can reuse
+the declaration. -/
+private def closeKernelTypedCore (certificate : CertificateGoal)
+    (certGoal : MVarId) : TacticM VerificationAttempt := do
+  try
+    let proof ← mkDecideProof certificate.type
+    let decidableInst := proof.appFn!.appArg!
+    let reduced ← withOptions (fun opts => opts.set `maxRecDepth 100000) do
+      withAtLeastTransparency .all <| whnf decidableInst
+    if reduced.isAppOf ``isFalse then
+      return .rejected
+    unless reduced.isAppOf ``isTrue do
+      return .failed s!"certificate decision procedure did not reduce to \
+        `isTrue` or `isFalse`: {reduced}"
+    let levelsInType := (collectLevelParams {} certificate.type).params
+    let lemmaLevels := (← Term.getLevelNames).reverse.filter levelsInType.contains
+    let lemmaName ← withOptions (Elab.async.set · false) do
+      mkAuxLemma lemmaLevels certificate.type proof
+    certGoal.assign <| mkConst lemmaName (lemmaLevels.map .param)
+    return .accepted
+  catch e =>
+    return .failed (← e.toMessageData.toString)
 
 /-! ### Auto-mode cost gate
 
@@ -309,79 +415,144 @@ def autoGateReason? (opts : Options) (certType : Expr) : Option String := Id.run
           return some s!"{iters} optimization iterations exceed autoMaxOptIterations={maxIters}"
   return none
 
-private def closeAutoCore (cfg : VerificationConfig) (certGoal : MVarId)
-    (tacticName : String) : TacticM VerificationEvent := do
-  let certType ← instantiateMVars (← certGoal.getType)
-  if let some reason := autoGateReason? (← getOptions) certType then
+private def closeAutoTypedCore (cfg : VerificationConfig)
+    (certificate : CertificateGoal) (certGoal : MVarId)
+    (tacticName : String) : TacticM VerificationResult := do
+  if let some reason := autoGateReason? (← getOptions) certificate.type then
     trace[leancert.verification] "{tacticName}: auto gate routed certificate to \
       native_decide ({reason})"
-    closeNativeCore certGoal tacticName
-    return {
-      requested := .auto
-      used := .native
-      cause := .autoNativeGate
-      gateReason := some reason
-    }
+    match ← closeNativeTypedCore certificate certGoal tacticName with
+    | .accepted =>
+        return .accepted {
+          requested := .auto
+          used := .native
+          cause := .autoNativeGate
+          gateReason := some reason
+        }
+    | .rejected => return .rejected
+    | .failed detail => return .failed (.nativeFailure detail)
   let s ← saveState
-  try
-    withOptions (fun o => o.set `maxHeartbeats cfg.kernelHeartbeats) do
-      closeKernelCore certGoal tacticName
-    trace[leancert.verification] "{tacticName}: certificate verified by kernel reduction (auto)"
-    pure {
-      requested := .auto
-      used := .kernel
-      cause := .autoKernel
-    }
-  catch e =>
+  match ← withOptions (fun o => o.set `maxHeartbeats cfg.kernelHeartbeats) do
+      closeKernelTypedCore certificate certGoal with
+  | .accepted =>
+      trace[leancert.verification] "{tacticName}: certificate verified by kernel reduction (auto)"
+      return .accepted {
+        requested := .auto
+        used := .kernel
+        cause := .autoKernel
+      }
+  | .rejected =>
+      -- A conclusive Boolean `false` is route-independent. Native fallback is
+      -- reserved for a kernel route that could not finish.
+      return .rejected
+  | .failed detail =>
     s.restore
     trace[leancert.verification] "{tacticName}: kernel attempt failed in auto mode, \
-      falling back to native_decide:{indentD e.toMessageData}"
-    unless (← autoFallbackReported.get) do
-      autoFallbackReported.set true
-      logInfo m!"{tacticName}: a certificate was verified with native_decide \
-        (kernel attempt did not succeed within budget). The proof \
-        additionally trusts the compiler. Further fallbacks in this \
-        session are reported under `trace[leancert.verification]` only."
-    closeNativeCore certGoal tacticName
-    pure {
-      requested := .auto
-      used := .native
-      cause := .autoNativeFallback
-    }
+      falling back to native_decide:\n{detail}"
+    match ← closeNativeTypedCore certificate certGoal tacticName with
+    | .accepted =>
+        unless (← autoFallbackReported.get) do
+          autoFallbackReported.set true
+          logInfo m!"{tacticName}: a certificate was verified with native_decide \
+            (kernel attempt did not succeed within budget). The proof \
+            additionally trusts the compiler. Further fallbacks in this \
+            session are reported under `trace[leancert.verification]` only."
+        return .accepted {
+          requested := .auto
+          used := .native
+          cause := .autoNativeFallback
+        }
+    | .rejected => return .rejected
+    | .failed nativeDetail =>
+        return .failed <| .nativeFailure
+          s!"native fallback failed after kernel verification failure:\n\
+            Kernel failure: {detail}\nNative failure: {nativeDetail}"
 
-/-- Close a Boolean certificate goal (`check … = true`) according to the
-verification mode, and return structured telemetry describing the requested
-policy, actual route, and auto-mode decision. The surrounding goal list is
-saved and restored. -/
+/-- Close a decidable certificate goal (normally `check … = true`) according to the
+verification mode and return a typed result.
+
+Only `.accepted` retains state changes. Rejection, malformed goals, and
+verification infrastructure failures restore the complete tactic state saved
+on entry, including environment declarations and messages. -/
+def closeCertificateGoalTyped (cfg : VerificationConfig) (certGoal : MVarId)
+    (tacticName : String := "leancert") : TacticM VerificationResult := do
+  let saved ← saveState
+  try
+    let savedGoals ← getGoals
+    let certificate ←
+      match ← parseCertificateGoal certGoal with
+      | .ok certificate => pure certificate
+      | .error failure =>
+          saved.restore
+          return .failed failure
+    let result ←
+      match cfg.mode with
+      | .native =>
+          match ← closeNativeTypedCore certificate certGoal tacticName with
+          | .accepted =>
+              trace[leancert.verification] "{tacticName}: certificate verified by native_decide"
+              pure <| .accepted {
+                requested := .native
+                used := .native
+                cause := .explicitNative
+              }
+          | .rejected => pure .rejected
+          | .failed detail => pure <| .failed (.nativeFailure detail)
+      | .kernel =>
+          match ← closeKernelTypedCore certificate certGoal with
+          | .accepted =>
+              trace[leancert.verification] "{tacticName}: certificate verified by kernel reduction"
+              pure <| .accepted {
+                requested := .kernel
+                used := .kernel
+                cause := .explicitKernel
+              }
+          | .rejected => pure .rejected
+          | .failed detail => pure <| .failed (.kernelFailure detail)
+      | .auto =>
+          closeAutoTypedCore cfg certificate certGoal tacticName
+    match result with
+    | .accepted _ =>
+        -- Restore the surrounding goal list while retaining the successful
+        -- environment extension and certificate assignment.
+        setGoals savedGoals
+        pruneSolvedGoals
+        return result
+    | .rejected | .failed _ =>
+        saved.restore
+        return result
+  catch e =>
+    saved.restore
+    let detail ←
+      try e.toMessageData.toString
+      catch _ => pure "an exception escaped the verification implementation"
+    return .failed <| .internalError detail
+
+def VerificationFailure.message (tacticName : String) :
+    VerificationFailure → String
+  | .malformedCertificateGoal detail =>
+      s!"{tacticName}: malformed certificate goal:\n{detail}"
+  | .kernelFailure detail =>
+      s!"{tacticName}: kernel verification failed on the certificate check:\n\
+        {detail}\nKernel mode never falls back to native verification. Use \
+        `set_option leancert.trust \"native\"` (or \"auto\") to allow \
+        `native_decide`, which additionally trusts the compiler."
+  | .nativeFailure detail =>
+      s!"{tacticName}: native certificate verification failed:\n{detail}"
+  | .internalError detail =>
+      s!"{tacticName}: internal certificate verification error:\n{detail}"
+
+/-- Throwing compatibility wrapper for callers that have not yet migrated to
+the typed verification protocol. New reporting-aware callers should use
+`closeCertificateGoalTyped`. -/
 def closeCertificateGoalReported (cfg : VerificationConfig) (certGoal : MVarId)
     (tacticName : String := "leancert") : TacticM VerificationEvent := do
-  let savedGoals ← getGoals
-  try
-    match cfg.mode with
-    | .native =>
-        closeNativeCore certGoal tacticName
-        trace[leancert.verification] "{tacticName}: certificate verified by native_decide"
-        pure {
-          requested := .native
-          used := .native
-          cause := .explicitNative
-        }
-    | .kernel =>
-        closeKernelCore certGoal tacticName
-        trace[leancert.verification] "{tacticName}: certificate verified by kernel reduction"
-        pure {
-          requested := .kernel
-          used := .kernel
-          cause := .explicitKernel
-        }
-    | .auto =>
-        closeAutoCore cfg certGoal tacticName
-  finally
-    -- Restore the surrounding goal list, dropping anything closed in the
-    -- meantime (in particular `certGoal` itself when it was the main goal —
-    -- callers check goal-list emptiness to detect success).
-    setGoals savedGoals
-    pruneSolvedGoals
+  match ← closeCertificateGoalTyped cfg certGoal tacticName with
+  | .accepted event => return event
+  | .rejected =>
+      throwError "{tacticName}: certificate checker evaluated to false"
+  | .failed failure =>
+      throwError (failure.message tacticName)
 
 /-- Compatibility wrapper returning only the route that closed the
 certificate. New reporting-aware callers should use

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -176,6 +176,65 @@ example : True := by
   expect_typed_multivariate_rollback
   trivial
 
+syntax (name := expectTypedOptimizationRejection)
+  "expect_typed_optimization_rejection" : tactic
+
+@[tactic expectTypedOptimizationRejection]
+unsafe def elabExpectTypedOptimizationRejection : Tactic := fun _ => do
+  let callerGoals ← getGoals
+  let falseType ← Term.elabTerm
+    (← `(∀ ρ, LeanCert.Engine.Optimization.Box.envMem ρ
+        ([⟨0, 2, by norm_num⟩] : LeanCert.Engine.Optimization.Box) →
+      (∀ i, i ≥
+        ([⟨0, 2, by norm_num⟩] : LeanCert.Engine.Optimization.Box).length →
+        ρ i = 0) →
+      LeanCert.Core.Expr.eval ρ
+        (.mul (.var 0) (.var 0)) ≤ (1 : ℚ))) none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let falseType ← instantiateMVars falseType
+  let falseGoal ← mkFreshExprMVar falseType
+  setGoals [falseGoal.mvarId!]
+  match ← Auto.optBoundCoreTyped 8 false 10 with
+  | .error (.rejected _) =>
+      unless !(← falseGoal.mvarId!.isAssigned) do
+        throwError "rejected opt_bound mutated the caller's goal"
+      setGoals callerGoals
+      evalTactic (← `(tactic| trivial))
+  | .error failure =>
+      throwError "false opt_bound certificate had wrong classification: {repr failure}"
+  | .ok _ =>
+      throwError "false opt_bound certificate unexpectedly succeeded"
+
+example : True := by
+  expect_typed_optimization_rejection
+
+syntax (name := expectTypedMultivariateRejection)
+  "expect_typed_multivariate_rejection" : tactic
+
+@[tactic expectTypedMultivariateRejection]
+unsafe def elabExpectTypedMultivariateRejection : Tactic := fun _ => do
+  let callerGoals ← getGoals
+  let falseType ← Term.elabTerm
+    (← `(∀ x ∈ Set.Icc (0 : ℝ) 1, ∀ y ∈ Set.Icc (0 : ℝ) 1,
+      x + y ≤ (-1 : ℚ))) none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let falseType ← instantiateMVars falseType
+  let falseGoal ← mkFreshExprMVar falseType
+  setGoals [falseGoal.mvarId!]
+  match ← Auto.multivariateBoundCoreTyped 8 (1 / 1000) false 10 with
+  | .error (.rejected _) =>
+      unless !(← falseGoal.mvarId!.isAssigned) do
+        throwError "rejected multivariate bound mutated the caller's goal"
+      setGoals callerGoals
+      evalTactic (← `(tactic| trivial))
+  | .error failure =>
+      throwError "false multivariate certificate had wrong classification: {repr failure}"
+  | .ok _ =>
+      throwError "false multivariate certificate unexpectedly succeeded"
+
+example : True := by
+  expect_typed_multivariate_rejection
+
 syntax (name := expectKernelBoundReport) "expect_kernel_bound_report" : tactic
 
 @[tactic expectKernelBoundReport]

--- a/LeanCert/Test/TrustModes.lean
+++ b/LeanCert/Test/TrustModes.lean
@@ -23,7 +23,7 @@ silently used native verification). These pins are the guard against a
 repeat.
 -/
 
-open Lean Elab Tactic
+open Lean Meta Elab Tactic
 
 private def closeAndExpectVerificationEvent
     (cfg : LeanCert.Tactic.VerificationConfig)
@@ -52,9 +52,127 @@ elab "close_expect_auto_kernel_event" : tactic =>
   closeAndExpectVerificationEvent { mode := .auto }
     .auto .kernel .autoKernel
 
-example : True := by close_expect_native_event
-example : True := by close_expect_kernel_event
-example : True := by close_expect_auto_kernel_event
+example : true = true := by close_expect_native_event
+example : true = true := by close_expect_kernel_event
+example : true = true := by close_expect_auto_kernel_event
+example : 0 < 1 := by close_expect_kernel_event
+
+private def expectTypedRejection
+    (cfg : LeanCert.Tactic.VerificationConfig) : TacticM Unit := do
+  let callerGoals ← getGoals
+  let envSizeBefore := (← getEnv).constants.toList.length
+  let certType ← mkEq (toExpr false) (toExpr true)
+  let certGoal ← mkFreshExprMVar certType
+  match ← LeanCert.Tactic.closeCertificateGoalTyped cfg certGoal.mvarId!
+      "typed rejection test" with
+  | .rejected => pure ()
+  | result => throwError "expected typed certificate rejection, got {repr result}"
+  unless (← getGoals) == callerGoals do
+    throwError "typed certificate rejection changed the caller's goal list"
+  unless (← getEnv).constants.toList.length == envSizeBefore do
+    throwError "typed certificate rejection leaked an environment declaration"
+  unless !(← certGoal.mvarId!.isAssigned) do
+    throwError "typed certificate rejection assigned the certificate goal"
+  evalTactic (← `(tactic| trivial))
+
+elab "expect_native_rejection" : tactic =>
+  expectTypedRejection { mode := .native }
+
+elab "expect_kernel_rejection" : tactic =>
+  expectTypedRejection { mode := .kernel }
+
+elab "expect_auto_rejection" : tactic =>
+  expectTypedRejection { mode := .auto }
+
+example : True := by expect_native_rejection
+example : True := by expect_kernel_rejection
+example : True := by expect_auto_rejection
+
+elab "expect_malformed_certificate_failure" : tactic => do
+  let callerGoals ← getGoals
+  let malformed ← mkFreshExprMVar (mkConst ``Bool)
+  match ← LeanCert.Tactic.closeCertificateGoalTyped { mode := .native }
+      malformed.mvarId! "malformed certificate test" with
+  | .failed (.malformedCertificateGoal _) => pure ()
+  | result => throwError "expected malformed-certificate failure, got {repr result}"
+  unless (← getGoals) == callerGoals do
+    throwError "malformed certificate failure changed the caller's goal list"
+  evalTactic (← `(tactic| trivial))
+
+example : True := by expect_malformed_certificate_failure
+
+elab "expect_free_variable_certificate_failure" : tactic => do
+  let callerGoals ← getGoals
+  let mainGoal ← getMainGoal
+  mainGoal.withContext do
+    let some fvar := (← getLCtx).getFVarIds.back?
+      | throwError "expected a local Boolean variable"
+    let certType ← mkEq (mkFVar fvar) (toExpr true)
+    let certGoal ← mkFreshExprMVar certType
+    match ← LeanCert.Tactic.closeCertificateGoalTyped { mode := .native }
+        certGoal.mvarId! "free-variable certificate test" with
+    | .failed (.malformedCertificateGoal _) => pure ()
+    | result => throwError "expected malformed free-variable certificate, got {repr result}"
+    unless (← getGoals) == callerGoals do
+      throwError "free-variable certificate failure changed the caller's goal list"
+    unless !(← certGoal.mvarId!.isAssigned) do
+      throwError "free-variable certificate failure assigned the certificate goal"
+  evalTactic (← `(tactic| trivial))
+
+example (_b : Bool) : True := by expect_free_variable_certificate_failure
+
+elab "expect_outer_boundary_failure" : tactic => do
+  let callerGoals ← getGoals
+  let invalidGoal := MVarId.mk `LeanCert.Test.missingCertificateGoal
+  match ← LeanCert.Tactic.closeCertificateGoalTyped { mode := .native }
+      invalidGoal "outer boundary failure test" with
+  | .failed (.internalError _) => pure ()
+  | result => throwError "expected internal boundary failure, got {repr result}"
+  unless (← getGoals) == callerGoals do
+    throwError "outer verification failure changed the caller's goal list"
+  evalTactic (← `(tactic| trivial))
+
+example : True := by expect_outer_boundary_failure
+
+noncomputable def verificationOpaqueBool : Bool :=
+  Classical.choice ⟨true⟩
+
+def verificationExpensiveBool : Bool :=
+  (List.range 10000).length == 10000
+
+elab "expect_failed_auto_fallback_is_silent" : tactic => do
+  let callerGoals ← getGoals
+  let messagesBefore := (← Core.getMessageLog).toList.length
+  let certType ← mkEq (mkConst ``verificationOpaqueBool) (toExpr true)
+  let certGoal ← mkFreshExprMVar certType
+  match ← LeanCert.Tactic.closeCertificateGoalTyped
+      { mode := .auto, kernelHeartbeats := 1 } certGoal.mvarId!
+      "failed auto fallback test" with
+  | .failed (.nativeFailure _) => pure ()
+  | result => throwError "expected failed native fallback, got {repr result}"
+  unless (← Core.getMessageLog).toList.length == messagesBefore do
+    throwError "failed auto fallback emitted a successful-verification notice"
+  unless (← getGoals) == callerGoals do
+    throwError "failed auto fallback changed the caller's goal list"
+  unless !(← certGoal.mvarId!.isAssigned) do
+    throwError "failed auto fallback assigned the certificate goal"
+  evalTactic (← `(tactic| trivial))
+
+example : True := by expect_failed_auto_fallback_is_silent
+
+elab "expect_successful_auto_fallback_notice" : tactic => do
+  let certType ← mkEq (mkConst ``verificationExpensiveBool) (toExpr true)
+  let certGoal ← mkFreshExprMVar certType
+  match ← LeanCert.Tactic.closeCertificateGoalTyped
+      { mode := .auto, kernelHeartbeats := 1 } certGoal.mvarId!
+      "successful auto fallback test" with
+  | .accepted event =>
+      unless event.used == .native && event.cause == .autoNativeFallback do
+        throwError "expected native auto fallback, got {repr event}"
+  | result => throwError "expected successful auto fallback, got {repr result}"
+  evalTactic (← `(tactic| trivial))
+
+example : True := by expect_successful_auto_fallback_notice
 
 /-! ### Default mode: native (behavior preserved) -/
 

--- a/docs/architecture/golden-theorems.md
+++ b/docs/architecture/golden-theorems.md
@@ -483,6 +483,12 @@ automatic-route gates, and audit commands.
 3. **Apply the Golden Theorem**: lift the boolean result to a semantic theorem
 4. **Complete the proof script**: keep the theorem statement and proof term in Lean
 
+The shared verification choke point returns three structured outcomes:
+accepted with route telemetry, rejected because the Boolean checker evaluated
+to `false`, or failed because verification infrastructure could not produce a
+result. Only accepted verification retains generated declarations; rejection
+and failure restore the complete speculative state.
+
 Optional external orchestration now lives in separate repos:
 
 - `https://github.com/alerad/leancert-python`

--- a/docs/direct/leancert.md
+++ b/docs/direct/leancert.md
@@ -110,6 +110,12 @@ LeanCert keeps three ideas separate:
 3. **Certificate verification** is how a successful executable check is
    discharged: `kernel`, `native`, or the `auto` policy.
 
+Certificate rejection and verification failure are different outcomes. A
+checker that conclusively evaluates to `false` is an expected, resumable
+solver result. Failure to reduce, compile, or evaluate the checker is an
+infrastructure error and stops routing. In `auto` mode, a conclusive `false`
+kernel result never falls back to native verification.
+
 In particular, subdivision and optimization are strategies, not numerical
 backends. Selecting `(trust := kernel)` does not select Rational, Dyadic, or
 Affine arithmetic.

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -60,6 +60,13 @@ Per-invocation `(trust := …)` overrides `set_option leancert.trust`, which
 overrides the native default. The syntax index above identifies tactics with
 an inline override. `discover` and `finsum_witness` use the scoped option.
 
+The verification boundary distinguishes a checker that evaluates to `false`
+from an inability to run the checker. The former is ordinary certificate
+rejection and may allow another solver strategy to run; kernel reduction,
+native compilation, evaluation, or protocol failures are terminal. Automatic
+mode falls back from an unfinished kernel attempt, never from a conclusive
+`false` result.
+
 Guidance from the calibration data (`scripts/bench-trust/README.md`): kernel
 verification is essentially free for point inequalities and quantified
 bounds, cheap for moderate partition/subdivision counts, and crosses over


### PR DESCRIPTION
## Summary

This PR adds a typed certificate-verification boundary that distinguishes:

- successful certificate verification;
- a checker conclusively evaluating to `false`;
- malformed certificates or verification infrastructure failures.

Reporting-aware solvers can now treat ordinary certificate rejection as resumable while surfacing compiler, kernel-reduction, trust-configuration, and protocol failures as terminal internal errors.

## Changes

- Introduces `VerificationResult`:
  - `.accepted`
  - `.rejected`
  - `.failed`
- Introduces structured `VerificationFailure` diagnostics.
- Supports arbitrary decidable certificate propositions, not only `check … = true`.
- Preserves existing native, kernel, and auto trust semantics.
- Evaluates each checker only once; reporting does not replay certificate computation.
- Restores the complete tactic state on rejection or infrastructure failure.
- Retains proof assignments and generated environment declarations only after successful verification.
- Migrates reporting-aware point, bound, optimization, multivariate, and discovery paths.
- Maps:
  - conclusive rejection to resumable portfolio rejection;
  - infrastructure failure to terminal internal error.
- Keeps the existing throwing verification functions as compatibility wrappers.

## Trust behavior

- `native` uses Lean’s structured native evaluator, distinguishing `false` from compilation or evaluation failure.
- `kernel` distinguishes `isFalse` from `isTrue`, while successful proofs retain auxiliary-lemma caching and kernel validation.
- `auto` never falls back to native after a conclusive kernel rejection. Native fallback is reserved for kernel resource or infrastructure failure.

## Tests

Added coverage for:

- native, kernel, and auto rejection;
- malformed certificate goals;
- native and kernel infrastructure failures;
- goal, metavariable, and environment rollback;
- rejected optimization and multivariate certificates;
- reporting-aware router classification.
