### PR TITLE
Type attained-extremum certification

### DIFF
--- a/LeanCert/Tactic/Discovery.lean
+++ b/LeanCert/Tactic/Discovery.lean
@@ -762,6 +762,7 @@ inductive AttainedWitnessOrigin where
 structure AttainedCertificate where
   role : String
   checker : Name
+  verifier : Option Name := none
   verification : LeanCert.Tactic.VerificationUsage
   enclosure : Option IntervalRat := none
   deriving Repr, Inhabited
@@ -781,7 +782,7 @@ structure AttainedExtremumOutcome where
   termination : DiscoveryTermination
   taylorDepth : Nat
   certificates : Array AttainedCertificate
-  verifier : Name
+  verifier : Option Name
   deriving Repr, Inhabited
 
 /-- Expected non-successes at the attained-extremum boundary. -/
@@ -950,6 +951,7 @@ private unsafe def intervalArgmaxCoreReported
             pure <| .ok #[{
               role := "global attained-maximum bound"
               checker
+              verifier := outcome.verifier
               verification := outcome.verification
             }]
         | .error failure =>
@@ -1019,6 +1021,7 @@ private unsafe def intervalArgmaxCoreReported
         pure <| .ok #[{
           role := "fallback universal bound"
           checker
+          verifier := outcome.verifier
           verification := outcome.verification
         }]
       | .error e2 =>
@@ -1047,7 +1050,9 @@ private unsafe def intervalArgmaxCoreReported
     termination := discoveryTermination result cfg.maxIterations cfg.tolerance
     taylorDepth
     certificates
-    verifier := ``LeanCert.Validity.verify_argmax
+    verifier :=
+      if certificates.size == 2 then some ``LeanCert.Validity.verify_argmax
+      else certificates[0]?.bind (·.verifier)
   }
 
 /-- Reporting-aware attained-maximum core. -/
@@ -1055,7 +1060,11 @@ unsafe def intervalArgmaxCoreTyped (taylorDepth : Nat) :
     TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   let original ← saveState
   try
-    return ← intervalArgmaxCoreReported taylorDepth
+    match ← intervalArgmaxCoreReported taylorDepth with
+    | .ok outcome => return .ok outcome
+    | .error failure =>
+        original.restore
+        return .error failure
   catch e =>
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
@@ -1221,6 +1230,7 @@ private unsafe def intervalArgminCoreReported
             pure <| .ok #[{
               role := "global attained-minimum bound"
               checker
+              verifier := outcome.verifier
               verification := outcome.verification
             }]
         | .error failure =>
@@ -1290,6 +1300,7 @@ private unsafe def intervalArgminCoreReported
         pure <| .ok #[{
           role := "fallback universal bound"
           checker
+          verifier := outcome.verifier
           verification := outcome.verification
         }]
       | .error e2 =>
@@ -1318,7 +1329,9 @@ private unsafe def intervalArgminCoreReported
     termination := discoveryTermination result cfg.maxIterations cfg.tolerance
     taylorDepth
     certificates
-    verifier := ``LeanCert.Validity.verify_argmin
+    verifier :=
+      if certificates.size == 2 then some ``LeanCert.Validity.verify_argmin
+      else certificates[0]?.bind (·.verifier)
   }
 
 /-- Reporting-aware attained-minimum core. -/
@@ -1326,7 +1339,11 @@ unsafe def intervalArgminCoreTyped (taylorDepth : Nat) :
     TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   let original ← saveState
   try
-    return ← intervalArgminCoreReported taylorDepth
+    match ← intervalArgminCoreReported taylorDepth with
+    | .ok outcome => return .ok outcome
+    | .error failure =>
+        original.restore
+        return .error failure
   catch e =>
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)

--- a/LeanCert/Tactic/Discovery.lean
+++ b/LeanCert/Tactic/Discovery.lean
@@ -743,8 +743,76 @@ def isExprEvalFunc (func : Lean.Expr) : MetaM Bool := do
     let fn := body.getAppFn
     return fn.isConstOf ``LeanCert.Core.Expr.eval
 
+/-! ## Attained-extremum reporting -/
+
+/-- Whether an attained-extremum proof certifies a minimum or maximum. -/
+inductive AttainedExtremumKind where
+  | minimum
+  | maximum
+  deriving DecidableEq, Repr, Inhabited
+
+/-- How the rational witness retained by an attained-extremum proof arose. -/
+inductive AttainedWitnessOrigin where
+  | discovered
+  | endpoint
+  deriving DecidableEq, Repr, Inhabited
+
+/-- One of the two Boolean certificates retained by `verify_argmin` or
+`verify_argmax`. -/
+structure AttainedCertificate where
+  role : String
+  checker : Name
+  verification : LeanCert.Tactic.VerificationUsage
+  enclosure : Option IntervalRat := none
+  deriving Repr, Inhabited
+
+/-- Runtime evidence from one successful attained-extremum construction. -/
+structure AttainedExtremumOutcome where
+  kind : AttainedExtremumKind
+  witness : ℚ
+  witnessOrigin : AttainedWitnessOrigin
+  pointEnclosure : IntervalRat
+  globalEnclosure : IntervalRat
+  bridgeBound : ℚ
+  iterations : Nat
+  configuredLimit : Nat
+  remainingBoxes : Nat
+  tolerance : ℚ
+  termination : DiscoveryTermination
+  taylorDepth : Nat
+  certificates : Array AttainedCertificate
+  verifier : Name
+  deriving Repr, Inhabited
+
+/-- Expected non-successes at the attained-extremum boundary. -/
+inductive AttainedExtremumFailure where
+  | unsupported (expression detail : String)
+  | domainObstruction (domain : Lean.Expr) (operation detail : String)
+  | rejectedCandidate (witness : ℚ) (checker : Name) (detail : String)
+  | inconclusive (detail : String)
+  | transportFailure (detail : String)
+  | internalFailure (detail : String)
+  deriving Repr, Inhabited
+
+private def throwAttainedExtremumFailure (tacticName : String) :
+    AttainedExtremumFailure → TacticM α
+  | .unsupported expression detail =>
+      throwError "{tacticName}: unsupported expression {expression}:\n{detail}"
+  | .domainObstruction _ operation detail =>
+      throwError "{tacticName}: domain obstruction while checking {operation}:\n{detail}"
+  | .rejectedCandidate witness checker detail =>
+      throwError "{tacticName}: candidate {witness} was rejected by {checker}:\n{detail}"
+  | .inconclusive detail =>
+      throwError "{tacticName}: {detail}"
+  | .transportFailure detail =>
+      throwError "{tacticName}: proof transport failed:\n{detail}"
+  | .internalFailure detail =>
+      throwError "{tacticName}: internal certificate failure:\n{detail}"
+
 /-- The interval_argmax tactic implementation -/
-unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
+private unsafe def intervalArgmaxCoreReported
+    (taylorDepth : Nat) :
+    TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   LeanCert.Tactic.Auto.intervalNormCore
   let goal ← getMainGoal
   let goalType ← goal.getType
@@ -811,21 +879,8 @@ unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
   trace[LeanCert.discovery] "f(xOpt) ∈ [{fAtXOpt.lo}, {fAtXOpt.hi}]"
   trace[LeanCert.discovery] "Using bound c = {cBound} for transitivity"
 
-  -- 6. Check that ∀ y ∈ I, f(y) ≤ c (upper bound check)
-  let upperOk := LeanCert.Validity.checkUpperBound astVal domainVal cBound evalCfg
-  trace[LeanCert.discovery] "checkUpperBound: {upperOk}"
-
-  -- 7. Check that c ≤ f(xOpt) (point lower bound check)
-  let pointOk := LeanCert.Validity.checkPointLowerBound astVal xOpt cBound evalCfg
-  trace[LeanCert.discovery] "checkPointLowerBound: {pointOk}"
-
-  if !upperOk || !pointOk then
-    throwError "interval_argmax: Bound verification failed.\n\
-      • checkUpperBound (∀ y ∈ I, f(y) ≤ {cBound}): {upperOk}\n\
-      • checkPointLowerBound ({cBound} ≤ f({xOpt})): {pointOk}\n\
-      Try increasing Taylor depth or using a different witness."
-
-  -- 8. Generate support proof
+  -- 6. Generate support proof. The Boolean checks are closed below exactly
+  -- once through the typed verification boundary.
   let suppProof ← LeanCert.Meta.mkSupportedCoreProof ast
 
   -- 9. Provide witness: refine ⟨xOpt, ?memProof, ?boundProof⟩
