### PR TITLE
Type root solver outcomes

### DIFF
--- a/LeanCert/Tactic/Discovery.lean
+++ b/LeanCert/Tactic/Discovery.lean
@@ -23,7 +23,7 @@ using discovery algorithms:
 
 * `interval_minimize` - Prove `∃ m, ∀ x ∈ I, f(x) ≥ m` by finding the minimum
 * `interval_maximize` - Prove `∃ M, ∀ x ∈ I, f(x) ≤ M` by finding the maximum
-* `interval_roots` - Prove `∃ x ∈ I, f(x) = 0` by finding roots (Stub)
+* `interval_roots` - Prove `∃ x ∈ I, f(x) = 0` from a checked sign change
 
 ## Usage
 
@@ -32,7 +32,7 @@ using discovery algorithms:
 example : ∃ m : ℚ, ∀ x ∈ I01, x^2 + Real.sin x ≥ m := by
   interval_minimize
 
--- Find a root (Not fully implemented yet)
+-- Certify a root from a sign change
 example : ∃ x ∈ Icc (-2 : ℝ) 2, x^3 - x = 0 := by
   interval_roots
 ```
@@ -1845,25 +1845,50 @@ structure RootDiscoveryOutcome where
   taylorDepth : Nat
   deriving Inhabited
 
-/-- Reporting-aware interval-roots implementation. -/
-def intervalRootsCoreReported (taylorDepth : Nat) : TacticM RootDiscoveryOutcome := do
-  LeanCert.Tactic.Auto.intervalNormCore
+/-- Expected and invariant failures from root existence and uniqueness
+certification. -/
+inductive RootDiscoveryFailure where
+  | unsupported (expression detail : String)
+  | rejected (detail : String)
+  | transportFailure (detail : String)
+  | internalFailure (detail : String)
+  deriving Inhabited, Repr
+
+private def throwRootDiscoveryFailure (tacticName : String) :
+    RootDiscoveryFailure → TacticM α
+  | .unsupported expression detail =>
+      throwError "{tacticName}: unsupported expression {expression}:\n{detail}"
+  | .rejected detail =>
+      throwError "{tacticName}: certificate rejected:\n{detail}"
+  | .transportFailure detail =>
+      throwError "{tacticName}: proof transport failed:\n{detail}"
+  | .internalFailure detail =>
+      throwError "{tacticName}: internal certificate failure:\n{detail}"
+
+private def intervalRootsCoreTypedImpl
+    (original : Lean.Elab.Tactic.SavedState) (taylorDepth : Nat) :
+    TacticM (Except RootDiscoveryFailure RootDiscoveryOutcome) := do
+  try LeanCert.Tactic.Auto.intervalNormCore
+  catch e =>
+    original.restore
+    return .error <| .unsupported "goal normalization" (← e.toMessageData.toString)
   let initialGoal ← getMainGoal
   let goalType ← initialGoal.getType
 
   -- 1. Parse the goal
   let some (.existsRoot _varName interval func reverseZeroEquality) ← parseRootExistsGoal goalType
-    | let diagReport ← LeanCert.Tactic.Auto.mkDiagnosticReport "interval_roots" goalType "parse"
-        (some m!"Expected form: ∃ x ∈ I, lhs(x) = rhs(x)\n\n\
-                 The function f must be continuous on interval I.\n\
-                 Uses intermediate value theorem to find roots.")
-      throwError "interval_roots: Could not parse goal.\n\n{diagReport}"
+    | original.restore
+      return .error <| .unsupported (toString goalType)
+        "expected `∃ x ∈ I, lhs x = rhs x`"
 
-  if reverseZeroEquality then
+  if reverseZeroEquality then try
     evalTactic (← `(tactic| conv => arg 1; ext x; arg 2; rw [eq_comm]))
+  catch e =>
+    original.restore
+    return .error <| .transportFailure (← e.toMessageData.toString)
   let goal ← getMainGoal
 
-  goal.withContext do
+  try goal.withContext do
     let mut fromSetIcc := false
     let intervalExpr ←
       match ← tryConvertSetIcc interval with
@@ -1875,18 +1900,32 @@ def intervalRootsCoreReported (taylorDepth : Nat) : TacticM RootDiscoveryOutcome
           if intervalTy.isConstOf ``IntervalRat then
             pure interval
           else
-            throwError "interval_roots: Only IntervalRat or literal Set.Icc intervals are supported"
+            original.restore
+            return .error <| .unsupported (toString interval)
+              "only IntervalRat or literal Set.Icc intervals are supported"
 
     -- 2. Get AST (either from Expr.eval or by reifying)
-    let reified ← getAstFromFuncWithReport func
+    let reified ←
+      try pure (← getAstFromFuncWithReport func)
+      catch e =>
+        original.restore
+        return .error <| .unsupported (toString func) (← e.toMessageData.toString)
     let ast := reified.expr
     LeanCert.Tactic.unfoldReifiedDefinitions reified.unfolded
 
     -- 3. Generate ExprSupportedCore proof
-    let supportProof ← mkSupportedCoreProof ast
+    let supportProof ←
+      try pure (← mkSupportedCoreProof ast)
+      catch e =>
+        original.restore
+        return .error <| .unsupported (toString func) (← e.toMessageData.toString)
 
     -- 4. Generate ContinuousOn proof
-    let contProof ← mkContinuousOnProofWithDomain ast intervalExpr
+    let contProof ←
+      try pure (← mkContinuousOnProofWithDomain ast intervalExpr)
+      catch e =>
+        original.restore
+        return .error <| .unsupported (toString func) (← e.toMessageData.toString)
 
     -- 5. Build config expression
     let cfgExpr ← mkAppM ``EvalConfig.mk #[toExpr taylorDepth]