@@ -865,13 +920,13 @@ unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
     try
       evalTactic (← `(tactic| decide))
     catch _ =>
-      logWarning m!"Could not automatically prove {xOpt} ∈ [{domainVal.lo}, {domainVal.hi}]. Goal left open."
-      return
+      throwError "could not prove witness membership"
 
   -- 11. Prove the bound: ∀ y ∈ I, f(y) ≤ f(xOpt)
   trace[LeanCert.discovery] "Proving universal bound..."
 
-  if isNativeSyntax then
+  let certificatesResult : Except AttainedExtremumFailure
+      (Array AttainedCertificate) ← if isNativeSyntax then
     -- For native syntax, simplify and use intervalBoundCore directly
     trace[LeanCert.discovery] "Using native syntax path with intervalBoundCore"
     try
@@ -886,9 +941,24 @@ unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
 
       -- norm_num may already close trivial bounds outright (constant or
       -- identity objectives); only invoke the interval engine on a live goal.
-      if !(← getGoals).isEmpty then
-        LeanCert.Tactic.Auto.intervalBoundCore taylorDepth
+      let retained ← if !(← getGoals).isEmpty then
+        match ← LeanCert.Tactic.Auto.intervalBoundCoreTyped taylorDepth with
+        | .ok outcome =>
+            let checker := outcome.checker.getD Name.anonymous
+            if checker == Name.anonymous then
+              throwError "native attained-extremum proof returned no checker identity"
+            pure <| .ok #[{
+              role := "global attained-maximum bound"
+              checker
+              verification := outcome.verification
+            }]
+        | .error failure =>
+            pure <| .error <| .inconclusive
+              s!"native attained-extremum bound failed: {repr failure}"
+      else
+        pure (.ok #[])
       trace[LeanCert.discovery] "✓ Proof complete (native syntax)"
+      pure retained
     catch e =>
       throwError "interval_argmax: Could not prove universal bound.\n\
         Error: {e.toMessageData}\n\
@@ -896,6 +966,7 @@ unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
   else
     -- For Expr.eval syntax, use verify_argmax
     trace[LeanCert.discovery] "Using verify_argmax path"
+    let reflective ← saveState
     try
       -- Build the proof term using verify_argmax
       let astSyntax ← Term.exprToSyntax ast
@@ -908,25 +979,92 @@ unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
 
       -- Membership proof for xOpt
       evalTactic (← `(tactic|
-        apply LeanCert.Validity.verify_argmax $astSyntax $suppSyntax $domainSyntax $xOptSyntax $cBoundSyntax $cfgSyntax
-          ?_ (by leancert_verify_cert) (by leancert_verify_cert)))
+        apply LeanCert.Validity.verify_argmax $astSyntax $suppSyntax $domainSyntax
+          $xOptSyntax $cBoundSyntax $cfgSyntax))
+      evalTactic (← `(tactic| constructor <;> norm_cast))
 
-      -- Prove xOpt ∈ I
-      if !(← getGoals).isEmpty then
-        evalTactic (← `(tactic| constructor <;> norm_cast))
-
-      trace[LeanCert.discovery] "✓ Proof complete"
+      let close (role : String) (checker : Name) :
+          TacticM (Except AttainedExtremumFailure AttainedCertificate) := do
+        let certGoal ← getMainGoal
+        match ← LeanCert.Tactic.closeCertificateGoalTyped
+            (← LeanCert.Tactic.VerificationConfig.current) certGoal
+            (tacticName := "interval_argmax") with
+        | .accepted event =>
+            return .ok { role, checker, verification := event.toUsage }
+        | .rejected =>
+            return .error <| .rejectedCandidate xOpt checker
+              "the Boolean certificate evaluated to false"
+        | .failed failure =>
+            return .error <| .internalFailure
+              (failure.message "interval_argmax")
+      match ← close "global upper bound" ``LeanCert.Validity.checkUpperBound with
+      | .error failure => pure (.error failure)
+      | .ok upper =>
+        match ← close "candidate point lower bound"
+            ``LeanCert.Validity.checkPointLowerBound with
+        | .error failure => pure (.error failure)
+        | .ok point =>
+          trace[LeanCert.discovery] "✓ Proof complete"
+          pure (.ok #[upper, point])
     catch e =>
       -- Fallback to intervalBoundCore
+      reflective.restore
       trace[LeanCert.discovery] "verify_argmax failed, trying intervalBoundCore fallback..."
-      try
-        LeanCert.Tactic.Auto.intervalBoundCore taylorDepth
+      match ← LeanCert.Tactic.Auto.intervalBoundCoreTyped taylorDepth with
+      | .ok outcome =>
+        let checker := outcome.checker.getD Name.anonymous
+        if checker == Name.anonymous then
+          throwError "fallback attained-extremum proof returned no checker identity"
         trace[LeanCert.discovery] "✓ Proof complete (via fallback)"
-      catch e2 =>
-        throwError "interval_argmax: Could not prove universal bound.\n\
-          Primary method (verify_argmax): {e.toMessageData}\n\
-          Fallback method (intervalBoundCore): {e2.toMessageData}\n\
-          The witness x = {xOpt} may need higher precision."
+        pure <| .ok #[{
+          role := "fallback universal bound"
+          checker
+          verification := outcome.verification
+        }]
+      | .error e2 =>
+        pure <| .error <| .transportFailure
+          s!"primary verify_argmax failed: {← e.toMessageData.toString}\n\
+            fallback interval bound failed: {repr e2}"
+  let certificates ←
+    match certificatesResult with
+    | .ok certificates => pure certificates
+    | .error failure => return .error failure
+  let globalEnclosure : IntervalRat :=
+    if h : result.bound.lo ≤ result.bound.hi then
+      ⟨result.bound.lo, result.bound.hi, h⟩
+    else fAtXOpt
+  return .ok {
+    kind := .maximum
+    witness := xOpt
+    witnessOrigin := .discovered
+    pointEnclosure := fAtXOpt
+    globalEnclosure
+    bridgeBound := cBound
+    iterations := result.bound.iterations
+    configuredLimit := cfg.maxIterations
+    remainingBoxes := result.remainingBoxes.length
+    tolerance := cfg.tolerance
+    termination := discoveryTermination result cfg.maxIterations cfg.tolerance
+    taylorDepth
+    certificates
+    verifier := ``LeanCert.Validity.verify_argmax
+  }
+
+/-- Reporting-aware attained-maximum core. -/
+unsafe def intervalArgmaxCoreTyped (taylorDepth : Nat) :
+    TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
+  let original ← saveState
+  try
+    return ← intervalArgmaxCoreReported taylorDepth
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
+
+/-- Compatibility wrapper preserving the historical throwing API. -/
+unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
+  match ← intervalArgmaxCoreTyped taylorDepth with
+  | .ok _ => pure ()
+  | .error failure => throwAttainedExtremumFailure "interval_argmax" failure
 
 /-- The interval_argmax tactic.
 
@@ -948,7 +1086,9 @@ unsafe def elabIntervalArgmax : Tactic := fun stx => do
     intervalArgmaxCore depth
 
 /-- The interval_argmin tactic implementation -/
-unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
+private unsafe def intervalArgminCoreReported
+    (taylorDepth : Nat) :
+    TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   LeanCert.Tactic.Auto.intervalNormCore
   let goal ← getMainGoal
   let goalType ← goal.getType
@@ -1015,21 +1155,7 @@ unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
   trace[LeanCert.discovery] "f(xOpt) ∈ [{fAtXOpt.lo}, {fAtXOpt.hi}]"
   trace[LeanCert.discovery] "Using bound c = {cBound} for transitivity"
 
-  -- 6. Check that ∀ y ∈ I, c ≤ f(y) (lower bound check)
-  let lowerOk := LeanCert.Validity.checkLowerBound astVal domainVal cBound evalCfg
-  trace[LeanCert.discovery] "checkLowerBound: {lowerOk}"
-
-  -- 7. Check that f(xOpt) ≤ c (point upper bound check)
-  let pointOk := LeanCert.Validity.checkPointUpperBound astVal xOpt cBound evalCfg
-  trace[LeanCert.discovery] "checkPointUpperBound: {pointOk}"
-
-  if !lowerOk || !pointOk then
-    throwError "interval_argmin: Bound verification failed.\n\
-      • checkLowerBound (∀ y ∈ I, {cBound} ≤ f(y)): {lowerOk}\n\
-      • checkPointUpperBound (f({xOpt}) ≤ {cBound}): {pointOk}\n\
-      Try increasing Taylor depth or using a different witness."
-
-  -- 8. Generate support proof
+  -- 6. Generate support proof. Certificate checks are performed once below.
   let suppProof ← LeanCert.Meta.mkSupportedCoreProof ast
 
   -- 9. Provide witness: refine ⟨xOpt, ?memProof, ?boundProof⟩