@@ -1899,30 +1938,63 @@ def intervalRootsCoreReported (taylorDepth : Nat) : TacticM RootDiscoveryOutcome
       #[ast, intervalExpr, cfgExpr]
     let certType ← mkAppM ``Eq #[checker, mkConst ``Bool.true]
     let certificate ← mkFreshExprMVar certType
-    let event ← LeanCert.Tactic.closeCertificateGoalReported
-      (← LeanCert.Tactic.VerificationConfig.current) certificate.mvarId!
-      (tacticName := "interval_roots")
+    let event ←
+      match ← LeanCert.Tactic.closeCertificateGoalTyped
+          (← LeanCert.Tactic.VerificationConfig.current) certificate.mvarId!
+          (tacticName := "interval_roots") with
+      | .accepted event => pure event
+      | .rejected =>
+          original.restore
+          return .error <| .rejected "the sign-change checker evaluated to false"
+      | .failed failure =>
+          original.restore
+          return .error <| .internalFailure (failure.message "interval_roots")
     let conclusion ← mkAppM' proof #[certificate]
 
     if fromSetIcc then
       let proofSyntax ← Term.exprToSyntax conclusion
-      evalTactic (← `(tactic| exact (by
-        have h := $proofSyntax
-        simpa [IntervalRat.mem_iff_mem_Icc, sub_eq_zero, sub_eq_add_neg,
-          add_eq_zero_iff_eq_neg, sq, pow_two] using h)))
+      try
+        evalTactic (← `(tactic| exact (by
+          have h := $proofSyntax
+          simpa [IntervalRat.mem_iff_mem_Icc, sub_eq_zero, sub_eq_add_neg,
+            add_eq_zero_iff_eq_neg, sq, pow_two] using h)))
+      catch e =>
+        original.restore
+        return .error <| .transportFailure (← e.toMessageData.toString)
     else
       goal.assign conclusion
       replaceMainGoal []