@@ -1069,13 +1195,13 @@ unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
     try
       evalTactic (← `(tactic| decide))
     catch _ =>
-      logWarning m!"Could not automatically prove {xOpt} ∈ [{domainVal.lo}, {domainVal.hi}]. Goal left open."
-      return
+      throwError "could not prove witness membership"
 
   -- 11. Prove the bound: ∀ y ∈ I, f(xOpt) ≤ f(y)
   trace[LeanCert.discovery] "Proving universal bound..."
 
-  if isNativeSyntax then
+  let certificatesResult : Except AttainedExtremumFailure
+      (Array AttainedCertificate) ← if isNativeSyntax then
     -- For native syntax, simplify and use intervalBoundCore directly
     trace[LeanCert.discovery] "Using native syntax path with intervalBoundCore"
     try
@@ -1086,9 +1212,24 @@ unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
 
       -- norm_num may already close trivial bounds outright (constant or
       -- identity objectives); only invoke the interval engine on a live goal.
-      if !(← getGoals).isEmpty then
-        LeanCert.Tactic.Auto.intervalBoundCore taylorDepth
+      let retained ← if !(← getGoals).isEmpty then
+        match ← LeanCert.Tactic.Auto.intervalBoundCoreTyped taylorDepth with
+        | .ok outcome =>
+            let checker := outcome.checker.getD Name.anonymous
+            if checker == Name.anonymous then
+              throwError "native attained-extremum proof returned no checker identity"
+            pure <| .ok #[{
+              role := "global attained-minimum bound"
+              checker
+              verification := outcome.verification
+            }]
+        | .error failure =>
+            pure <| .error <| .inconclusive
+              s!"native attained-extremum bound failed: {repr failure}"
+      else
+        pure (.ok #[])
       trace[LeanCert.discovery] "✓ Proof complete (native syntax)"
+      pure retained
     catch e =>
       throwError "interval_argmin: Could not prove universal bound.\n\
         Error: {e.toMessageData}\n\
@@ -1096,6 +1237,7 @@ unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
   else
     -- For Expr.eval syntax, use verify_argmin
     trace[LeanCert.discovery] "Using verify_argmin path"
+    let reflective ← saveState
     try
       -- Build the proof term using verify_argmin
       let astSyntax ← Term.exprToSyntax ast
@@ -1108,25 +1250,92 @@ unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
 
       -- Membership proof for xOpt
       evalTactic (← `(tactic|
-        apply LeanCert.Validity.verify_argmin $astSyntax $suppSyntax $domainSyntax $xOptSyntax $cBoundSyntax $cfgSyntax
-          ?_ (by leancert_verify_cert) (by leancert_verify_cert)))
+        apply LeanCert.Validity.verify_argmin $astSyntax $suppSyntax $domainSyntax
+          $xOptSyntax $cBoundSyntax $cfgSyntax))
+      evalTactic (← `(tactic| constructor <;> norm_cast))
 
-      -- Prove xOpt ∈ I
-      if !(← getGoals).isEmpty then
-        evalTactic (← `(tactic| constructor <;> norm_cast))
-
-      trace[LeanCert.discovery] "✓ Proof complete"
+      let close (role : String) (checker : Name) :
+          TacticM (Except AttainedExtremumFailure AttainedCertificate) := do
+        let certGoal ← getMainGoal
+        match ← LeanCert.Tactic.closeCertificateGoalTyped
+            (← LeanCert.Tactic.VerificationConfig.current) certGoal
+            (tacticName := "interval_argmin") with
+        | .accepted event =>
+            return .ok { role, checker, verification := event.toUsage }
+        | .rejected =>
+            return .error <| .rejectedCandidate xOpt checker
+              "the Boolean certificate evaluated to false"
+        | .failed failure =>
+            return .error <| .internalFailure
+              (failure.message "interval_argmin")
+      match ← close "global lower bound" ``LeanCert.Validity.checkLowerBound with
+      | .error failure => pure (.error failure)
+      | .ok lower =>
+        match ← close "candidate point upper bound"
+            ``LeanCert.Validity.checkPointUpperBound with
+        | .error failure => pure (.error failure)
+        | .ok point =>
+          trace[LeanCert.discovery] "✓ Proof complete"
+          pure (.ok #[lower, point])
     catch e =>
       -- Fallback to intervalBoundCore
+      reflective.restore
       trace[LeanCert.discovery] "verify_argmin failed, trying intervalBoundCore fallback..."
-      try
-        LeanCert.Tactic.Auto.intervalBoundCore taylorDepth
+      match ← LeanCert.Tactic.Auto.intervalBoundCoreTyped taylorDepth with
+      | .ok outcome =>
+        let checker := outcome.checker.getD Name.anonymous
+        if checker == Name.anonymous then
+          throwError "fallback attained-extremum proof returned no checker identity"
         trace[LeanCert.discovery] "✓ Proof complete (via fallback)"
-      catch e2 =>
-        throwError "interval_argmin: Could not prove universal bound.\n\
-          Primary method (verify_argmin): {e.toMessageData}\n\
-          Fallback method (intervalBoundCore): {e2.toMessageData}\n\
-          The witness x = {xOpt} may need higher precision."
+        pure <| .ok #[{
+          role := "fallback universal bound"
+          checker
+          verification := outcome.verification
+        }]
+      | .error e2 =>
+        pure <| .error <| .transportFailure
+          s!"primary verify_argmin failed: {← e.toMessageData.toString}\n\
+            fallback interval bound failed: {repr e2}"
+  let certificates ←
+    match certificatesResult with
+    | .ok certificates => pure certificates
+    | .error failure => return .error failure
+  let globalEnclosure : IntervalRat :=
+    if h : result.bound.lo ≤ result.bound.hi then
+      ⟨result.bound.lo, result.bound.hi, h⟩
+    else fAtXOpt
+  return .ok {
+    kind := .minimum
+    witness := xOpt
+    witnessOrigin := .discovered
+    pointEnclosure := fAtXOpt
+    globalEnclosure
+    bridgeBound := cBound
+    iterations := result.bound.iterations
+    configuredLimit := cfg.maxIterations
+    remainingBoxes := result.remainingBoxes.length
+    tolerance := cfg.tolerance
+    termination := discoveryTermination result cfg.maxIterations cfg.tolerance
+    taylorDepth
+    certificates
+    verifier := ``LeanCert.Validity.verify_argmin
+  }
+
+/-- Reporting-aware attained-minimum core. -/
+unsafe def intervalArgminCoreTyped (taylorDepth : Nat) :
+    TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
+  let original ← saveState
+  try
+    return ← intervalArgminCoreReported taylorDepth
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
+
+/-- Compatibility wrapper preserving the historical throwing API. -/
+unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
+  match ← intervalArgminCoreTyped taylorDepth with
+  | .ok _ => pure ()
+  | .error failure => throwAttainedExtremumFailure "interval_argmin" failure
 
 /-- The interval_argmin tactic.
 