-    return {
+    return .ok {
       checker := ``LeanCert.Validity.RootFinding.checkSignChange
       verifier := ``LeanCert.Validity.RootFinding.verify_sign_change
       verification := event.toUsage
       taylorDepth := taylorDepth
     }
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
+
+/-- Typed interval-roots implementation. Every non-success restores the
+caller's complete tactic state. -/
+def intervalRootsCoreTyped (taylorDepth : Nat) :
+    TacticM (Except RootDiscoveryFailure RootDiscoveryOutcome) := do
+  let original ← saveState
+  try intervalRootsCoreTypedImpl original taylorDepth
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
+
+/-- Reporting compatibility entry point preserving the historical throwing API. -/
+def intervalRootsCoreReported (taylorDepth : Nat) : TacticM RootDiscoveryOutcome := do
+  match ← intervalRootsCoreTyped taylorDepth with
+  | .ok outcome => return outcome
+  | .error failure => throwRootDiscoveryFailure "interval_roots" failure
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
 def intervalRootsCore (taylorDepth : Nat) : TacticM Unit := do
-  discard <| intervalRootsCoreReported taylorDepth
+  match ← intervalRootsCoreTyped taylorDepth with
+  | .ok _ => pure ()
+  | .error failure => throwRootDiscoveryFailure "interval_roots" failure
 
 /-- The interval_roots tactic.
 
@@ -2031,20 +2103,30 @@ def parseUniqueRootGoal (goalType : Lean.Expr) :
     (configured via `leancert.trust`) to work without noncomputable Real
     functions.
 -/
-unsafe def intervalUniqueRootCoreReported (taylorDepth : Nat) :
-    TacticM RootDiscoveryOutcome := do
-  LeanCert.Tactic.Auto.intervalNormCore
+private unsafe def intervalUniqueRootCoreTypedImpl
+    (original : Lean.Elab.Tactic.SavedState) (taylorDepth : Nat) :
+    TacticM (Except RootDiscoveryFailure RootDiscoveryOutcome) := do
+  try LeanCert.Tactic.Auto.intervalNormCore
+  catch e =>
+    original.restore
+    return .error <| .unsupported "goal normalization" (← e.toMessageData.toString)
   let initialGoal ← getMainGoal
   let goalType ← initialGoal.getType
 
   -- Parse goal: ∃! x, x ∈ I ∧ f(x) = 0
   let some (_varName, interval, func, reverseZeroEquality) ← parseUniqueRootGoal goalType
-    | throwError "interval_unique_root: Goal must be of form `∃! x, x ∈ I ∧ lhs(x) = rhs(x)`"
+    | original.restore
+      return .error <| .unsupported (toString goalType)
+        "expected `∃! x, x ∈ I ∧ lhs x = rhs x`"
 
-  if reverseZeroEquality then
+  if reverseZeroEquality then try
     evalTactic (← `(tactic| conv => arg 1; ext x; arg 2; rw [eq_comm]))
+  catch e =>
+    original.restore
+    return .error <| .transportFailure (← e.toMessageData.toString)
   let goal ← getMainGoal
 
+  try
   let mut fromSetIcc := false
   let intervalExpr ←
     match ← tryConvertSetIcc interval with
@@ -2056,21 +2138,39 @@ unsafe def intervalUniqueRootCoreReported (taylorDepth : Nat) :
         if intervalTy.isConstOf ``IntervalRat then
           pure interval
         else
-          throwError "interval_unique_root: Only IntervalRat or literal Set.Icc intervals are supported"
+          original.restore
+          return .error <| .unsupported (toString interval)
+            "only IntervalRat or literal Set.Icc intervals are supported"
 
   -- Extract AST
-  let reified ← getAstFromFuncWithReport func
+  let reified ←
+    try pure (← getAstFromFuncWithReport func)
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString func) (← e.toMessageData.toString)
   let ast := reified.expr
   LeanCert.Tactic.unfoldReifiedDefinitions reified.unfolded
 
   -- Generate ADSupported proof (required by verify_unique_root_computable)
-  let supportProof ← mkSupportedProof ast
+  let supportProof ←
+    try pure (← mkSupportedProof ast)
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString func) (← e.toMessageData.toString)
 
   -- Generate UsesOnlyVar0 proof
-  let var0Proof ← mkUsesOnlyVar0Proof ast
+  let var0Proof ←
+    try pure (← mkUsesOnlyVar0Proof ast)
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString func) (← e.toMessageData.toString)
 
   -- Generate ContinuousOn proof
-  let contProof ← LeanCert.Meta.mkContinuousOnProofWithDomain ast intervalExpr
+  let contProof ←
+    try pure (← LeanCert.Meta.mkContinuousOnProofWithDomain ast intervalExpr)
+    catch e =>
+      original.restore
+      return .error <| .unsupported (toString func) (← e.toMessageData.toString)
 
   -- Build EvalConfig (for the computable core check)
   let evalCfgExpr ← mkAppM ``EvalConfig.mk #[toExpr taylorDepth]
@@ -2083,30 +2183,64 @@ unsafe def intervalUniqueRootCoreReported (taylorDepth : Nat) :
     #[ast, intervalExpr, evalCfgExpr]
   let certType ← mkAppM ``Eq #[checker, mkConst ``Bool.true]
   let certificate ← mkFreshExprMVar certType
-  let event ← LeanCert.Tactic.closeCertificateGoalReported
-    (← LeanCert.Tactic.VerificationConfig.current) certificate.mvarId!
-    (tacticName := "interval_unique_root")
+  let event ←
+    match ← LeanCert.Tactic.closeCertificateGoalTyped
+        (← LeanCert.Tactic.VerificationConfig.current) certificate.mvarId!
+        (tacticName := "interval_unique_root") with
+    | .accepted event => pure event
+    | .rejected =>
+        original.restore
+        return .error <| .rejected "the interval-Newton checker evaluated to false"
+    | .failed failure =>
+        original.restore
+        return .error <| .internalFailure (failure.message "interval_unique_root")
   let conclusion ← mkAppM' proof #[certificate]
 
   if fromSetIcc then
     let proofSyntax ← Term.exprToSyntax conclusion
-    evalTactic (← `(tactic| exact (by
-      have h := $proofSyntax
-      simpa [IntervalRat.mem_iff_mem_Icc, sub_eq_zero, sub_eq_add_neg,
-        add_eq_zero_iff_eq_neg, sq, pow_two] using h)))
+    try
+      evalTactic (← `(tactic| exact (by
+        have h := $proofSyntax
+        simpa [IntervalRat.mem_iff_mem_Icc, sub_eq_zero, sub_eq_add_neg,
+          add_eq_zero_iff_eq_neg, sq, pow_two] using h)))
+    catch e =>
+      original.restore
+      return .error <| .transportFailure (← e.toMessageData.toString)
   else
     goal.assign conclusion
     replaceMainGoal []
-  return {
+  return .ok {
     checker := ``Validity.RootFinding.checkNewtonContractsCore
     verifier := ``Validity.RootFinding.verify_unique_root_computable
     verification := event.toUsage
     taylorDepth := taylorDepth
   }
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
+
+/-- Typed interval-Newton implementation. Every non-success restores the
+caller's complete tactic state. -/
+unsafe def intervalUniqueRootCoreTyped (taylorDepth : Nat) :
+    TacticM (Except RootDiscoveryFailure RootDiscoveryOutcome) := do
+  let original ← saveState
+  try intervalUniqueRootCoreTypedImpl original taylorDepth
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
+
+/-- Reporting compatibility entry point preserving the historical throwing API. -/
+unsafe def intervalUniqueRootCoreReported (taylorDepth : Nat) :
+    TacticM RootDiscoveryOutcome := do
+  match ← intervalUniqueRootCoreTyped taylorDepth with
+  | .ok outcome => return outcome
+  | .error failure => throwRootDiscoveryFailure "interval_unique_root" failure
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
 unsafe def intervalUniqueRootCore (taylorDepth : Nat) : TacticM Unit := do
-  discard <| intervalUniqueRootCoreReported taylorDepth
+  match ← intervalUniqueRootCoreTyped taylorDepth with
+  | .ok _ => pure ()
+  | .error failure => throwRootDiscoveryFailure "interval_unique_root" failure
 
 /-- The interval_unique_root tactic.
 

--- a/LeanCert/Tactic/IntervalAuto/RootBound.lean
+++ b/LeanCert/Tactic/IntervalAuto/RootBound.lean
@@ -31,28 +31,48 @@ structure RootBoundOutcome where
   taylorDepth : Nat
   deriving Inhabited
 
-/-- Reporting-aware root-bound implementation. -/
-def rootBoundCoreReported (taylorDepth : Nat) : TacticM RootBoundOutcome := do
+/-- Expected and invariant failures from no-root certification. -/
+inductive RootBoundFailure where
+  | unsupported (expression detail : String)
+  | rejected (detail : String)
+  | transportFailure (detail : String)
+  | internalFailure (detail : String)
+  deriving Inhabited, Repr
+
+private def throwRootBoundFailure : RootBoundFailure → TacticM α
+  | .unsupported expression detail =>
+      throwError "root_bound: unsupported expression {expression}:\n{detail}"
+  | .rejected detail => throwError "root_bound: certificate rejected:\n{detail}"
+  | .transportFailure detail => throwError "root_bound: proof transport failed:\n{detail}"
+  | .internalFailure detail => throwError "root_bound: internal certificate failure:\n{detail}"
+
+private def rootBoundCoreTypedImpl
+    (original : Lean.Elab.Tactic.SavedState) (taylorDepth : Nat) :
+    TacticM (Except RootBoundFailure RootBoundOutcome) := do
   let goal ← getMainGoal
   let goalType ← goal.getType
 
   -- Parse the goal
   let some rootGoal ← parseRootGoal goalType
-    | let diagReport ← mkDiagnosticReport "root_bound" goalType "parse"
-        (some m!"Expected form: ∀ x ∈ I, f x ≠ 0\n\n\
-                 The function f must be continuous and supported by LeanCert.\n\
-                 The interval I must be Set.Icc or equivalent.")
-      throwError "root_bound: Could not parse goal as a root goal.\n\n{diagReport}"
+    | original.restore
+      return .error <| .unsupported (toString goalType)
+        "expected `∀ x ∈ I, f x ≠ 0`"
 
-  match rootGoal with
-  | .forallNeZero _name interval func =>
-    let event ← proveForallNeZero goal interval func taylorDepth
-    return {
-      checker := ``Validity.RootFinding.checkNoRoot
-      verifier := ``Validity.RootFinding.verify_no_root
-      verification := event.toUsage
-      taylorDepth := taylorDepth
-    }
+  try
+    match rootGoal with
+    | .forallNeZero _name interval func =>
+      match ← proveForallNeZero original goal interval func taylorDepth with
+      | .error failure => return .error failure
+      | .ok event =>
+        return .ok {
+          checker := ``Validity.RootFinding.checkNoRoot
+          verifier := ``Validity.RootFinding.verify_no_root
+          verification := event.toUsage
+          taylorDepth := taylorDepth
+        }
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
 
 where
   /-- Extract an AST and retain definitions unfolded during reification. -/
@@ -88,8 +108,9 @@ where
     return none
 
   /-- Prove ∀ x ∈ I, f x ≠ 0 using verify_no_root -/
-  proveForallNeZero (goal : MVarId) (interval func : Lean.Expr)
-      (taylorDepth : Nat) : TacticM LeanCert.Tactic.VerificationEvent := do
+  proveForallNeZero (original : Lean.Elab.Tactic.SavedState) (goal : MVarId)
+      (interval func : Lean.Expr) (taylorDepth : Nat) :
+      TacticM (Except RootBoundFailure LeanCert.Tactic.VerificationEvent) := do
     goal.withContext do
       -- 0. Try to convert Set.Icc to IntervalRat if needed
       let mut fromSetIcc := false
@@ -103,10 +124,16 @@ where
             if intervalTy.isConstOf ``IntervalRat then
               pure interval
             else
-              throwError "root_bound: Only IntervalRat or literal Set.Icc intervals are supported"
+              original.restore
+              return .error <| .unsupported (toString interval)
+                "only IntervalRat or literal Set.Icc intervals are supported"
 
       -- 1. Get AST
-      let reified ← getAst func
+      let reified ←
+        try pure (← getAst func)
+        catch e =>
+          original.restore
+          return .error <| .unsupported (toString func) (← e.toMessageData.toString)
       let ast := reified.expr
 
       -- Keep the user's goal synchronized with definitions delta-reduced by
@@ -115,7 +142,11 @@ where
       unfoldReifiedDefinitions reified.unfolded
 
       -- 2. Generate ExprSupportedCore proof
-      let supportProof ← mkSupportedCoreProof ast
+      let supportProof ←
+        try pure (← mkSupportedCoreProof ast)
+        catch e =>
+          original.restore
+          return .error <| .unsupported (toString func) (← e.toMessageData.toString)
 
       -- 3. Build config expression
       let cfgExpr ← mkAppM ``EvalConfig.mk #[toExpr taylorDepth]
@@ -127,25 +158,55 @@ where
         #[ast, intervalExpr, cfgExpr]
       let certTy ← mkAppM ``Eq #[checkExpr, mkConst ``Bool.true]
       let certGoal ← mkFreshExprMVar certTy
-      let event ← LeanCert.Tactic.closeCertificateGoalReported
-        (← LeanCert.Tactic.VerificationConfig.current) certGoal.mvarId!
-        (tacticName := "root_bound")
+      let event ←
+        match ← LeanCert.Tactic.closeCertificateGoalTyped
+            (← LeanCert.Tactic.VerificationConfig.current) certGoal.mvarId!
+            (tacticName := "root_bound") with
+        | .accepted event => pure event
+        | .rejected =>
+            original.restore
+            return .error <| .rejected "the zero-exclusion checker evaluated to false"
+        | .failed failure =>
+            original.restore
+            return .error <| .internalFailure (failure.message "root_bound")
       let conclusionProof ← mkAppM' proof #[certGoal]
 
       if fromSetIcc then
         -- Use simpa to bridge Set.Icc to IntervalRat
         let proofSyntax ← Term.exprToSyntax conclusionProof
-        evalTactic (← `(tactic| exact (by
-          have h := $proofSyntax
-          simpa [IntervalRat.mem_iff_mem_Icc, sub_eq_add_neg, sq, pow_two] using h)))
+        try
+          evalTactic (← `(tactic| exact (by
+            have h := $proofSyntax
+            simpa [IntervalRat.mem_iff_mem_Icc, sub_eq_add_neg, sq, pow_two] using h)))
+        catch e =>
+          original.restore
+          return .error <| .transportFailure (← e.toMessageData.toString)
       else
         goal.assign conclusionProof
         replaceMainGoal []
-      return event
+      return .ok event
+
+/-- Typed root-bound implementation. Every non-success restores the caller's
+complete tactic state. -/
+def rootBoundCoreTyped (taylorDepth : Nat) :
+    TacticM (Except RootBoundFailure RootBoundOutcome) := do
+  let original ← saveState
+  try rootBoundCoreTypedImpl original taylorDepth
+  catch e =>
+    original.restore
+    return .error <| .internalFailure (← e.toMessageData.toString)
+
+/-- Reporting compatibility entry point preserving the historical throwing API. -/
+def rootBoundCoreReported (taylorDepth : Nat) : TacticM RootBoundOutcome := do
+  match ← rootBoundCoreTyped taylorDepth with
+  | .ok outcome => return outcome
+  | .error failure => throwRootBoundFailure failure
 
 /-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
 def rootBoundCore (taylorDepth : Nat) : TacticM Unit := do
-  discard <| rootBoundCoreReported taylorDepth
+  match ← rootBoundCoreTyped taylorDepth with
+  | .ok _ => pure ()
+  | .error failure => throwRootBoundFailure failure
 
 /-- The root_bound tactic.
 

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -401,24 +401,49 @@ private def checkedExecution (backend : Option NumericalBackend)
   notes
 }
 
-private def rootExistsAttemptReported (depth : Nat) : TacticM SolverExecution := do
-  let outcome ← intervalRootsCoreReported depth
-  return checkedExecution none
-    outcome.verification outcome.checker outcome.verifier
-    #[s!"Taylor depth: {outcome.taylorDepth}"]
+private def rootDiscoveryAttemptTyped
+    (solver : Name)
+    (attempt : TacticM (Except RootDiscoveryFailure RootDiscoveryOutcome)) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← attempt with
+  | .ok outcome =>
+      return .ok <| checkedExecution none
+        outcome.verification outcome.checker outcome.verifier
+        #[s!"Taylor depth: {outcome.taylorDepth}"]
+  | .error (.unsupported expression detail) =>
+      return .error <| .unsupported { expression, detail := some detail }
+  | .error (.rejected detail) =>
+      return .error <| .rejected { detail }
+  | .error (.transportFailure detail) =>
+      return .error <| .internalError solver detail
+  | .error (.internalFailure detail) =>
+      return .error <| .internalError solver detail
 
-private unsafe def uniqueRootAttemptReported (depth : Nat) :
-    TacticM SolverExecution := do
-  let outcome ← intervalUniqueRootCoreReported depth
-  return checkedExecution none
-    outcome.verification outcome.checker outcome.verifier
-    #[s!"Taylor depth: {outcome.taylorDepth}"]
+private def rootExistsAttemptTyped (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) :=
+  rootDiscoveryAttemptTyped `LeanCert.Tactic.Discovery.interval_roots
+    (intervalRootsCoreTyped depth)
 
-private def noRootAttemptReported (depth : Nat) : TacticM SolverExecution := do
-  let outcome ← Auto.rootBoundCoreReported depth
-  return checkedExecution none
-    outcome.verification outcome.checker outcome.verifier
-    #[s!"Taylor depth: {outcome.taylorDepth}"]
+private unsafe def uniqueRootAttemptTyped (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) :=
+  rootDiscoveryAttemptTyped `LeanCert.Tactic.Discovery.interval_unique_root
+    (intervalUniqueRootCoreTyped depth)
+
+private def noRootAttemptTyped (depth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← Auto.rootBoundCoreTyped depth with
+  | .ok outcome =>
+      return .ok <| checkedExecution none
+        outcome.verification outcome.checker outcome.verifier
+        #[s!"Taylor depth: {outcome.taylorDepth}"]
+  | .error (.unsupported expression detail) =>
+      return .error <| .unsupported { expression, detail := some detail }
+  | .error (.rejected detail) =>
+      return .error <| .rejected { detail }
+  | .error (.transportFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.root_bound detail
+  | .error (.internalFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.root_bound detail
 
 private unsafe def optimizationAttemptTyped (maxIterations : Nat)
     (useMonotonicity : Bool) (depth : Nat) :
@@ -565,58 +590,49 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
           (.policy "checked root certificate arithmetic")
           (some (suggestion "interval_roots" #[toString d])),
         solve := intervalRootsCore d
-        solveReported := some (rootExistsAttemptReported d)
-        legacyExceptionAdapter := true },
+        solveReportedResult := some (rootExistsAttemptTyped d) },
       { report := report intent "endpoint sign-change certificate" cfg mode
           (.policy "checked root certificate arithmetic")
           (some (suggestion "interval_roots" #[toString d2])),
         solve := intervalRootsCore d2
-        solveReported := some (rootExistsAttemptReported d2)
-        legacyExceptionAdapter := true },
+        solveReportedResult := some (rootExistsAttemptTyped d2) },
       { report := report intent "endpoint sign-change certificate" cfg mode
           (.policy "checked root certificate arithmetic")
           (some (suggestion "interval_roots" #[toString d3])),
         solve := intervalRootsCore d3
-        solveReported := some (rootExistsAttemptReported d3)
-        legacyExceptionAdapter := true }]
+        solveReportedResult := some (rootExistsAttemptTyped d3) }]
   | .uniqueRoot => #[
       { report := report intent "interval Newton contraction" cfg mode
           (.policy "checked Newton certificate arithmetic")
           (some (suggestion "interval_unique_root" #[toString d])),
         solve := intervalUniqueRootCore d
-        solveReported := some (uniqueRootAttemptReported d)
-        legacyExceptionAdapter := true },
+        solveReportedResult := some (uniqueRootAttemptTyped d) },
       { report := report intent "interval Newton contraction" cfg mode
           (.policy "checked Newton certificate arithmetic")
           (some (suggestion "interval_unique_root" #[toString d2])),
         solve := intervalUniqueRootCore d2
-        solveReported := some (uniqueRootAttemptReported d2)
-        legacyExceptionAdapter := true },
+        solveReportedResult := some (uniqueRootAttemptTyped d2) },
       { report := report intent "interval Newton contraction" cfg mode
           (.policy "checked Newton certificate arithmetic")
           (some (suggestion "interval_unique_root" #[toString d3])),
         solve := intervalUniqueRootCore d3
-        solveReported := some (uniqueRootAttemptReported d3)
-        legacyExceptionAdapter := true }]
+        solveReportedResult := some (uniqueRootAttemptTyped d3) }]
   | .noRoot => #[
       { report := report intent "zero-exclusion enclosure" cfg mode
           (.policy "checked interval tactic portfolio")
           (some (suggestion "root_bound" #[toString d])),
         solve := Auto.rootBoundCore d
-        solveReported := some (noRootAttemptReported d)
-        legacyExceptionAdapter := true },
+        solveReportedResult := some (noRootAttemptTyped d) },
       { report := report intent "zero-exclusion enclosure" cfg mode
           (.policy "checked interval tactic portfolio")
           (some (suggestion "root_bound" #[toString d2])),
         solve := Auto.rootBoundCore d2
-        solveReported := some (noRootAttemptReported d2)
-        legacyExceptionAdapter := true },
+        solveReportedResult := some (noRootAttemptTyped d2) },
       { report := report intent "zero-exclusion enclosure" cfg mode
           (.policy "checked interval tactic portfolio")
           (some (suggestion "root_bound" #[toString d3])),
         solve := Auto.rootBoundCore d3
-        solveReported := some (noRootAttemptReported d3)
-        legacyExceptionAdapter := true }]
+        solveReportedResult := some (noRootAttemptTyped d3) }]
   | .existentialMinimum => #[
       { report := report intent "guided lower-bound discovery and certification" cfg mode
           (.policy "guided optimization followed by checked interval certification")

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -24,6 +24,7 @@ set_option linter.unusedTactic false
 private def checkerExpr : LeanCert.Core.Expr := .var 0
 private def checkerInterval : LeanCert.Core.IntervalRat := ⟨0, 1, by norm_num⟩
 private def checkerInterval35 : LeanCert.Core.IntervalRat := ⟨3, 5, by norm_num⟩
+private def checkerIntervalNeg11 : LeanCert.Core.IntervalRat := ⟨-1, 1, by norm_num⟩
 
 private def adapterTestPlan : SolverPlan := {
   intent := .pointInequality
@@ -74,6 +75,185 @@ elab "expect_terminal_outcome_stops" : tactic => do
       throwError "terminal outcome lost its diagnostic: {detail}"
   if continued then
     throwError "routing continued after a terminal outcome"
+
+syntax (name := expectRootTypedReport)
+  "expect_root_typed_report" ident : tactic
+
+private structure RootReportProbe where
+  checker : Name
+  verifier : Name
+  verification : LeanCert.Tactic.VerificationUsage
+  expectedChecker : Name
+  expectedVerifier : Name
+
+@[tactic expectRootTypedReport]
+unsafe def elabExpectRootTypedReport : Tactic := fun stx => do
+  let family := stx[1].getId
+  let probe : RootReportProbe ←
+    if family == `existence then
+      match ← Discovery.intervalRootsCoreTyped 10 with
+      | .ok outcome => pure {
+          checker := outcome.checker
+          verifier := outcome.verifier
+          verification := outcome.verification
+          expectedChecker := ``LeanCert.Validity.RootFinding.checkSignChange
+          expectedVerifier := ``LeanCert.Validity.RootFinding.verify_sign_change
+        }
+      | .error failure => throwError "typed root-existence route failed: {repr failure}"
+    else if family == `unique then
+      match ← Discovery.intervalUniqueRootCoreTyped 10 with
+      | .ok outcome => pure {
+          checker := outcome.checker
+          verifier := outcome.verifier
+          verification := outcome.verification
+          expectedChecker := ``LeanCert.Validity.RootFinding.checkNewtonContractsCore
+          expectedVerifier := ``LeanCert.Validity.RootFinding.verify_unique_root_computable
+        }
+      | .error failure => throwError "typed unique-root route failed: {repr failure}"
+    else
+      match ← Auto.rootBoundCoreTyped 10 with
+      | .ok outcome => pure {
+          checker := outcome.checker
+          verifier := outcome.verifier
+          verification := outcome.verification
+          expectedChecker := ``LeanCert.Validity.RootFinding.checkNoRoot
+          expectedVerifier := ``LeanCert.Validity.RootFinding.verify_no_root
+        }
+      | .error failure => throwError "typed no-root route failed: {repr failure}"
+  unless probe.checker == probe.expectedChecker &&
+      probe.verifier == probe.expectedVerifier do
+    throwError "root route retained the wrong checker/Golden Theorem: \
+      checker={probe.checker}, verifier={probe.verifier}"
+  unless probe.verification.nativeChecks + probe.verification.kernelChecks == 1 do
+    throwError "root route did not retain exactly one successful certificate check"
+
+syntax (name := expectRootRejectionRollback)
+  "expect_root_rejection_rollback" ident : tactic
+
+@[tactic expectRootRejectionRollback]
+unsafe def elabExpectRootRejectionRollback : Tactic := fun stx => do
+  let family := stx[1].getId
+  let originalGoals ← getGoals
+  let originalType ← (← getMainGoal).getType
+  let rejected ←
+    if family == `existence then
+      match ← Discovery.intervalRootsCoreTyped 10 with
+      | .error (.rejected _) => pure true
+      | .error failure => throwError "root existence returned wrong failure: {repr failure}"
+      | .ok _ => pure false
+    else if family == `unique then
+      match ← Discovery.intervalUniqueRootCoreTyped 10 with
+      | .error (.rejected _) => pure true
+      | .error failure => throwError "unique root returned wrong failure: {repr failure}"
+      | .ok _ => pure false
+    else
+      match ← Auto.rootBoundCoreTyped 10 with
+      | .error (.rejected _) => pure true
+      | .error failure => throwError "no-root route returned wrong failure: {repr failure}"
+      | .ok _ => pure false
+  unless rejected do
+    throwError "false root candidate was accepted"
+  let restoredGoals ← getGoals
+  unless restoredGoals == originalGoals do
+    throwError "typed root rejection did not restore the caller's goal list"
+  let restoredType ← (← getMainGoal).getType
+  unless ← isDefEq restoredType originalType do
+    throwError "typed root rejection changed the caller's goal"
+
+syntax (name := expectRootUnsupportedRollback)
+  "expect_root_unsupported_rollback" : tactic
+
+@[tactic expectRootUnsupportedRollback]
+unsafe def elabExpectRootUnsupportedRollback : Tactic := fun _ => do
+  let originalGoals ← getGoals
+  let checkRestored (family : String) : TacticM Unit := do
+    unless (← getGoals) == originalGoals do
+      throwError "{family} unsupported result did not restore the goal list"
+  match ← Discovery.intervalRootsCoreTyped 10 with
+  | .error (.unsupported ..) => checkRestored "root existence"
+  | .error failure => throwError "root existence returned wrong malformed-goal failure: {repr failure}"
+  | .ok _ => throwError "root existence accepted a malformed goal"
+  match ← Discovery.intervalUniqueRootCoreTyped 10 with
+  | .error (.unsupported ..) => checkRestored "unique root"
+  | .error failure => throwError "unique root returned wrong malformed-goal failure: {repr failure}"
+  | .ok _ => throwError "unique root accepted a malformed goal"
+  match ← Auto.rootBoundCoreTyped 10 with
+  | .error (.unsupported ..) => checkRestored "no root"
+  | .error failure => throwError "no-root returned wrong malformed-goal failure: {repr failure}"
+  | .ok _ => throwError "no-root accepted a malformed goal"
+
+syntax (name := expectRootRouterReport)
+  "expect_root_router_report" ident : tactic
+
+@[tactic expectRootRouterReport]
+unsafe def elabExpectRootRouterReport : Tactic := fun stx => do
+  let family := stx[1].getId
+  let result ← runLeanCert {} .compact
+  let (expectedChecker, expectedVerifier) :=
+    if family == `existence then
+      (``LeanCert.Validity.RootFinding.checkSignChange,
+        ``LeanCert.Validity.RootFinding.verify_sign_change)
+    else if family == `unique then
+      (``LeanCert.Validity.RootFinding.checkNewtonContractsCore,
+        ``LeanCert.Validity.RootFinding.verify_unique_root_computable)
+    else
+      (``LeanCert.Validity.RootFinding.checkNoRoot,
+        ``LeanCert.Validity.RootFinding.verify_no_root)
+  unless result.execution.checker == some expectedChecker &&
+      result.execution.verifier == some expectedVerifier do
+    throwError "front-door root route lost certificate provenance: \
+      checker={result.execution.checker}, verifier={result.execution.verifier}"
+  unless result.execution.verificationUsage.nativeChecks +
+      result.execution.verificationUsage.kernelChecks == 1 do
+    throwError "front-door root route did not retain exactly one certificate check"
+
+example : ∃ x ∈ checkerIntervalNeg11,
+    LeanCert.Core.Expr.eval (fun _ => x) (.var 0) = 0 := by
+  expect_root_typed_report existence
+
+example : ∃! x, x ∈ checkerIntervalNeg11 ∧
+    LeanCert.Core.Expr.eval (fun _ => x) (.var 0) = 0 := by
+  expect_root_typed_report unique
+
+example : ∀ x ∈ checkerInterval,
+    LeanCert.Core.Expr.eval (fun _ => x) (.add (.var 0) (.const 2)) ≠ 0 := by
+  expect_root_typed_report absent
+
+example (h : ∃ x ∈ checkerInterval,
+    LeanCert.Core.Expr.eval (fun _ => x)
+      (.add (.mul (.var 0) (.var 0)) (.const 1)) = 0) :
+    ∃ x ∈ checkerInterval,
+      LeanCert.Core.Expr.eval (fun _ => x)
+        (.add (.mul (.var 0) (.var 0)) (.const 1)) = 0 := by
+  expect_root_rejection_rollback existence
+  exact h
+
+example (h : ∃! x, x ∈ checkerInterval ∧
+    LeanCert.Core.Expr.eval (fun _ => x) (.const 1) = 0) :
+    ∃! x, x ∈ checkerInterval ∧
+      LeanCert.Core.Expr.eval (fun _ => x) (.const 1) = 0 := by
+  expect_root_rejection_rollback unique
+  exact h
+
+example (h : ∀ x ∈ checkerIntervalNeg11,
+    LeanCert.Core.Expr.eval (fun _ => x) (.var 0) ≠ 0) :
+    ∀ x ∈ checkerIntervalNeg11,
+      LeanCert.Core.Expr.eval (fun _ => x) (.var 0) ≠ 0 := by
+  expect_root_rejection_rollback absent
+  exact h
+
+example (h : True) : True := by
+  expect_root_unsupported_rollback
+  exact h
+
+example : ∃ x ∈ Set.Icc (1 : ℝ) 2, x ^ 2 = 2 := by
+  expect_root_router_report existence
+
+example : ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x ^ 2 = 2 := by
+  expect_root_router_report unique
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, x + 2 ≠ 0 := by
+  expect_root_router_report absent
 
 syntax (name := expectRationalPointReport) "expect_rational_point_report" : tactic
 

--- a/docs/direct/roots.md
+++ b/docs/direct/roots.md
@@ -33,6 +33,24 @@ interval_roots
 interval_unique_root
 root_bound
 ```
+
+All three dedicated tactics use typed, transactional certificate boundaries.
+A checker result of `false` is an ordinary rejected candidate; malformed
+input is unsupported; verifier or proof-transport failures remain terminal.
+Every non-success restores the complete caller tactic state. The retained
+success report records the actual checker, Golden Theorem, verification route,
+and Taylor depth without rerunning the certificate.
+
+The corresponding programmatic entry points are:
+
+```text
+intervalRootsCoreTyped
+intervalUniqueRootCoreTyped
+rootBoundCoreTyped
+```
+
+Their historical throwing entry points remain available for compatibility.
+
 ## Global algebraic simplicity and counts
 
 For an exact rational polynomial, `BezoutCert` checks an identity

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -326,6 +326,10 @@ example : ∃ x ∈ I12, Expr.eval (fun _ => x)
 2. Detects sign change (f(lo) < 0 < f(hi) or vice versa)
 3. Applies IVT to prove existence
 
+`intervalRootsCoreTyped` returns the retained checker and verifier identities,
+verification usage, and Taylor depth. A false sign-change check is typed
+rejection and restores the original tactic state.
+
 ---
 
 ### `interval_unique_root`
@@ -360,6 +364,10 @@ example : ∃! x ∈ I12, Expr.eval (fun _ => x) expr_x2_minus_2 = 0 := by
 2. Verifies N maps interval into itself
 3. Verifies |N'(x)| < 1 (contraction)
 4. Banach fixed-point theorem gives uniqueness
+
+`intervalUniqueRootCoreTyped` distinguishes unsupported goals, rejected
+Newton certificates, proof transport failures, and internal verification
+failures. Every failure is transactional.
 
 ---
 
@@ -609,6 +617,11 @@ example : ∀ x ∈ I01, Expr.eval (fun _ => x)
     (Expr.add (Expr.mul (Expr.var 0) (Expr.var 0)) (Expr.const 1)) ≠ (0 : ℝ) := by
   root_bound
 ```
+
+`rootBoundCoreTyped` reports the exact `checkNoRoot`/`verify_no_root`
+certificate pair. A zero-exclusion checker returning false is a resumable
+rejection rather than an infrastructure exception, and the original goal is
+restored.
 
 ---
 


### PR DESCRIPTION
## Summary

Migrates LeanCert’s three root-solving families to the typed solver protocol:

- `interval_roots` — root existence through a checked sign-change certificate
- `interval_unique_root` — unique-root certification through interval Newton
- `root_bound` — root exclusion through a checked no-root certificate

## What changed

- Adds typed success and failure results for root discovery and exclusion.
- Distinguishes:
  - unsupported goals or expressions;
  - conclusive certificate rejection;
  - proof-transport failure;
  - internal verification failure.
- Restores the complete tactic state after every non-success.
- Uses `closeCertificateGoalTyped` directly, without rerunning certificate checkers.
- Retains the actual checker, Golden Theorem, verification route, and Taylor depth from the successful run.
- Migrates all root portfolio entries away from the legacy exception adapter.
- Preserves the existing throwing APIs and dedicated tactic syntax as compatibility wrappers.

## Router behavior

Certificate rejection is resumable, allowing the portfolio to try the next Taylor depth. Transport and infrastructure failures remain terminal.

The front door now reports the exact retained certificate pair:

- `checkSignChange` / `verify_sign_change`
- `checkNewtonContractsCore` / `verify_unique_root_computable`
- `checkNoRoot` / `verify_no_root`

## Tests

Adds regression coverage for:

- successful typed outcomes for all three root families;
- exact checker and verifier identities;
- exactly one retained verification event;
- rejection classification;
- complete rollback after rejection;
- rollback and classification of malformed goals;
- end-to-end `leancert` routing for root existence, uniqueness, and exclusion.

Existing native, kernel, auto, natural-syntax, edge-form, and downstream root tests continue to pass.

## Documentation

Documents the typed programmatic entry points, transactional guarantees, retained telemetry, and compatibility behavior.