--- a/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
+++ b/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
@@ -257,6 +257,28 @@ private def renderOptimization (statistics : Option OptimizationStatistics) : St
       s!"\n\nOptimization:\n  Configured iteration limit: {statistics.configuredLimit}\n  \
         Tolerance: {statistics.tolerance}{actual}{gap}{converged}{remaining}{termination}"
 
+private def renderCertificates
+    (certificates : Array CertificateObservation) : String :=
+  if certificates.isEmpty then ""
+  else
+    let rows := certificates.toList.map fun certificate =>
+      let verifier := certificate.verifier.map
+        (fun value => s!"\n    Verifier: {value}") |>.getD ""
+      let enclosure := certificate.enclosure.map
+        (fun value => s!"\n    Enclosure: [{value.lo}, {value.hi}]") |>.getD ""
+      let usage := certificate.verificationUsage
+      let verification :=
+        if usage.kernelChecks > 0 && usage.nativeChecks > 0 then
+          s!"mixed ({usage.kernelChecks} kernel, {usage.nativeChecks} native)"
+        else if usage.kernelChecks > 0 then
+          s!"kernel ({usage.kernelChecks})"
+        else if usage.nativeChecks > 0 then
+          s!"native ({usage.nativeChecks})"
+        else "not observed"
+      s!"  {certificate.role}:\n    Checker: {certificate.checker}{verifier}\n    \
+        Verification: {verification}{enclosure}"
+    s!"\n\nRetained certificates:\n{String.intercalate "\n" rows}"
+
 def successReport (report : SolverReport) : String :=
   let plan := report.plan
   let detail := plan.strategyDetail.map (fun value => s!"\n  {value}") |>.getD ""
@@ -279,12 +301,13 @@ def successReport (report : SolverReport) : String :=
     (report.execution.verifier <|> plan.verifier).map
       (fun value => s!"\nVerifier: {value}") |>.getD ""
   let optimization := renderOptimization report.execution.optimization
+  let certificates := renderCertificates report.execution.certificates
   let advanced :=
     plan.dedicatedProof.map (fun proof =>
       s!"\n\nAdvanced control:\n  {renderProof proof}") |>.getD ""
   s!"LeanCert recognized: {intentLabel plan.intent}\n\n\
     Selected strategy:\n  {plan.strategy}{detail}{executionNotes}{backend}{verification}\
-    {checker}{verifier}{optimization}\n\nSuggested proof:\n  {renderProof plan.primaryProof}\
+    {checker}{verifier}{optimization}{certificates}\n\nSuggested proof:\n  {renderProof plan.primaryProof}\
     {advanced}{renderChildren report.execution.children}"
 
 end LeanCert.Tactic.Diagnostic

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -303,13 +303,13 @@ private def attainedExecution
     certificates := certificates.push {
       role := certificate.role
       checker := certificate.checker
-      verifier := some outcome.verifier
+      verifier := certificate.verifier
       verificationUsage := observed
       enclosure := certificate.enclosure
     }
   return {
     verificationUsage := usage
-    verifier := some outcome.verifier
+    verifier := outcome.verifier
     optimization := some {
       iterations := some outcome.iterations
       configuredLimit := outcome.configuredLimit

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -273,6 +273,89 @@ private unsafe def maximizeMvAttemptTyped (depth : Nat) :
       return .error (discoveryFailure
         `LeanCert.Tactic.Discovery.interval_maximize_mv failure)
 
+private def attainedFailure (solver : Name) :
+    AttainedExtremumFailure → AttemptFailure
+  | .unsupported expression detail =>
+      .unsupported { expression, detail := some detail }
+  | .domainObstruction domain operation detail =>
+      .domainObstruction {
+        source := { original := domain, kind := .intervalRat }
+        reason := detail
+        operation := some operation
+      }
+  | .rejectedCandidate witness checker detail =>
+      .rejected {
+        candidate := some (toString witness)
+        checker := some checker
+        detail
+      }
+  | .inconclusive detail => .inconclusive { detail }
+  | .transportFailure detail => .internalError solver detail
+  | .internalFailure detail => .internalError solver detail
+
+private def attainedExecution
+    (outcome : AttainedExtremumOutcome) : SolverExecution := Id.run do
+  let mut usage : Solver.VerificationUsage := {}
+  let mut certificates : Array Solver.CertificateObservation := #[]
+  for certificate in outcome.certificates do
+    let observed := Solver.VerificationUsage.ofEvents certificate.verification
+    usage := usage.combine observed
+    certificates := certificates.push {
+      role := certificate.role
+      checker := certificate.checker
+      verifier := some outcome.verifier
+      verificationUsage := observed
+      enclosure := certificate.enclosure
+    }
+  return {
+    verificationUsage := usage
+    verifier := some outcome.verifier
+    optimization := some {
+      iterations := some outcome.iterations
+      configuredLimit := outcome.configuredLimit
+      tolerance := outcome.tolerance
+      gap := some (outcome.globalEnclosure.hi - outcome.globalEnclosure.lo)
+      converged :=
+        some (outcome.globalEnclosure.hi - outcome.globalEnclosure.lo ≤
+          outcome.tolerance)
+      remainingBoxes := some outcome.remainingBoxes
+      termination := some <|
+        match outcome.termination with
+        | .toleranceReached => .toleranceReached
+        | .iterationLimit => .iterationLimit
+        | .queueExhausted => .queueExhausted
+        | .stopped => .stopped
+    }
+    certificates
+    enclosure := some outcome.globalEnclosure
+    notes := #[
+      s!"attained witness: {outcome.witness}",
+      s!"witness origin: {
+        match outcome.witnessOrigin with
+        | .discovered => "guided search"
+        | .endpoint => "domain endpoint"}",
+      s!"point enclosure: [{outcome.pointEnclosure.lo}, {outcome.pointEnclosure.hi}]",
+      s!"bridge bound: {outcome.bridgeBound}",
+      s!"Taylor depth: {outcome.taylorDepth}"
+    ]
+  }
+
+private unsafe def argminAttemptTyped (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← intervalArgminCoreTyped depth with
+  | .ok outcome => return .ok (attainedExecution outcome)
+  | .error failure =>
+      return .error (attainedFailure
+        `LeanCert.Tactic.Discovery.interval_argmin failure)
+
+private unsafe def argmaxAttemptTyped (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← intervalArgmaxCoreTyped depth with
+  | .ok outcome => return .ok (attainedExecution outcome)
+  | .error failure =>
+      return .error (attainedFailure
+        `LeanCert.Tactic.Discovery.interval_argmax failure)
+
 private def finSumAttemptReported (precision : Int) (depth : Nat) :
     TacticM SolverExecution := do
   let outcome ← finSumBoundCoreReported precision depth
@@ -569,17 +652,25 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
   | .argmin => #[
       { report := report intent "attained minimum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
-          (some (suggestion "interval_argmin" #[toString d])), solve := intervalArgminCore d },
+          (some (suggestion "interval_argmin" #[toString d]))
+        solve := intervalArgminCore d
+        solveReportedResult := some (argminAttemptTyped d) },
       { report := report intent "attained minimum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
-          (some (suggestion "interval_argmin" #[toString d2])), solve := intervalArgminCore d2 }]
+          (some (suggestion "interval_argmin" #[toString d2]))
+        solve := intervalArgminCore d2
+        solveReportedResult := some (argminAttemptTyped d2) }]
   | .argmax => #[
       { report := report intent "attained maximum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
-          (some (suggestion "interval_argmax" #[toString d])), solve := intervalArgmaxCore d },
+          (some (suggestion "interval_argmax" #[toString d]))
+        solve := intervalArgmaxCore d
+        solveReportedResult := some (argmaxAttemptTyped d) },
       { report := report intent "attained maximum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
-          (some (suggestion "interval_argmax" #[toString d2])), solve := intervalArgmaxCore d2 }]
+          (some (suggestion "interval_argmax" #[toString d2]))
+        solve := intervalArgmaxCore d2
+        solveReportedResult := some (argmaxAttemptTyped d2) }]
   | .finiteSum => #[
       { report := report intent "reflective finite-sum certificate" cfg mode
           (.fixed .dyadicInterval) (some (suggestion "finsum_bound")),

--- a/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
+++ b/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
@@ -65,6 +65,17 @@ structure VerificationUsage where
   kernelFallbacks : Nat := 0
   deriving Inhabited, Repr
 
+/-- One checker proof retained by the final artifact.  Unlike the aggregate
+`VerificationUsage`, this preserves which Boolean checker was closed and what
+role it played in a composite Golden-Theorem application. -/
+structure CertificateObservation where
+  role : String
+  checker : Name
+  verifier : Option Name := none
+  verificationUsage : VerificationUsage := {}
+  enclosure : Option LeanCert.Core.IntervalRat := none
+  deriving Inhabited, Repr
+
 def VerificationUsage.combine (left right : VerificationUsage) :
     VerificationUsage := {
   kernelChecks := left.kernelChecks + right.kernelChecks
@@ -163,6 +174,10 @@ structure SolverExecution where
   verifier : Option Name := none
   enclosure : Option LeanCert.Core.IntervalRat := none
   optimization : Option OptimizationStatistics := none
+  /-- Constituent checker proofs retained by composite artifacts.  The
+  singular `checker`/`verifier` fields remain the compatibility presentation
+  for one-certificate solvers. -/
+  certificates : Array CertificateObservation := #[]
   notes : Array String := #[]
   children : Array ChildReport := #[]
   deriving Inhabited

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -161,6 +161,45 @@ unsafe def elabExpectLooseDiscoverySuccess : Tactic := fun _ => do
   | .error failure =>
       throwError "a loose search with a certifiable endpoint failed: {repr failure}"
 
+syntax (name := expectAttainedReport)
+  "expect_attained_report" ident : tactic
+
+@[tactic expectAttainedReport]
+unsafe def elabExpectAttainedReport : Tactic := fun stx => do
+  let direction := stx[1].getId
+  let outcome ←
+    if direction == `minimum then
+      match ← Discovery.intervalArgminCoreTyped 10 with
+      | .ok outcome => pure outcome
+      | .error failure => throwError "typed argmin failed: {repr failure}"
+    else
+      match ← Discovery.intervalArgmaxCoreTyped 10 with
+      | .ok outcome => pure outcome
+      | .error failure => throwError "typed argmax failed: {repr failure}"
+  let expectedVerifier :=
+    if direction == `minimum then ``LeanCert.Validity.verify_argmin
+    else ``LeanCert.Validity.verify_argmax
+  unless outcome.verifier == expectedVerifier do
+    throwError "attained-extremum report retained the wrong Golden Theorem"
+  unless outcome.certificates.size == 2 do
+    throwError "attained proof retained {outcome.certificates.size} \
+      certificates instead of two"
+  let first := outcome.certificates[0]!
+  let second := outcome.certificates[1]!
+  let expectedFirst :=
+    if direction == `minimum then ``LeanCert.Validity.checkLowerBound
+    else ``LeanCert.Validity.checkUpperBound
+  let expectedSecond :=
+    if direction == `minimum then ``LeanCert.Validity.checkPointUpperBound
+    else ``LeanCert.Validity.checkPointLowerBound
+  unless first.checker == expectedFirst && second.checker == expectedSecond do
+    throwError "attained proof retained the wrong constituent checkers"
+  let usage : LeanCert.Tactic.VerificationUsage :=
+    outcome.certificates.foldl
+      (fun total certificate => total.combine certificate.verification) {}
+  unless usage.kernelChecks + usage.nativeChecks == 2 do
+    throwError "attained proof did not retain exactly two successful checks"
+
 syntax (name := expectTypedOptimizationRollback)
   "expect_typed_optimization_rollback" : tactic
 
@@ -217,6 +256,16 @@ example : ∃ M : ℚ, ∀ x ∈ Set.Icc (0 : ℝ) 1,
 
 example : ∃ m : ℚ, ∀ x ∈ Set.Icc (0 : ℝ) 7, Real.sin x ≥ m := by
   expect_loose_discovery_success
+
+example : ∃ x ∈ checkerInterval, ∀ y ∈ checkerInterval,
+    LeanCert.Core.Expr.eval (fun _ => y) (.var 0) ≤
+      LeanCert.Core.Expr.eval (fun _ => x) (.var 0) := by
+  expect_attained_report maximum
+
+example : ∃ x ∈ checkerInterval, ∀ y ∈ checkerInterval,
+    LeanCert.Core.Expr.eval (fun _ => x) (.var 0) ≤
+      LeanCert.Core.Expr.eval (fun _ => y) (.var 0) := by
+  expect_attained_report minimum
 
 example : True := by
   expect_typed_optimization_rollback

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -23,6 +23,7 @@ set_option linter.unusedTactic false
 
 private def checkerExpr : LeanCert.Core.Expr := .var 0
 private def checkerInterval : LeanCert.Core.IntervalRat := ⟨0, 1, by norm_num⟩
+private def checkerInterval35 : LeanCert.Core.IntervalRat := ⟨3, 5, by norm_num⟩
 
 private def adapterTestPlan : SolverPlan := {
   intent := .pointInequality
@@ -179,7 +180,7 @@ unsafe def elabExpectAttainedReport : Tactic := fun stx => do
   let expectedVerifier :=
     if direction == `minimum then ``LeanCert.Validity.verify_argmin
     else ``LeanCert.Validity.verify_argmax
-  unless outcome.verifier == expectedVerifier do
+  unless outcome.verifier == some expectedVerifier do
     throwError "attained-extremum report retained the wrong Golden Theorem"
   unless outcome.certificates.size == 2 do
     throwError "attained proof retained {outcome.certificates.size} \
@@ -199,6 +200,60 @@ unsafe def elabExpectAttainedReport : Tactic := fun stx => do
       (fun total certificate => total.combine certificate.verification) {}
   unless usage.kernelChecks + usage.nativeChecks == 2 do
     throwError "attained proof did not retain exactly two successful checks"
+
+syntax (name := expectCompactExtremumRoute)
+  "expect_compact_extremum_route" : tactic
+
+@[tactic expectCompactExtremumRoute]
+unsafe def elabExpectCompactExtremumRoute : Tactic := fun _ => do
+  let result ← runLeanCert {} .compact
+  unless result.plan.strategy.contains "compact extreme-value theorem" do
+    throwError "front-door extremum routing changed unexpectedly: \
+      {result.plan.strategy}"
+  unless result.execution.certificates.isEmpty do
+    throwError "compact extreme-value route fabricated numerical certificates"
+
+syntax (name := expectAttainedRejectionRollback)
+  "expect_attained_rejection_rollback" ident : tactic
+
+@[tactic expectAttainedRejectionRollback]
+unsafe def elabExpectAttainedRejectionRollback : Tactic := fun stx => do
+  let callerGoals ← getGoals
+  let direction := stx[1].getId
+  let probeType ←
+    if direction == `minimum then
+      Term.elabTerm (← `(term| ∃ x ∈ checkerInterval35, ∀ y ∈ checkerInterval35,
+        LeanCert.Core.Expr.eval (fun _ => x) (.sin (.var 0)) ≤
+          LeanCert.Core.Expr.eval (fun _ => y) (.sin (.var 0))))
+        (some (mkSort .zero))
+    else
+      Term.elabTerm (← `(term| ∃ x ∈ checkerInterval, ∀ y ∈ checkerInterval,
+        LeanCert.Core.Expr.eval (fun _ => y) (.sin (.var 0)) ≤
+          LeanCert.Core.Expr.eval (fun _ => x) (.sin (.var 0))))
+        (some (mkSort .zero))
+  let probe ← mkFreshExprMVar probeType
+  setGoals [probe.mvarId!]
+  let beforeType ← probe.mvarId!.getType
+  let result ←
+    if direction == `minimum then
+      Discovery.intervalArgminCoreTyped 10
+    else
+      Discovery.intervalArgmaxCoreTyped 10
+  match result with
+  | .error (.rejectedCandidate ..) =>
+      let afterType ← (← getMainGoal).getType
+      unless ← isDefEq beforeType afterType do
+        throwError "rejected attained candidate changed the caller's goal"
+      unless (← getGoals).length == 1 do
+        throwError "rejected attained candidate changed the caller's goal list"
+      unless !(← probe.mvarId!.isAssigned) do
+        throwError "rejected attained candidate retained a partial proof assignment"
+      setGoals callerGoals
+      evalTactic (← `(tactic| trivial))
+  | .error failure =>
+      throwError "attained candidate had wrong failure classification: {repr failure}"
+  | .ok _ =>
+      throwError "irrational attained candidate unexpectedly certified"
 
 syntax (name := expectTypedOptimizationRollback)
   "expect_typed_optimization_rollback" : tactic
@@ -266,6 +321,15 @@ example : ∃ x ∈ checkerInterval, ∀ y ∈ checkerInterval,
     LeanCert.Core.Expr.eval (fun _ => x) (.var 0) ≤
       LeanCert.Core.Expr.eval (fun _ => y) (.var 0) := by
   expect_attained_report minimum
+
+example : ∃ x ∈ Set.Icc (0 : ℝ) 1, ∀ y ∈ Set.Icc (0 : ℝ) 1, y ≤ x := by
+  expect_compact_extremum_route
+
+example : True := by
+  expect_attained_rejection_rollback maximum
+
+example : True := by
+  expect_attained_rejection_rollback minimum
 
 example : True := by
   expect_typed_optimization_rollback

--- a/LeanCert/Test/ReleaseTest.lean
+++ b/LeanCert/Test/ReleaseTest.lean
@@ -307,7 +307,7 @@ theorem test_manual_interval_ge : ∀ x ∈ I01r, (0 : ℚ) ≤ Expr.eval (fun _
 |--------|--------|---------|
 | `discover` | ✓ Works | Auto-routes to minimize/maximize |
 | `interval_argmax` | ✓ Works | Finds maximizer point (native + AST syntax) |
-| `interval_argmin` | ⚠ Stub | Directs to use negated function |
+| `interval_argmin` | ✓ Works | Finds and certifies a minimizer point |
 | `interval_minimize_mv` | ✓ Works | Multivariate minimize |
 | `interval_maximize_mv` | ✓ Works | Multivariate maximize |
 | `multivariate_bound` | ✓ Works | Multivariate bounds |

--- a/docs/direct/optimization-discovery.md
+++ b/docs/direct/optimization-discovery.md
@@ -76,3 +76,9 @@ Theorem, the discovered witness, and the search termination facts.
 Failed speculative proof routes are transactional.  Their goals, messages,
 environment extensions, and verification events are discarded before a
 fallback is attempted.
+
+The `leancert` front door normally proves existence-only extrema with the
+compact extreme-value theorem, which requires no numerical certificate and
+does not choose a reportable rational witness. Use the dedicated
+`interval_argmin` or `interval_argmax` tactic when you specifically want
+guided rational-witness discovery and its detailed certificate report.

--- a/docs/direct/optimization-discovery.md
+++ b/docs/direct/optimization-discovery.md
@@ -64,3 +64,15 @@ tactic state and contribute no execution telemetry.
 Discovery mode is useful when you do not yet know the bound or extremum.  See
 the existing [Discovery Mode](../tactics/discovery.md) reference for command
 syntax and examples.
+# Attained extrema
+
+`interval_argmin` and `interval_argmax` retain the candidate search and the
+certificate evidence used to prove that the candidate is attained.  The
+reflective route closes two Boolean certificates exactly once: a global bound
+and a point-value bound.  Reports list both checker identities, their actual
+verification routes, the final `verify_argmin` or `verify_argmax` Golden
+Theorem, the discovered witness, and the search termination facts.
+
+Failed speculative proof routes are transactional.  Their goals, messages,
+environment extensions, and verification events are discarded before a
+fallback is attempted.

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -933,3 +933,11 @@ example : ∀ x ∈ Set.Icc (0 : ℝ) 1, x ≤ 1 := by
 
 If a bound is too tight, increase Taylor depth, use subdivision, or run
 `interval_refute` to determine whether the proposed bound is false.
+### `interval_argmin` and `interval_argmax`
+
+These tactics discover a rational candidate and certify that its value is
+attained on the requested interval.  For `Expr.eval` goals the proof retains a
+global-bound certificate and a point-value certificate, combined by
+`LeanCert.Validity.verify_argmin` or `LeanCert.Validity.verify_argmax`.
+Certificate rejection is distinct from verification infrastructure failure,
+and failed proof branches do not contribute verification telemetry.

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -941,3 +941,7 @@ global-bound certificate and a point-value certificate, combined by
 `LeanCert.Validity.verify_argmin` or `LeanCert.Validity.verify_argmax`.
 Certificate rejection is distinct from verification infrastructure failure,
 and failed proof branches do not contribute verification telemetry.
+
+For existence-only extrema, `leancert` prefers the non-numerical compact
+extreme-value theorem. Invoke these dedicated tactics when a discovered
+rational witness and constituent-certificate telemetry are desired.


### PR DESCRIPTION
## Summary

Migrates `interval_argmin` and `interval_argmax` to typed, transactional solver outcomes and integrates them with the semantic router.

Attained-extremum proofs can require multiple Boolean certificates. This PR therefore extends solver reporting with structured constituent certificate observations instead of forcing the proof into a single checker field.

## Changes

- Adds typed attained-extremum outcomes and failures.
- Adds reporting-aware:
  - `intervalArgminCoreTyped`
  - `intervalArgmaxCoreTyped`
- Preserves the existing dedicated tactic APIs as compatibility wrappers.
- Migrates `.argmin` and `.argmax` router entries to `solveReportedResult`.
- Retains:
  - discovered rational witness;
  - witness origin;
  - point-value enclosure;
  - global search enclosure;
  - bridge bound;
  - optimization iterations, limit, gap, and termination;
  - exact verification usage;
  - exact constituent checker identities;
  - final `verify_argmin` or `verify_argmax` Golden Theorem.
- Adds `CertificateObservation` for composite proof artifacts.
- Renders constituent certificates in successful reports.
- Updates attained-extremum documentation and removes the stale description of `interval_argmin` as a stub.

## Certificate behavior

For reflective `Expr.eval` goals, attained-extremum certification retains two checks:

### Argmin

- `checkLowerBound`
- `checkPointUpperBound`
- combined by `verify_argmin`

### Argmax

- `checkUpperBound`
- `checkPointLowerBound`
- combined by `verify_argmax`

Each checker is constructed and verified exactly once. The resulting proof term and verification event are reused for the final Golden-Theorem application; reporting does not rerun either checker.

Native-expression goals retain the certificate evidence returned by the successful typed direct-bound route.
