### PR TITLE
Remove legacy solver protocol adapters

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Check every test module is wired
         run: python3 scripts/check_test_wiring.py
 
+      - name: Enforce typed solver protocol
+        run: python3 scripts/check_solver_protocol_policy.py
+
       - name: Build complete functional suite
         run: lake build FunctionalTests
 

--- a/LeanCert/Tactic/BridgeNative.lean
+++ b/LeanCert/Tactic/BridgeNative.lean
@@ -11,7 +11,7 @@ import LeanCert.Tactic.Verification
 
 Common pattern for `finsum_bound`, `finsum_witness`, and `finmatrix_bound`:
 apply a bridge proof term, close the Bool/ℚ check via the verification
-choke point (`closeCertificateGoal`, honoring `leancert.trust`), and handle
+boundary (`closeCertificateGoalTyped`, honoring `leancert.trust`), and handle
 the case where the bridge's type isn't defEq to the goal via a
 suffices + converter fallback.
 -/
@@ -26,14 +26,6 @@ inductive BridgeFailure where
   | verificationFailure (detail : String)
   | transportFailure (detail : String)
   deriving Inhabited, Repr
-
-private def throwBridgeFailure (tacticName : String) : BridgeFailure → TacticM α
-  | .rejected =>
-      throwError "{tacticName}: the bridge certificate was rejected"
-  | .verificationFailure detail =>
-      throwError "{tacticName}: certificate verification failed:\n{detail}"
-  | .transportFailure detail =>
-      throwError "{tacticName}: could not transport the checked bridge theorem:\n{detail}"
 
 /-- Apply a bridge proof and close its certificate through the configured
 verification route.
@@ -132,26 +124,5 @@ def closeBridgeWithVerificationTyped
   catch e =>
     original.restore
     return .error <| .transportFailure (← e.toMessageData.toString)
-
-/-- Reporting compatibility wrapper preserving the historical throwing API. -/
-def closeBridgeWithVerificationReported
-    (goal : MVarId) (goalType : Lean.Expr)
-    (proof checkMVar : Lean.Expr)
-    (tacticName : String)
-    (converterSteps : Array (TacticM Unit))
-    : TacticM VerificationEvent := do
-  match ← closeBridgeWithVerificationTyped goal goalType proof checkMVar
-      tacticName converterSteps with
-  | .ok event => return event
-  | .error failure => throwBridgeFailure tacticName failure
-
-/-- Compatibility wrapper retaining the historical API name and result type. -/
-def closeBridgeWithNativeDecide
-    (goal : MVarId) (goalType : Lean.Expr)
-    (proof checkMVar : Lean.Expr)
-    (tacticName : String)
-    (converterSteps : Array (TacticM Unit)) : TacticM Unit := do
-  discard <| closeBridgeWithVerificationReported goal goalType proof checkMVar
-    tacticName converterSteps
 
 end LeanCert.Tactic

--- a/LeanCert/Tactic/Discovery.lean
+++ b/LeanCert/Tactic/Discovery.lean
@@ -443,12 +443,6 @@ unsafe def intervalMinimizeCoreTyped (taylorDepth : Nat) :
     taylorDepth := taylorDepth
   }
 
-/-- Compatibility entry point preserving the dedicated tactic's throwing API. -/
-unsafe def intervalMinimizeCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalMinimizeCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwDiscoveryFailure "interval_minimize" failure
-
 /-- The interval_minimize tactic.
 
 Proves goals of the form `∃ m, ∀ x ∈ I, f(x) ≥ m` by:
@@ -465,7 +459,9 @@ unsafe def elabIntervalMinimize : Tactic := fun stx => do
     | some n => n.toNat
     | none => 10
   withTrustMode (← elabTrustItem? (stx[2].getOptional?.map (⟨·⟩))) do
-    intervalMinimizeCore depth
+    match ← intervalMinimizeCoreTyped depth with
+    | .ok _ => pure ()
+    | .error failure => throwDiscoveryFailure "interval_minimize" failure
 
 /-! ## Maximization Tactic -/
 
@@ -588,12 +584,6 @@ unsafe def intervalMaximizeCoreTyped (taylorDepth : Nat) :
     taylorDepth := taylorDepth
   }
 
-/-- Compatibility entry point preserving the dedicated tactic's throwing API. -/
-unsafe def intervalMaximizeCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalMaximizeCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwDiscoveryFailure "interval_maximize" failure
-
 /-- The interval_maximize tactic.
 
 Proves goals of the form `∃ M, ∀ x ∈ I, f(x) ≤ M`.
@@ -607,7 +597,9 @@ unsafe def elabIntervalMaximize : Tactic := fun stx => do
     | some n => n.toNat
     | none => 10
   withTrustMode (← elabTrustItem? (stx[2].getOptional?.map (⟨·⟩))) do
-    intervalMaximizeCore depth
+    match ← intervalMaximizeCoreTyped depth with
+    | .ok _ => pure ()
+    | .error failure => throwDiscoveryFailure "interval_maximize" failure
 
 /-! ## Argmax/Argmin Tactics -/
 
@@ -811,7 +803,7 @@ private def throwAttainedExtremumFailure (tacticName : String) :
       throwError "{tacticName}: internal certificate failure:\n{detail}"
 
 /-- The interval_argmax tactic implementation -/
-private unsafe def intervalArgmaxCoreReported
+private unsafe def intervalArgmaxCoreImpl
     (taylorDepth : Nat) :
     TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   LeanCert.Tactic.Auto.intervalNormCore
@@ -1060,7 +1052,7 @@ unsafe def intervalArgmaxCoreTyped (taylorDepth : Nat) :
     TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   let original ← saveState
   try
-    match ← intervalArgmaxCoreReported taylorDepth with
+    match ← intervalArgmaxCoreImpl taylorDepth with
     | .ok outcome => return .ok outcome
     | .error failure =>
         original.restore
@@ -1068,12 +1060,6 @@ unsafe def intervalArgmaxCoreTyped (taylorDepth : Nat) :
   catch e =>
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
-
-/-- Compatibility wrapper preserving the historical throwing API. -/
-unsafe def intervalArgmaxCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalArgmaxCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwAttainedExtremumFailure "interval_argmax" failure
 
 /-- The interval_argmax tactic.
 
@@ -1092,10 +1078,12 @@ unsafe def elabIntervalArgmax : Tactic := fun stx => do
     | some n => n.toNat
     | none => 10
   withTrustMode (← elabTrustItem? (stx[2].getOptional?.map (⟨·⟩))) do
-    intervalArgmaxCore depth
+    match ← intervalArgmaxCoreTyped depth with
+    | .ok _ => pure ()
+    | .error failure => throwAttainedExtremumFailure "interval_argmax" failure
 
 /-- The interval_argmin tactic implementation -/
-private unsafe def intervalArgminCoreReported
+private unsafe def intervalArgminCoreImpl
     (taylorDepth : Nat) :
     TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   LeanCert.Tactic.Auto.intervalNormCore
@@ -1339,7 +1327,7 @@ unsafe def intervalArgminCoreTyped (taylorDepth : Nat) :
     TacticM (Except AttainedExtremumFailure AttainedExtremumOutcome) := do
   let original ← saveState
   try
-    match ← intervalArgminCoreReported taylorDepth with
+    match ← intervalArgminCoreImpl taylorDepth with
     | .ok outcome => return .ok outcome
     | .error failure =>
         original.restore
@@ -1347,12 +1335,6 @@ unsafe def intervalArgminCoreTyped (taylorDepth : Nat) :
   catch e =>
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
-
-/-- Compatibility wrapper preserving the historical throwing API. -/
-unsafe def intervalArgminCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalArgminCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwAttainedExtremumFailure "interval_argmin" failure
 
 /-- The interval_argmin tactic.
 
@@ -1371,7 +1353,9 @@ unsafe def elabIntervalArgmin : Tactic := fun stx => do
     | some n => n.toNat
     | none => 10
   withTrustMode (← elabTrustItem? (stx[2].getOptional?.map (⟨·⟩))) do
-    intervalArgminCore depth
+    match ← intervalArgminCoreTyped depth with
+    | .ok _ => pure ()
+    | .error failure => throwAttainedExtremumFailure "interval_argmin" failure
 
 /-! ## Multivariate Minimization/Maximization Tactics -/
 
@@ -1539,87 +1523,6 @@ unsafe def intervalMaximizeMvCoreTyped (taylorDepth : Nat) :
     TacticM (Except DiscoveryFailure DiscoveryOutcome) :=
   intervalMvCoreTyped .maximum taylorDepth
 
-/-- Legacy implementation retained temporarily for source comparison. -/
-private unsafe def intervalMinimizeMvCoreLegacy (taylorDepth : Nat) : TacticM Unit := do
-  LeanCert.Tactic.Auto.intervalNormCore
-  let goal ← getMainGoal
-  let goalType ← goal.getType
-
-  let some (.minimize varType vars funcExpr) ← parseMultivariateExistentialGoal goalType
-    | throwError "interval_minimize_mv: Goal must be of form `∃ m, ∀ x ∈ I, ∀ y ∈ J, ..., f(...) ≥ m`"
-
-  trace[LeanCert.discovery] "Parsing multivariate goal: ∃ m, ∀ vars ∈ domains, f(...) ≥ m"
-  trace[LeanCert.discovery] "Number of variables: {vars.size}"
-  trace[LeanCert.discovery] "Function expression: {funcExpr}"
-
-  -- 1. Reify the function
-  let ast := (← getAstFromFuncWithReport funcExpr).expr
-  trace[LeanCert.discovery] "Reified AST: {ast}"
-
-  -- 2. Build the box from all variable intervals
-  let mut boxVals : Array IntervalRat := #[]
-  for v in vars do
-    let intervalVal ← evalExpr IntervalRat (mkConst ``IntervalRat) v.intervalRat
-    boxVals := boxVals.push intervalVal
-    trace[LeanCert.discovery] "Variable {v.varName}: [{intervalVal.lo}, {intervalVal.hi}]"
-
-  let boxVal : Box := boxVals.toList
-
-  -- 3. Prepare config for multivariate guided optimization
-  let cfg : GuidedOptConfig := {
-    maxIterations := 2000,  -- More iterations for multivariate
-    tolerance := 1/1000,
-    taylorDepth := taylorDepth,
-    useMonotonicity := true,
-    heuristicSamples := 300,  -- More samples for higher dimensions
-    seed := 12345,
-    useGridSearch := true,
-    gridPointsPerDim := 5  -- Fewer points per dim for multivariate
-  }
-
-  -- 4. Run float-guided optimization
-  trace[LeanCert.discovery] "Running multivariate float-guided optimization..."
-  let astVal ← evalExpr LExpr (mkConst ``LeanCert.Core.Expr) ast
-  let result := globalMinimizeGuided astVal boxVal cfg
-  let boundVal := result.bound.lo
-
-  trace[LeanCert.discovery] "Optimization complete: {result.bound.iterations} iterations"
-  trace[LeanCert.discovery] "Found minimum bound: {boundVal}"
-  trace[LeanCert.discovery] "Gap: [{result.bound.lo}, {result.bound.hi}]"
-
-  -- Check if optimization converged well
-  let gap := result.bound.hi - result.bound.lo
-  if gap > cfg.tolerance then
-    logWarning m!"⚠️ Optimization gap [{result.bound.lo}, {result.bound.hi}] exceeds tolerance {cfg.tolerance}.\n\
-                  Consider increasing maxIterations or taylorDepth."
-
-  -- 5. Provide witness and prove the bound
-  -- Note: Coerce to ℝ since Expr.eval returns ℝ
-  let boundRatExpr := toExpr boundVal
-  let boundTerm ←
-    match (← whnf varType) with
-    | ty =>
-      if ty.isConstOf ``Rat then
-        pure boundRatExpr
-      else if ty.isConstOf ``Real then
-        mkAppOptM ``Rat.cast #[mkConst ``Real, none, boundRatExpr]
-      else
-        throwError "interval_minimize_mv: Unsupported bound type. Use ℚ or ℝ."
-  let boundSyntax ← Term.exprToSyntax boundTerm
-  trace[LeanCert.discovery] "Providing witness: m = {boundVal}"
-  evalTactic (← `(tactic| refine ⟨$boundSyntax, ?_⟩))
-
-  -- 6. Now we have a multivariate goal `∀ x ∈ I, ∀ y ∈ J, ..., f(...) ≥ bound`
-  trace[LeanCert.discovery] "Proving multivariate universal bound with certify_bound..."
-  LeanCert.Tactic.Auto.multivariateBoundCore cfg.maxIterations cfg.tolerance cfg.useMonotonicity taylorDepth
-  trace[LeanCert.discovery] "✓ Proof complete"
-
-/-- Compatibility entry point preserving the dedicated tactic's throwing API. -/
-unsafe def intervalMinimizeMvCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalMinimizeMvCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwDiscoveryFailure "interval_minimize_mv" failure
-
 /-- The interval_minimize_mv tactic.
 
 Proves multivariate goals of the form `∃ m, ∀ x ∈ I, ∀ y ∈ J, f(x,y) ≥ m` by:
@@ -1636,88 +1539,9 @@ unsafe def elabIntervalMinimizeMv : Tactic := fun stx => do
     | some n => n.toNat
     | none => 10
   withTrustMode (← elabTrustItem? (stx[2].getOptional?.map (⟨·⟩))) do
-    intervalMinimizeMvCore depth
-
-/-- Legacy implementation retained temporarily for source comparison. -/
-private unsafe def intervalMaximizeMvCoreLegacy (taylorDepth : Nat) : TacticM Unit := do
-  LeanCert.Tactic.Auto.intervalNormCore
-  let goal ← getMainGoal
-  let goalType ← goal.getType
-
-  let some (.maximize varType vars funcExpr) ← parseMultivariateExistentialGoal goalType
-    | throwError "interval_maximize_mv: Goal must be of form `∃ M, ∀ x ∈ I, ∀ y ∈ J, ..., f(...) ≤ M`"
-
-  trace[LeanCert.discovery] "Parsing multivariate goal: ∃ M, ∀ vars ∈ domains, f(...) ≤ M"
-  trace[LeanCert.discovery] "Number of variables: {vars.size}"
-  trace[LeanCert.discovery] "Function expression: {funcExpr}"
-
-  -- 1. Reify the function
-  let ast := (← getAstFromFuncWithReport funcExpr).expr
-  trace[LeanCert.discovery] "Reified AST: {ast}"
-
-  -- 2. Build the box from all variable intervals
-  let mut boxVals : Array IntervalRat := #[]
-  for v in vars do
-    let intervalVal ← evalExpr IntervalRat (mkConst ``IntervalRat) v.intervalRat
-    boxVals := boxVals.push intervalVal
-    trace[LeanCert.discovery] "Variable {v.varName}: [{intervalVal.lo}, {intervalVal.hi}]"
-
-  let boxVal : Box := boxVals.toList
-
-  -- 3. Prepare config
-  let cfg : GuidedOptConfig := {
-    maxIterations := 2000,
-    tolerance := 1/1000,
-    taylorDepth := taylorDepth,
-    useMonotonicity := true,
-    heuristicSamples := 300,
-    seed := 12345,
-    useGridSearch := true,
-    gridPointsPerDim := 5
-  }
-
-  -- 4. Run float-guided optimization
-  trace[LeanCert.discovery] "Running multivariate float-guided optimization..."
-  let astVal ← evalExpr LExpr (mkConst ``LeanCert.Core.Expr) ast
-  let result := globalMaximizeGuided astVal boxVal cfg
-  let boundVal := result.bound.hi
-
-  trace[LeanCert.discovery] "Optimization complete: {result.bound.iterations} iterations"
-  trace[LeanCert.discovery] "Found maximum bound: {boundVal}"
-  trace[LeanCert.discovery] "Gap: [{result.bound.lo}, {result.bound.hi}]"
-
-  -- Check convergence
-  let gap := result.bound.hi - result.bound.lo
-  if gap > cfg.tolerance then
-    logWarning m!"⚠️ Optimization gap [{result.bound.lo}, {result.bound.hi}] exceeds tolerance {cfg.tolerance}.\n\
-                  Consider increasing maxIterations or taylorDepth."
-
-  -- 5. Provide witness
-  -- Note: Coerce to ℝ since Expr.eval returns ℝ
-  let boundRatExpr := toExpr boundVal
-  let boundTerm ←
-    match (← whnf varType) with
-    | ty =>
-      if ty.isConstOf ``Rat then
-        pure boundRatExpr
-      else if ty.isConstOf ``Real then
-        mkAppOptM ``Rat.cast #[mkConst ``Real, none, boundRatExpr]
-      else
-        throwError "interval_maximize_mv: Unsupported bound type. Use ℚ or ℝ."
-  let boundSyntax ← Term.exprToSyntax boundTerm
-  trace[LeanCert.discovery] "Providing witness: M = {boundVal}"
-  evalTactic (← `(tactic| refine ⟨$boundSyntax, ?_⟩))
-
-  -- 6. Prove the multivariate bound
-  trace[LeanCert.discovery] "Proving multivariate universal bound with certify_bound..."
-  LeanCert.Tactic.Auto.multivariateBoundCore cfg.maxIterations cfg.tolerance cfg.useMonotonicity taylorDepth
-  trace[LeanCert.discovery] "✓ Proof complete"
-
-/-- Compatibility entry point preserving the dedicated tactic's throwing API. -/
-unsafe def intervalMaximizeMvCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalMaximizeMvCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwDiscoveryFailure "interval_maximize_mv" failure
+    match ← intervalMinimizeMvCoreTyped depth with
+    | .ok _ => pure ()
+    | .error failure => throwDiscoveryFailure "interval_minimize_mv" failure
 
 /-- The interval_maximize_mv tactic.
 
@@ -1735,7 +1559,9 @@ unsafe def elabIntervalMaximizeMv : Tactic := fun stx => do
     | some n => n.toNat
     | none => 10
   withTrustMode (← elabTrustItem? (stx[2].getOptional?.map (⟨·⟩))) do
-    intervalMaximizeMvCore depth
+    match ← intervalMaximizeMvCoreTyped depth with
+    | .ok _ => pure ()
+    | .error failure => throwDiscoveryFailure "interval_maximize_mv" failure
 
 /-! ## Roots Tactic -/
 
@@ -1984,18 +1810,6 @@ def intervalRootsCoreTyped (taylorDepth : Nat) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Reporting compatibility entry point preserving the historical throwing API. -/
-def intervalRootsCoreReported (taylorDepth : Nat) : TacticM RootDiscoveryOutcome := do
-  match ← intervalRootsCoreTyped taylorDepth with
-  | .ok outcome => return outcome
-  | .error failure => throwRootDiscoveryFailure "interval_roots" failure
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-def intervalRootsCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalRootsCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwRootDiscoveryFailure "interval_roots" failure
-
 /-- The interval_roots tactic.
 
 Proves goals of the form `∃ x ∈ I, f(x) = 0` by:
@@ -2024,7 +1838,9 @@ elab "interval_roots" depth:(num)? t:(leancertTrustItem)? : tactic => do
     | some n => n.getNat
     | none => 10
   withTrustMode (← elabTrustItem? t) do
-    intervalRootsCore taylorDepth
+    match ← intervalRootsCoreTyped taylorDepth with
+    | .ok _ => pure ()
+    | .error failure => throwRootDiscoveryFailure "interval_roots" failure
 
 /-! ## Unique Root Tactic -/
 
@@ -2229,19 +2045,6 @@ unsafe def intervalUniqueRootCoreTyped (taylorDepth : Nat) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Reporting compatibility entry point preserving the historical throwing API. -/
-unsafe def intervalUniqueRootCoreReported (taylorDepth : Nat) :
-    TacticM RootDiscoveryOutcome := do
-  match ← intervalUniqueRootCoreTyped taylorDepth with
-  | .ok outcome => return outcome
-  | .error failure => throwRootDiscoveryFailure "interval_unique_root" failure
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-unsafe def intervalUniqueRootCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← intervalUniqueRootCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwRootDiscoveryFailure "interval_unique_root" failure
-
 /-- The interval_unique_root tactic.
 
 Proves goals of the form `∃! x ∈ I, f(x) = 0` by:
@@ -2268,7 +2071,9 @@ unsafe def elabIntervalUniqueRoot : Tactic := fun stx => do
     | some n => n.toNat
     | none => 10
   withTrustMode (← elabTrustItem? (stx[2].getOptional?.map (⟨·⟩))) do
-    intervalUniqueRootCore taylorDepth
+    match ← intervalUniqueRootCoreTyped taylorDepth with
+    | .ok _ => pure ()
+    | .error failure => throwRootDiscoveryFailure "interval_unique_root" failure
 
 /-! ## Discover Tactic -/
 
@@ -2288,8 +2093,14 @@ unsafe def elabDiscover : Tactic := fun stx => do
 
   if let some goalKind ← parseExistentialGoal goalType then
     match goalKind with
-    | .minimize .. => intervalMinimizeCore depth
-    | .maximize .. => intervalMaximizeCore depth
+    | .minimize .. =>
+        match ← intervalMinimizeCoreTyped depth with
+        | .ok _ => pure ()
+        | .error failure => throwDiscoveryFailure "discover" failure
+    | .maximize .. =>
+        match ← intervalMaximizeCoreTyped depth with
+        | .ok _ => pure ()
+        | .error failure => throwDiscoveryFailure "discover" failure
   else
     throwError "discover: Goal not recognized. Supported forms:\n\
                 - ∃ m, ∀ x ∈ I, f(x) ≥ m\n\

--- a/LeanCert/Tactic/DyadicAuto.lean
+++ b/LeanCert/Tactic/DyadicAuto.lean
@@ -94,7 +94,7 @@ theorem verify_lower_bound_dyadic (e : Core.Expr) (hsupp : ExprSupportedCore e)
 /-! ## Deprecated tactics
 
 The original `certify_kernel` family predates the trust choke point
-(`LeanCert.Tactic.closeCertificateGoal`) and its strict kernel path had
+(`LeanCert.Tactic.closeCertificateGoalTyped`) and its strict kernel path had
 rotted: it required a `Decidable` instance for `evalDomainValidDyadic` that
 no longer exists, so every invocation failed. The spellings below are kept
 as deprecated aliases over `certify_bound`'s trust modes, which subsume them:

--- a/LeanCert/Tactic/FinSumBound.lean
+++ b/LeanCert/Tactic/FinSumBound.lean
@@ -538,17 +538,6 @@ def finSumBoundCoreTyped (prec : Int) (taylorDepth : Nat) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Reporting compatibility wrapper preserving the historical result API. -/
-def finSumBoundCoreReported (prec : Int) (taylorDepth : Nat) :
-    TacticM FinSumOutcome := do
-  match ← finSumBoundCoreTyped prec taylorDepth with
-  | .ok outcome => return outcome
-  | .error failure => throwError "finsum_bound: {repr failure}"
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-def finSumBoundCore (prec : Int) (taylorDepth : Nat) : TacticM Unit := do
-  discard <| finSumBoundCoreReported prec taylorDepth
-
 /-- Transactional typed entry for the `finsum_bound using ...` syntax,
 including a possible `Fin n` rewrite. -/
 def finSumWitnessBoundCoreTyped (evalTermSyn hmemSyn : Syntax) (prec : Int) :
@@ -623,7 +612,9 @@ elab_rules : tactic
       | some n => -(n.getNat : Int)
       | none => -53
     withTrustMode (← elabTrustItem? trust) do
-      finSumBoundCore precision 10
+      match ← finSumBoundCoreTyped precision 10 with
+      | .ok _ => pure ()
+      | .error failure => throwError "finsum_bound: {repr failure}"
   | `(tactic| finsum_bound auto $evalTerm:term $[$prec:num]?
       $[$trust:leancertTrustItem]?) => do
     let precision : Int := match prec with

--- a/LeanCert/Tactic/FinSumWitness.lean
+++ b/LeanCert/Tactic/FinSumWitness.lean
@@ -372,48 +372,92 @@ def finSumWitnessCoreTyped (evalTermSyn hmemSyn : Syntax) (prec : Int) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Try to auto-prove an hmem metavar using several strategies.
-    Works best when the evaluator returns singletons or tight intervals
-    where membership reduces to decidable ℚ comparisons. -/
-private def tryAutoProveHmem (hmemMVar : MVarId) : TacticM Unit := do
-  -- Strategy 1: simp [mem_def] + split into ≤ components + cast to ℚ + native_decide
-  -- Works for constant evaluators (no free variables in the comparison)
+/-- Run one structural membership-synthesis strategy, then close every closed
+decidable obligation through the typed verification boundary.
+
+The caller selects a strategy that matches the already parsed range or explicit
+Finset shape. Structural exceptions therefore remain unexpected and escape to
+the outer transactional core as internal failures. Once certificate
+obligations exist, rejection and verification failures are retained as typed
+failures and never reinterpreted as unsupported syntax. -/
+private def tryAutoHmemStrategy (hmemMVar : MVarId) (strategy : Syntax) :
+    TacticM (Except FinSumFailure (Option VerificationUsage)) := do
+  let strategyState ← saveState
+  let surroundingGoals ← getGoals
   setGoals [hmemMVar]
-  try
-    evalTactic (← `(tactic|
+  evalTactic strategy
+
+  let cfg ← VerificationConfig.current
+  let mut usage : VerificationUsage := {}
+  while !(← getGoals).isEmpty do
+    let certGoal ← getMainGoal
+    let certType ← instantiateMVars (← certGoal.getType)
+    -- A strategy that leaves the quantified index in its obligation has not
+    -- reached a certificate boundary yet; allow the enumerating strategies
+    -- below to try instead.
+    if certType.hasFVar || certType.hasMVar then
+      strategyState.restore
+      return .ok none
+    match ← closeCertificateGoalTyped cfg certGoal
+        (tacticName := "finsum_bound auto membership") with
+    | .accepted event =>
+        usage := usage.combine event.toUsage
+    | .rejected =>
+        strategyState.restore
+        return .error <| .rejected
+          `LeanCert.Tactic.finsum_bound_auto_membership none
+    | .failed failure =>
+        strategyState.restore
+        let detail := failure.message "finsum_bound auto membership"
+        match failure with
+        | .malformedCertificateGoal _ | .internalError _ =>
+            return .error <| .internalFailure detail
+        | .kernelFailure _ | .nativeFailure _ =>
+            return .error <| .verificationFailure detail
+
+  unless ← hmemMVar.isAssigned do
+    strategyState.restore
+    return .error <| .internalFailure
+      "membership synthesis discharged its subgoals without assigning the membership proof"
+  setGoals surroundingGoals
+  return .ok (some usage)
+
+/-- Parsed shape of an automatically synthesized membership theorem. -/
+private inductive AutoHmemShape where
+  | range
+  | explicit
+
+/-- Try to auto-prove an hmem metavar using shape-specific structural strategies.
+Works best when the evaluator returns singletons or tight intervals whose
+membership reduces to closed decidable comparisons. -/
+private def tryAutoProveHmemTyped (shape : AutoHmemShape) (hmemMVar : MVarId) :
+    TacticM (Except FinSumFailure VerificationUsage) := do
+  let constantStrategy ← `(tactic|
       intros;
       simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton];
-      refine ⟨?_, ?_⟩ <;> exact_mod_cast (by leancert_verify_cert)))
-    return
-  catch _ => pure ()
-  -- Strategy 2: interval_cases to enumerate k, then per-case native_decide
-  -- Works for k-dependent evaluators on Icc (bounds are concrete literals)
-  setGoals [hmemMVar]
-  try
-    evalTactic (← `(tactic|
+      constructor <;> norm_cast)
+  let rangeStrategy ← `(tactic|
       intro k hlo hhi;
-      interval_cases k <;> {
-        simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton];
-        refine ⟨?_, ?_⟩ <;> exact_mod_cast (by leancert_verify_cert)
-      }))
-    return
-  catch _ => pure ()
-  -- Strategy 3: fin_cases for list path (1 premise: k ∈ S)
-  setGoals [hmemMVar]
-  try
-    evalTactic (← `(tactic|
+      interval_cases k <;>
+      simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton] <;>
+      constructor <;> norm_cast)
+  let explicitStrategy ← `(tactic|
       intro k hk;
-      fin_cases hk <;> {
-        simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton];
-        refine ⟨?_, ?_⟩ <;> exact_mod_cast (by leancert_verify_cert)
-      }))
-    return
-  catch _ => pure ()
-  -- All strategies failed
+      fin_cases hk <;>
+      simp only [IntervalDyadic.mem_def, IntervalDyadic.singleton] <;>
+      constructor <;> norm_cast)
+  let strategies : Array Syntax := match shape with
+    | .range => #[constantStrategy, rangeStrategy]
+    | .explicit => #[constantStrategy, explicitStrategy]
+  for strategy in strategies do
+    match ← tryAutoHmemStrategy hmemMVar strategy with
+    | .ok (some usage) => return .ok usage
+    | .ok none => pure ()
+    | .error failure => return .error failure
   let hmemTy ← hmemMVar.getType
-  throwError "finsum_bound auto: could not auto-prove membership.\n\
-    Expected type: {← ppExpr hmemTy}\n\
-    Provide hmem explicitly: `finsum_bound using evalTerm hmemProof`"
+  return .error <| .unsupported
+    s!"could not auto-prove membership.\nExpected type: {← ppExpr hmemTy}\n\
+      Provide hmem explicitly: `finsum_bound using evalTerm hmemProof`"
 
 /-- Core implementation of `finsum_bound auto` for Icc goals. -/
 private def finSumWitnessAutoIccCore (wGoal : WitnessGoal) (evalTermSyn : Syntax)
@@ -452,13 +496,10 @@ private def finSumWitnessAutoIccCore (wGoal : WitnessGoal) (evalTermSyn : Syntax
 
     -- Auto-prove hmem
     let hmemMVar ← mkFreshExprMVar (some hmemTy) (kind := .syntheticOpaque)
-    let savedGoals ← getGoals
-    try
-      tryAutoProveHmem hmemMVar.mvarId!
-    catch e =>
-      return .error <| .unsupported
-        s!"could not synthesize the witness membership proof: {← e.toMessageData.toString}"
-    setGoals savedGoals
+    let membershipUsage ←
+      match ← tryAutoProveHmemTyped .range hmemMVar.mvarId! with
+      | .ok usage => pure usage
+      | .error failure => return .error failure
 
     let hmemExpr := hmemMVar
 
@@ -517,7 +558,7 @@ private def finSumWitnessAutoIccCore (wGoal : WitnessGoal) (evalTermSyn : Syntax
         enclosure := enclosureRat
         checker := checkerName
         verifier := verifierName
-        verification := event.toUsage
+        verification := membershipUsage.combine event.toUsage
       }
 
 /-- Core implementation of `finsum_bound auto` for arbitrary Finsets (list path). -/
@@ -556,13 +597,10 @@ private def finSumWitnessAutoListCore (wGoal : WitnessGoalList) (evalTermSyn : S
 
     -- Auto-prove hmem
     let hmemMVar ← mkFreshExprMVar (some hmemTy) (kind := .syntheticOpaque)
-    let savedGoals ← getGoals
-    try
-      tryAutoProveHmem hmemMVar.mvarId!
-    catch e =>
-      return .error <| .unsupported
-        s!"could not synthesize the witness membership proof: {← e.toMessageData.toString}"
-    setGoals savedGoals
+    let membershipUsage ←
+      match ← tryAutoProveHmemTyped .explicit hmemMVar.mvarId! with
+      | .ok usage => pure usage
+      | .error failure => return .error failure
 
     let hmemExpr := hmemMVar
 
@@ -619,7 +657,7 @@ private def finSumWitnessAutoListCore (wGoal : WitnessGoalList) (evalTermSyn : S
         enclosure := enclosureRat
         checker := checkerName
         verifier := verifierName
-        verification := event.toUsage
+        verification := membershipUsage.combine event.toUsage
       }
 
 /-- Main dispatch for auto-hmem mode: try Icc path first, then list path. -/

--- a/LeanCert/Tactic/FinSumWitness.lean
+++ b/LeanCert/Tactic/FinSumWitness.lean
@@ -372,11 +372,6 @@ def finSumWitnessCoreTyped (evalTermSyn hmemSyn : Syntax) (prec : Int) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-def finSumWitnessCore (evalTermSyn hmemSyn : Syntax) (prec : Int) : TacticM Unit := do
-  match ← finSumWitnessCoreTyped evalTermSyn hmemSyn prec with
-  | .ok _ => pure ()
-  | .error failure => throwError "finsum_witness: {repr failure}"
-
 /-- Try to auto-prove an hmem metavar using several strategies.
     Works best when the evaluator returns singletons or tight intervals
     where membership reduces to decidable ℚ comparisons. -/
@@ -650,11 +645,6 @@ def finSumWitnessAutoCoreTyped (evalTermSyn : Syntax) (prec : Int) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-def finSumWitnessAutoCore (evalTermSyn : Syntax) (prec : Int) : TacticM Unit := do
-  match ← finSumWitnessAutoCoreTyped evalTermSyn prec with
-  | .ok _ => pure ()
-  | .error failure => throwError "finsum_bound auto: {repr failure}"
-
 /-! ## Main Tactic -/
 
 /-- Prove bounds on finite sums using a witness evaluator.
@@ -670,6 +660,8 @@ elab "finsum_witness" evalTerm:term "using" hmem:term prec:(num)? : tactic => do
   let precision : Int := match prec with
     | some n => -(n.getNat : Int)
     | none => -53
-  finSumWitnessCore evalTerm hmem precision
+  match ← finSumWitnessCoreTyped evalTerm hmem precision with
+  | .ok _ => pure ()
+  | .error failure => throwError "finsum_witness: {repr failure}"
 
 end LeanCert.Tactic

--- a/LeanCert/Tactic/IntervalAuto/Adaptive.lean
+++ b/LeanCert/Tactic/IntervalAuto/Adaptive.lean
@@ -50,10 +50,14 @@ private def proveForallLeAdaptive (goal : MVarId) (intervalInfo : IntervalInfo)
     let savedGoals ← getGoals
     let checkGoal ← mkFreshExprMVar checkTy
     setGoals [checkGoal.mvarId!]
-    try
-      discard <| LeanCert.Tactic.closeCertificateGoal (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal) (tacticName := "interval_bound_adaptive")
-    catch _ =>
-      throwError "interval_bound_adaptive: Adaptive verification failed - bound not tight enough"
+    match ← LeanCert.Tactic.closeCertificateGoalTyped
+        (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
+        (tacticName := "interval_bound_adaptive") with
+    | .accepted _ => pure ()
+    | .rejected =>
+        throwError "interval_bound_adaptive: Adaptive verification failed - bound not tight enough"
+    | .failed failure =>
+        throwError (failure.message "interval_bound_adaptive")
     let checkProof := checkGoal
 
     setGoals savedGoals
@@ -138,10 +142,14 @@ private def proveForallGeAdaptive (goal : MVarId) (intervalInfo : IntervalInfo)
     let savedGoals ← getGoals
     let checkGoal ← mkFreshExprMVar checkTy
     setGoals [checkGoal.mvarId!]
-    try
-      discard <| LeanCert.Tactic.closeCertificateGoal (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal) (tacticName := "interval_bound_adaptive")
-    catch _ =>
-      throwError "interval_bound_adaptive: Adaptive verification failed - bound not tight enough"
+    match ← LeanCert.Tactic.closeCertificateGoalTyped
+        (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
+        (tacticName := "interval_bound_adaptive") with
+    | .accepted _ => pure ()
+    | .rejected =>
+        throwError "interval_bound_adaptive: Adaptive verification failed - bound not tight enough"
+    | .failed failure =>
+        throwError (failure.message "interval_bound_adaptive")
     let checkProof := checkGoal
 
     setGoals savedGoals

--- a/LeanCert/Tactic/IntervalAuto/Bound.lean
+++ b/LeanCert/Tactic/IntervalAuto/Bound.lean
@@ -186,8 +186,11 @@ private def boundCheckerName (isStrict isLower useChecked : Bool) : Name :=
 
 private def closeBoundCertificate (_verifier : Name) (goal : MVarId) :
     TacticM Unit := do
-  discard <| closeCertificateGoalReported (← VerificationConfig.current) goal
-    (tacticName := "certify_bound")
+  match ← closeCertificateGoalTyped (← VerificationConfig.current) goal
+      (tacticName := "certify_bound") with
+  | .accepted _ => pure ()
+  | .rejected => throwError "certify_bound: certificate checker evaluated to false"
+  | .failed failure => throwError (failure.message "certify_bound")
 
 private def closeBoundTransport (goal : MVarId) (proof : Lean.Expr)
     (reified? : Option LeanCert.Meta.ReifyReport := none) :
@@ -247,7 +250,7 @@ private def closeBoundTransport (goal : MVarId) (proof : Lean.Expr)
 /-- Try to prove a forall-bound goal using the Dyadic backend.
     Returns metadata if the entire goal was closed, `none` otherwise.
     Uses the checked Dyadic evaluator for arbitrary expressions. -/
-def tryDyadicBoundReported (goal : MVarId) (reified : LeanCert.Meta.ReifyReport)
+def tryDyadicBoundImpl (goal : MVarId) (reified : LeanCert.Meta.ReifyReport)
     (boundRat : Lean.Expr)
     (intervalInfo : IntervalInfo) (taylorDepth : Nat)
     (isStrict isLower : Bool) :
@@ -310,7 +313,7 @@ private def tryDyadicBoundCompatibility (goal : MVarId)
     (reified : LeanCert.Meta.ReifyReport) (boundRat : Lean.Expr)
     (intervalInfo : IntervalInfo) (taylorDepth : Nat)
     (isStrict isLower : Bool) : TacticM (Option DyadicBoundOutcome) := do
-  match ← tryDyadicBoundReported goal reified boundRat intervalInfo taylorDepth
+  match ← tryDyadicBoundImpl goal reified boundRat intervalInfo taylorDepth
       isStrict isLower with
   | .ok outcome => return outcome
   | .error (.transportFailure detail) =>
@@ -1190,7 +1193,7 @@ def intervalBoundCoreTyped (taylorDepth : Nat) :
         | original.restore
           return .error <| .unsupported (toString func)
             "Dyadic preparation produced no expression"
-      tryDyadicBoundReported normalizedGoal reified boundRat intervalInfo taylorDepth
+      tryDyadicBoundImpl normalizedGoal reified boundRat intervalInfo taylorDepth
         isStrict isLower
   let dyadicResult ←
     match boundGoal with
@@ -1218,25 +1221,6 @@ def intervalBoundCoreTyped (taylorDepth : Nat) :
   | .ok none => pure ()
   original.restore
   intervalBoundRationalCoreTyped taylorDepth
-
-/-- Reporting-aware direct-bound entry point.
-
-The checked Dyadic attempt already returns complete telemetry. If it does not
-close the goal, the original state is restored and the Rational core runs
-without retrying Dyadic. Only the winning branch's observation is returned. -/
-def intervalBoundCoreReported (taylorDepth : Nat) :
-    TacticM IntervalBoundOutcome := do
-  match ← intervalBoundCoreTyped taylorDepth with
-  | .ok outcome => return outcome
-  | .error (.unsupported expression detail) =>
-      throwError "reported direct bound: unsupported expression {expression}:\n{detail}"
-  | .error (.inconclusive detail) =>
-      throwError "reported direct bound: {detail}"
-  | .error (.transportFailure detail) =>
-      throwError "reported direct bound: proof transport failed:\n{detail}"
-  | .error (.internalFailure detail) =>
-      throwError "reported direct bound: certificate verification failed:\n{detail}"
-
 
 /-! ## Tactic Syntax -/
 

--- a/LeanCert/Tactic/IntervalAuto/Multivariate.lean
+++ b/LeanCert/Tactic/IntervalAuto/Multivariate.lean
@@ -379,27 +379,6 @@ where
         return .error <| .transportFailure (← e.toMessageData.toString)
       return .ok event
 
-/-- Reporting compatibility wrapper preserving the historical throwing API. -/
-unsafe def multivariateBoundCoreReported (maxIters : Nat) (tolerance : ℚ)
-    (useMonotonicity : Bool) (taylorDepth : Nat) :
-    TacticM MultivariateBoundOutcome := do
-  match ← multivariateBoundCoreTyped maxIters tolerance useMonotonicity
-      taylorDepth with
-  | .ok outcome => return outcome
-  | .error (.unsupported expression detail) =>
-      throwError "multivariate_bound: unsupported expression {expression}:\n{detail}"
-  | .error (.rejected detail) =>
-      throwError "multivariate_bound: certificate rejected:\n{detail}"
-  | .error (.transportFailure detail) =>
-      throwError "multivariate_bound: proof transport failed:\n{detail}"
-  | .error (.internalFailure detail) =>
-      throwError "multivariate_bound: internal verification failure:\n{detail}"
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-unsafe def multivariateBoundCore (maxIters : Nat) (tolerance : ℚ)
-    (useMonotonicity : Bool) (taylorDepth : Nat) : TacticM Unit := do
-  discard <| multivariateBoundCoreReported maxIters tolerance useMonotonicity taylorDepth
-
 /-- The multivariate_bound tactic.
 
     Automatically proves bounds on multivariate expressions using global optimization.
@@ -424,6 +403,15 @@ unsafe def elabMultivariateBound : Tactic := fun stx => do
     let maxIters := match iters with
       | some n => n.toNat
       | none => 1000
-    multivariateBoundCore maxIters (1/1000) false 10
+    match ← multivariateBoundCoreTyped maxIters (1/1000) false 10 with
+    | .ok _ => pure ()
+    | .error (.unsupported expression detail) =>
+        throwError "multivariate_bound: unsupported expression {expression}:\n{detail}"
+    | .error (.rejected detail) =>
+        throwError "multivariate_bound: certificate rejected:\n{detail}"
+    | .error (.transportFailure detail) =>
+        throwError "multivariate_bound: proof transport failed:\n{detail}"
+    | .error (.internalFailure detail) =>
+        throwError "multivariate_bound: internal verification failure:\n{detail}"
 
 end LeanCert.Tactic.Auto

--- a/LeanCert/Tactic/IntervalAuto/OptBound.lean
+++ b/LeanCert/Tactic/IntervalAuto/OptBound.lean
@@ -173,25 +173,6 @@ where
         let proof ← mkSupportedProof expr
         goal.assign proof
 
-/-- Reporting compatibility wrapper preserving the historical throwing API. -/
-unsafe def optBoundCoreReported (maxIters : Nat) (useMonotonicity : Bool)
-    (taylorDepth : Nat) : TacticM OptBoundOutcome := do
-  match ← optBoundCoreTyped maxIters useMonotonicity taylorDepth with
-  | .ok outcome => return outcome
-  | .error (.unsupported expression detail) =>
-      throwError "opt_bound: unsupported goal {expression}:\n{detail}"
-  | .error (.rejected detail) =>
-      throwError "opt_bound: certificate rejected:\n{detail}"
-  | .error (.transportFailure detail) =>
-      throwError "opt_bound: proof transport failed:\n{detail}"
-  | .error (.internalFailure detail) =>
-      throwError "opt_bound: internal verification failure:\n{detail}"
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-unsafe def optBoundCore (maxIters : Nat) (useMonotonicity : Bool)
-    (taylorDepth : Nat) : TacticM Unit := do
-  discard <| optBoundCoreReported maxIters useMonotonicity taylorDepth
-
 /-- The opt_bound tactic.
 
     Automatically proves global bounds on expressions over boxes using
@@ -220,6 +201,15 @@ unsafe def elabOptBound : Tactic := fun stx => do
       | some n => n.toNat
       | none => 1000
     let useMonotonicity := monoOpt.isSome
-    optBoundCore maxIters useMonotonicity 10
+    match ← optBoundCoreTyped maxIters useMonotonicity 10 with
+    | .ok _ => pure ()
+    | .error (.unsupported expression detail) =>
+        throwError "opt_bound: unsupported goal {expression}:\n{detail}"
+    | .error (.rejected detail) =>
+        throwError "opt_bound: certificate rejected:\n{detail}"
+    | .error (.transportFailure detail) =>
+        throwError "opt_bound: proof transport failed:\n{detail}"
+    | .error (.internalFailure detail) =>
+        throwError "opt_bound: internal verification failure:\n{detail}"
 
 end LeanCert.Tactic.Auto

--- a/LeanCert/Tactic/IntervalAuto/PointIneq.lean
+++ b/LeanCert/Tactic/IntervalAuto/PointIneq.lean
@@ -50,7 +50,7 @@ inductive PointInequalityFailure where
 def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
     (taylorDepth : Nat) :
     TacticM (Except PointInequalityFailure PointInequalityOutcome) := do
-  trace[interval_decide] "proveClosedExpressionBound: Starting with goal {goalType}"
+  trace[interval_decide] "typed point bound: starting with goal {goalType}"
   goal.withContext do
     -- Parse the inequality
     let some (lhs, rhs, isStrict, isReversedOrig) ← parsePointIneq goalType
@@ -454,27 +454,20 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
     return .error <| .transportFailure
       "certified Rational proof did not close the original point inequality"
 
-/-- Reporting-aware compatibility entry point. Expected typed failures retain
-the historical exception behavior for direct tactic callers. -/
-def proveClosedExpressionBoundReported (goal : MVarId) (goalType : Lean.Expr)
-    (taylorDepth : Nat) : TacticM PointInequalityOutcome := do
-  match ← proveClosedExpressionBoundTyped goal goalType taylorDepth with
-  | .ok outcome => return outcome
-  | .error (.unsupported expression detail) =>
-      throwError "proveClosedExpressionBound: unsupported expression {expression}:\n{detail}"
-  | .error (.rejected detail) =>
-      throwError "proveClosedExpressionBound: certificate rejected:\n{detail}"
-  | .error (.inconclusive detail) =>
-      throwError "proveClosedExpressionBound: inconclusive:\n{detail}"
-  | .error (.transportFailure detail) =>
-      throwError "proveClosedExpressionBound: proof transport failed:\n{detail}"
-  | .error (.internalFailure detail) =>
-      throwError "proveClosedExpressionBound: certificate verification failed:\n{detail}"
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-def proveClosedExpressionBound (goal : MVarId) (goalType : Lean.Expr)
+private def proveClosedExpressionBoundOrThrow (goal : MVarId) (goalType : Lean.Expr)
     (taylorDepth : Nat) : TacticM Unit := do
-  discard <| proveClosedExpressionBoundReported goal goalType taylorDepth
+  match ← proveClosedExpressionBoundTyped goal goalType taylorDepth with
+  | .ok _ => pure ()
+  | .error (.unsupported expression detail) =>
+      throwError "interval_decide: unsupported expression {expression}:\n{detail}"
+  | .error (.rejected detail) =>
+      throwError "interval_decide: certificate rejected:\n{detail}"
+  | .error (.inconclusive detail) =>
+      throwError "interval_decide: inconclusive:\n{detail}"
+  | .error (.transportFailure detail) =>
+      throwError "interval_decide: proof transport failed:\n{detail}"
+  | .error (.internalFailure detail) =>
+      throwError "interval_decide: certificate verification failed:\n{detail}"
 
 /-- The interval_decide tactic implementation. -/
 def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
@@ -521,7 +514,7 @@ def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
     if !hasFreeVars then
       trace[interval_decide] "No free variables, trying closed expression path"
       try
-        proveClosedExpressionBound goal goalType taylorDepth
+        proveClosedExpressionBoundOrThrow goal goalType taylorDepth
         return
       catch e =>
         trace[interval_decide] "Closed expression path on original goal failed: {e.toMessageData}"
@@ -540,7 +533,7 @@ def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
       catch _ => pure ()
 
       try
-        proveClosedExpressionBound currentGoal currentGoalType taylorDepth
+        proveClosedExpressionBoundOrThrow currentGoal currentGoalType taylorDepth
         return
       catch _ => pure ()
 

--- a/LeanCert/Tactic/IntervalAuto/ProveCommon.lean
+++ b/LeanCert/Tactic/IntervalAuto/ProveCommon.lean
@@ -391,14 +391,14 @@ def certCheckSucceeds (checkFn : Lean.Expr) : TacticM Bool := do
   let certGoal ← mkFreshExprMVar certTy
   let certGoalId := certGoal.mvarId!
   let savedState ← saveState
-  try
-    setGoals [certGoalId]
-    discard <| LeanCert.Tactic.closeCertificateGoal (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal) (tacticName := "leancert")
-    restoreState savedState
-    return true
-  catch _ =>
-    restoreState savedState
-    return false
+  setGoals [certGoalId]
+  let result ← LeanCert.Tactic.closeCertificateGoalTyped
+    (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
+    (tacticName := "leancert")
+  restoreState savedState
+  return match result with
+    | .accepted _ => true
+    | .rejected | .failed _ => false
 
 /-- Extract bounds from IntervalInfo for subdivision -/
 def getSubdivBounds (intervalInfo : IntervalInfo) :

--- a/LeanCert/Tactic/IntervalAuto/RootBound.lean
+++ b/LeanCert/Tactic/IntervalAuto/RootBound.lean
@@ -196,18 +196,6 @@ def rootBoundCoreTyped (taylorDepth : Nat) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Reporting compatibility entry point preserving the historical throwing API. -/
-def rootBoundCoreReported (taylorDepth : Nat) : TacticM RootBoundOutcome := do
-  match ← rootBoundCoreTyped taylorDepth with
-  | .ok outcome => return outcome
-  | .error failure => throwRootBoundFailure failure
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-def rootBoundCore (taylorDepth : Nat) : TacticM Unit := do
-  match ← rootBoundCoreTyped taylorDepth with
-  | .ok _ => pure ()
-  | .error failure => throwRootBoundFailure failure
-
 /-- The root_bound tactic.
 
     Automatically proves root-related properties using interval arithmetic.
@@ -224,6 +212,8 @@ elab "root_bound" depth:(num)? t:(leancertTrustItem)? : tactic => do
     let taylorDepth := match depth with
       | some n => n.getNat
       | none => 10
-    rootBoundCore taylorDepth
+    match ← rootBoundCoreTyped taylorDepth with
+    | .ok _ => pure ()
+    | .error failure => throwRootBoundFailure failure
 
 end LeanCert.Tactic.Auto

--- a/LeanCert/Tactic/IntervalAuto/Subdiv.lean
+++ b/LeanCert/Tactic/IntervalAuto/Subdiv.lean
@@ -406,20 +406,6 @@ unsafe def intervalBoundSubdivCoreTyped
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Reporting compatibility wrapper preserving the historical throwing API. -/
-unsafe def intervalBoundSubdivWithDepthReported
-    (depth : Option Nat) (maxSubdiv : Nat) : TacticM SubdivisionOutcome := do
-  match ← intervalBoundSubdivCoreTyped depth maxSubdiv with
-  | .ok outcome => return outcome
-  | .error failure => throwSubdivisionFailure failure
-
-/-- Compatibility core retaining the historical `TacticM Unit` shape. -/
-unsafe def intervalBoundSubdivWithDepth (depth : Option Nat) (maxSubdiv : Nat) :
-    TacticM Unit := do
-  match ← intervalBoundSubdivCoreTyped depth maxSubdiv with
-  | .ok _ => pure ()
-  | .error failure => throwSubdivisionFailure failure
-
 /-- The interval_bound_subdiv tactic. -/
 syntax (name := intervalBoundSubdivTac) "interval_bound_subdiv" (num)? (num)?
   (leancertTrustItem)? : tactic
@@ -435,6 +421,8 @@ unsafe def elabIntervalBoundSubdiv : Tactic := fun stx => do
       | some n => n.toNat
       | none => 3
     let depth := depthSyntax.map (·.toNat)
-    intervalBoundSubdivWithDepth depth maxSubdiv
+    match ← intervalBoundSubdivCoreTyped depth maxSubdiv with
+    | .ok _ => pure ()
+    | .error failure => throwSubdivisionFailure failure
 
 end LeanCert.Tactic.Auto

--- a/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
+++ b/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
@@ -151,13 +151,11 @@ private def renderBackend :
     Option NumericalBackend × BackendPolicy → Option String
   | (some backend, _) => some (numericalBackend backend)
   | (none, .fixed backend) =>
-      some s!"Configured backend: {numericalBackend backend}\n  Execution was not \
-        observed by the legacy solver adapter."
+      some s!"Configured backend: {numericalBackend backend}"
   | (none, .policy description) =>
-      some s!"Policy: {description}\n  The legacy adapter does not yet expose \
-        the winning backend."
+      some s!"Policy: {description}"
   | (none, .notApplicable) => none
-  | (none, .unknown) => some "not observed by the legacy solver adapter"
+  | (none, .unknown) => none
 
 private def verificationMode : VerificationMode → String
   | .native => "native"
@@ -173,7 +171,7 @@ private def renderVerification (report : SolverReport) : Option String :=
     | .exactIntegral =>
         some "kernel proof construction; trust selection not applicable"
     | _ =>
-        some s!"requested {requested}; actual route not observed by the legacy adapter"
+        some s!"requested {requested}; no certificate checks retained"
   else
     let used :=
       if usage.kernelChecks > 0 && usage.nativeChecks > 0 then
@@ -327,10 +325,10 @@ def successReport (report : SolverReport) : String :=
     | some value => s!"\n\nCertificate verification:\n  {value}"
     | none => ""
   let checker :=
-    (report.execution.checker <|> plan.checker).map
+    report.execution.checker.map
       (fun value => s!"\nChecker: {value}") |>.getD ""
   let verifier :=
-    (report.execution.verifier <|> plan.verifier).map
+    report.execution.verifier.map
       (fun value => s!"\nVerifier: {value}") |>.getD ""
   let optimization := renderOptimization report.execution.optimization
   let subdivision := renderSubdivision report.execution.subdivision

--- a/LeanCert/Tactic/LeanCert/Integral.lean
+++ b/LeanCert/Tactic/LeanCert/Integral.lean
@@ -372,16 +372,6 @@ partial def integralExactCoreTyped : TacticM (Except IntegralFailure (Array Inte
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Throwing compatibility wrapper for the historical reported API. -/
-partial def integralExactCoreReported : TacticM (Array IntegralOutcome) := do
-  match ← integralExactCoreTyped with
-  | .ok outcomes => return outcomes
-  | .error failure => throwError "integral_exact: {repr failure}"
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-partial def integralExactCore : TacticM Unit := do
-  discard <| integralExactCoreReported
-
 /-- Checked partition-search strategy used by the semantic router. -/
 partial def integralSearchCoreTyped (startN maxN : Nat) :
     TacticM (Except IntegralFailure (Array IntegralOutcome)) := do
@@ -416,20 +406,12 @@ partial def integralSearchCoreTyped (startN maxN : Nat) :
     original.restore
     return .error <| .internalFailure (← e.toMessageData.toString)
 
-/-- Throwing compatibility wrapper for the historical reported API. -/
-partial def integralSearchCoreReported (startN maxN : Nat) :
-    TacticM (Array IntegralOutcome) := do
-  match ← integralSearchCoreTyped startN maxN with
-  | .ok outcomes => return outcomes
-  | .error failure => throwError "integral_search: {repr failure}"
-
-/-- Compatibility wrapper retaining the historical `TacticM Unit` API. -/
-partial def integralSearchCore (startN maxN : Nat) : TacticM Unit := do
-  discard <| integralSearchCoreReported startN maxN
-
 syntax (name := integralExactTac) "integral_exact" : tactic
 
 @[tactic integralExactTac]
-unsafe def elabIntegralExact : Tactic := fun _ => integralExactCore
+unsafe def elabIntegralExact : Tactic := fun _ => do
+  match ← integralExactCoreTyped with
+  | .ok _ => pure ()
+  | .error failure => throwError "integral_exact: {repr failure}"
 
 end LeanCert.Tactic

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -613,15 +613,16 @@ private unsafe def multivariateAttemptTyped (maxIterations : Nat)
       return .error <| .internalError
         `LeanCert.Tactic.Auto.multivariate_bound detail
 
-/-- Run an exact, non-certificate tactic as an expected portfolio attempt.
-Failure means that the tactic did not recognize or close the proposition. -/
-private def exactTacticAttempt (detail : String) (tactic : TacticM Unit) :
+/-- Run an exact, non-certificate tactic through the typed solver boundary.
+
+Ordinary tactical inability is represented by retained proof obligations and
+classified as inconclusive by `proveWithTypedSolver`. Unexpected exceptions
+must escape this helper so the same boundary classifies them as terminal
+internal errors. -/
+def exactTacticAttemptTyped (tactic : TacticM Unit) :
     TacticM (Except AttemptFailure SolverExecution) := do
-  try
-    tactic
-    return .ok {}
-  catch _ =>
-    return .error <| .inconclusive { detail }
+  tactic
+  return .ok {}
 
 private def certificateCheckAttemptTyped :
     TacticM (Except AttemptFailure SolverExecution) := do
@@ -651,8 +652,7 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
   | .pointInequality => #[
       { report := report intent "exact normalization" cfg mode .notApplicable
           (some (suggestion "norm_num")) (strategyId := .exactNormalization),
-        solve := exactTacticAttempt
-          "Exact normalization did not close the prepared proposition."
+        solve := exactTacticAttemptTyped
           (do evalTactic (← `(tactic| norm_num))) },
       { report := report intent s!"direct point enclosure (Taylor depth {d})" cfg mode
           (.policy "checked interval tactic portfolio")
@@ -1150,8 +1150,7 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
   let normalizationSpec : SolverSpec := {
     report := normalizationReport
     cost := 0
-    solve := exactTacticAttempt
-      "Exact normalization did not close the prepared proposition."
+    solve := exactTacticAttemptTyped
       (do evalTactic (← `(tactic| norm_num)))
   }
   match ← trySolver normalizationSpec with
@@ -1225,8 +1224,7 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
           cfg verificationMode .notApplicable
           (strategyId := .exactNormalization)
         cost := 0
-        solve := exactTacticAttempt
-          "Empty-domain normalization did not close the prepared proposition."
+        solve := exactTacticAttemptTyped
           (do evalTactic (← `(tactic| simp [Set.mem_Icc])))
       }
       match ← trySolver vacuitySpec
@@ -1326,21 +1324,24 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
         let exactSpec : SolverSpec := {
           report := exactReport
           cost := 0
-          solve := exactTacticAttempt
-            "The exact rational candidate did not prove the root proposition." do
+          solve := exactTacticAttemptTyped do
             if spec.kind == .exists then
               evalTactic (← `(tactic|
-                refine ⟨$candidateSyntax, ?_, ?_⟩ <;>
-                  norm_num [Set.mem_Icc]))
+                first
+                | (refine ⟨$candidateSyntax, ?_, ?_⟩ <;>
+                    norm_num [Set.mem_Icc])
+                | skip))
             else
               evalTactic (← `(tactic|
-                refine ⟨$candidateSyntax,
-                  (by constructor <;> norm_num [Set.mem_Icc]), ?_⟩;
-                intro y hy;
-                rcases hy with ⟨hyMem, hyRoot⟩;
-                simp only [Set.mem_Icc] at hyMem;
-                norm_num at hyRoot ⊢;
-                nlinarith))
+                first
+                | (refine ⟨$candidateSyntax,
+                    (by constructor <;> norm_num [Set.mem_Icc]), ?_⟩;
+                   intro y hy;
+                   rcases hy with ⟨hyMem, hyRoot⟩;
+                   simp only [Set.mem_Icc] at hyMem;
+                   norm_num at hyRoot ⊢;
+                   nlinarith)
+                | skip))
         }
         match ← trySolver exactSpec with
         | .proved artifact => return ← commitArtifact artifact
@@ -1373,8 +1374,7 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
       let evtSpec : SolverSpec := {
         report := evtReport
         cost := 0
-        solve := exactTacticAttempt
-          "The compact extreme-value theorem route could not construct the proof." do
+        solve := exactTacticAttemptTyped do
           evalTactic (← `(tactic|
             suffices hnormalized : $canonicalSyntax by
               simpa only [and_comm] using hnormalized))
@@ -1429,8 +1429,7 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
       let equalitySpec : SolverSpec := {
         report := equalityReport
         cost := 0
-        solve := exactTacticAttempt
-          "Exact finite-sum expansion did not close the proposition."
+        solve := exactTacticAttemptTyped
           (do evalTactic (← `(tactic| finsum_expand; norm_num)))
       }
       match ← trySolver equalitySpec with

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -34,22 +34,11 @@ open LeanCert.Engine.Search
 
 initialize registerTraceClass `LeanCert.router
 
-/-- Transitional description of one router strategy. Exposed so the adapter
-contract can be regression-tested; it is not part of the stable tactic API. -/
+/-- Description of one typed router strategy. Exposed so the protocol contract
+can be regression-tested; it is not part of the stable tactic API. -/
 structure SolverSpec where
   report : SolverPlan
-  solve : TacticM Unit
-  /-- Migrated cores can return execution facts. Legacy cores leave this empty
-  and are reported as policy/unknown rather than fabricating telemetry. -/
-  solveReported : Option (TacticM SolverExecution) := none
-  /-- Recursive routes can return a typed public failure without converting it
-  into an implementation exception inside speculative execution. -/
-  solveReportedResult :
-    Option (TacticM (Except AttemptFailure SolverExecution)) := none
-  /-- Existing engine adapters still signal ordinary numerical rejection by
-  throwing. They remain explicitly quarantined behind the compatibility
-  exception policy until their PR2 migration returns typed outcomes directly. -/
-  legacyExceptionAdapter : Bool := false
+  solve : TacticM (Except AttemptFailure SolverExecution)
   cost : Nat := 1
   /-- Comparisons accepted by this solver. `none` means the solver accepts the
   full comparison language for its intent. -/
@@ -80,7 +69,7 @@ private def report (intent : GoalIntent) (strategy : String)
     (backendPolicy : BackendPolicy := .unknown)
     (dedicatedProof : Option ProofSuggestion := none)
     (strategyDetail : Option String := none)
-    (strategyId : StrategyId := .legacy) : SolverPlan :=
+    (strategyId : StrategyId) : SolverPlan :=
   let dedicatedProof := dedicatedProof.map fun proof =>
     if proof.tactic == "norm_num" || proof.tactic == "integral_exact" then proof
     else {
@@ -99,14 +88,6 @@ private def report (intent : GoalIntent) (strategy : String)
     backendPolicy
     verificationRequested := mode
   }
-
-private def numSyntax (n : Nat) : TSyntax `num :=
-  ⟨Syntax.mkNumLit (toString n)⟩
-
-private def subdivisionAttempt (cfg : LeanCertConfig) : TacticM Unit := do
-  let depth := numSyntax cfg.taylorDepth
-  let subdivisions := numSyntax cfg.subdivisions
-  evalTactic (← `(tactic| interval_bound_subdiv $depth:num $subdivisions:num))
 
 private def subdivisionExecution
     (outcome : Auto.SubdivisionOutcome) : SolverExecution := {
@@ -154,10 +135,6 @@ private unsafe def subdivisionAttemptTyped (cfg : LeanCertConfig) :
       (some cfg.taylorDepth) cfg.subdivisions with
   | .ok outcome => return .ok (subdivisionExecution outcome)
   | .error failure => return .error (subdivisionFailure failure)
-
-private def pointAttempt (depth : Nat) : TacticM Unit := do
-  let depth := numSyntax depth
-  evalTactic (← `(tactic| interval_auto $depth:num))
 
 private def pointExecution (outcome : Auto.PointInequalityOutcome) :
     SolverExecution := Id.run do
@@ -636,6 +613,34 @@ private unsafe def multivariateAttemptTyped (maxIterations : Nat)
       return .error <| .internalError
         `LeanCert.Tactic.Auto.multivariate_bound detail
 
+/-- Run an exact, non-certificate tactic as an expected portfolio attempt.
+Failure means that the tactic did not recognize or close the proposition. -/
+private def exactTacticAttempt (detail : String) (tactic : TacticM Unit) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  try
+    tactic
+    return .ok {}
+  catch _ =>
+    return .error <| .inconclusive { detail }
+
+private def certificateCheckAttemptTyped :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  let cfg ← LeanCert.Tactic.VerificationConfig.current
+  let goal ← getMainGoal
+  match ← LeanCert.Tactic.closeCertificateGoalTyped cfg goal
+      (tacticName := "leancert") with
+  | .accepted event =>
+      return .ok {
+        verificationUsage := Solver.VerificationUsage.ofEvents event.toUsage
+      }
+  | .rejected =>
+      return .error <| .rejected {
+        detail := "The closed Boolean certificate evaluated to false."
+      }
+  | .failed failure =>
+      return .error <| .internalError `LeanCert.Tactic.leancert
+        (failure.message "leancert")
+
 /-- The deterministic strategy portfolio for a recognized goal intent. -/
 private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
     (mode : VerificationMode) : Array SolverSpec :=
@@ -646,36 +651,37 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
   | .pointInequality => #[
       { report := report intent "exact normalization" cfg mode .notApplicable
           (some (suggestion "norm_num")) (strategyId := .exactNormalization),
-        solve := do evalTactic (← `(tactic| norm_num)) },
+        solve := exactTacticAttempt
+          "Exact normalization did not close the prepared proposition."
+          (do evalTactic (← `(tactic| norm_num))) },
       { report := report intent s!"direct point enclosure (Taylor depth {d})" cfg mode
           (.policy "checked interval tactic portfolio")
-          (some (suggestion "interval_auto" #[toString d])),
-        solve := pointAttempt d
-        solveReportedResult := some (pointAttemptTyped d) },
+          (some (suggestion "interval_auto" #[toString d]))
+          (strategyId := .pointEnclosure),
+        solve := pointAttemptTyped d },
       { report := report intent s!"direct point enclosure (Taylor depth {d2})" cfg mode
           (.policy "checked interval tactic portfolio")
-          (some (suggestion "interval_auto" #[toString d2])),
-        solve := pointAttempt d2
-        solveReportedResult := some (pointAttemptTyped d2) }]
+          (some (suggestion "interval_auto" #[toString d2]))
+          (strategyId := .pointEnclosure),
+        solve := pointAttemptTyped d2 }]
   | .intervalBound => #[
       { report := report intent s!"direct interval enclosure (Taylor depth {d})" cfg mode
           (.policy "Dyadic-first, then checked Rational fallback")
-          (some (suggestion "certify_bound" #[toString d])),
-        solve := Auto.intervalBoundCore d
-        solveReportedResult := some (directBoundAttemptTyped d) },
+          (some (suggestion "certify_bound" #[toString d]))
+          (strategyId := .intervalEnclosure),
+        solve := directBoundAttemptTyped d },
       { report := report intent s!"direct interval enclosure (Taylor depth {d2})" cfg mode
           (.policy "Dyadic-first, then checked Rational fallback")
-          (some (suggestion "certify_bound" #[toString d2])),
-        solve := Auto.intervalBoundCore d2
-        solveReportedResult := some (directBoundAttemptTyped d2) },
+          (some (suggestion "certify_bound" #[toString d2]))
+          (strategyId := .intervalEnclosure),
+        solve := directBoundAttemptTyped d2 },
       { report := report intent "recursive interval subdivision" cfg mode
           (.fixed .rationalInterval)
           (some (suggestion "interval_bound_subdiv"
             #[toString d, toString cfg.subdivisions]))
           (some s!"Taylor depth {d}; maximum recursive depth {cfg.subdivisions}")
           .subdivision,
-        solve := subdivisionAttempt cfg
-        solveReportedResult := some (subdivisionAttemptTyped cfg) },
+        solve := subdivisionAttemptTyped cfg },
       { report := report intent
           (if cfg.useMonotonicity then s!"opt_bound {cfg.maxIterations} mono"
            else s!"opt_bound {cfg.maxIterations}") cfg mode
@@ -686,9 +692,7 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
                else #[toString cfg.maxIterations]))
            else none)
           (strategyId := .globalOptimization),
-        solve := Auto.optBoundCore cfg.maxIterations cfg.useMonotonicity d
-        solveReportedResult := some
-          (optimizationAttemptTyped cfg.maxIterations cfg.useMonotonicity d)
+        solve := optimizationAttemptTyped cfg.maxIterations cfg.useMonotonicity d
         cost := 3 }]
   | .multivariateBound => #[
       { report := report intent s!"multivariate_bound {cfg.maxIterations}"
@@ -696,167 +700,146 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
           (if !cfg.useMonotonicity && d == 10 then
             some (suggestion "multivariate_bound" #[toString cfg.maxIterations])
            else none)
-          (strategyId := .globalOptimization),
-        solve := Auto.multivariateBoundCore cfg.maxIterations (1 / 1000)
+          (strategyId := .multivariateOptimization),
+        solve := multivariateAttemptTyped cfg.maxIterations (1 / 1000)
           cfg.useMonotonicity d
-        solveReportedResult := some <|
-          multivariateAttemptTyped cfg.maxIterations (1 / 1000)
-            cfg.useMonotonicity d
         cost := 3 },
       { report := report intent s!"multivariate_bound {2 * cfg.maxIterations}"
           cfg mode (.policy "checked global-optimization certificate")
-          none (strategyId := .globalOptimization),
-        solve := Auto.multivariateBoundCore (2 * cfg.maxIterations) (1 / 10000)
+          none (strategyId := .multivariateOptimization),
+        solve := multivariateAttemptTyped (2 * cfg.maxIterations) (1 / 10000)
           cfg.useMonotonicity d2
-        solveReportedResult := some <|
-          multivariateAttemptTyped (2 * cfg.maxIterations) (1 / 10000)
-            cfg.useMonotonicity d2
         cost := 4 }]
   | .rootExists => #[
       { report := report intent "endpoint sign-change certificate" cfg mode
           (.policy "checked root certificate arithmetic")
-          (some (suggestion "interval_roots" #[toString d])),
-        solve := intervalRootsCore d
-        solveReportedResult := some (rootExistsAttemptTyped d) },
+          (some (suggestion "interval_roots" #[toString d]))
+          (strategyId := .rootExistence),
+        solve := rootExistsAttemptTyped d },
       { report := report intent "endpoint sign-change certificate" cfg mode
           (.policy "checked root certificate arithmetic")
-          (some (suggestion "interval_roots" #[toString d2])),
-        solve := intervalRootsCore d2
-        solveReportedResult := some (rootExistsAttemptTyped d2) },
+          (some (suggestion "interval_roots" #[toString d2]))
+          (strategyId := .rootExistence),
+        solve := rootExistsAttemptTyped d2 },
       { report := report intent "endpoint sign-change certificate" cfg mode
           (.policy "checked root certificate arithmetic")
-          (some (suggestion "interval_roots" #[toString d3])),
-        solve := intervalRootsCore d3
-        solveReportedResult := some (rootExistsAttemptTyped d3) }]
+          (some (suggestion "interval_roots" #[toString d3]))
+          (strategyId := .rootExistence),
+        solve := rootExistsAttemptTyped d3 }]
   | .uniqueRoot => #[
       { report := report intent "interval Newton contraction" cfg mode
           (.policy "checked Newton certificate arithmetic")
-          (some (suggestion "interval_unique_root" #[toString d])),
-        solve := intervalUniqueRootCore d
-        solveReportedResult := some (uniqueRootAttemptTyped d) },
+          (some (suggestion "interval_unique_root" #[toString d]))
+          (strategyId := .rootUniqueness),
+        solve := uniqueRootAttemptTyped d },
       { report := report intent "interval Newton contraction" cfg mode
           (.policy "checked Newton certificate arithmetic")
-          (some (suggestion "interval_unique_root" #[toString d2])),
-        solve := intervalUniqueRootCore d2
-        solveReportedResult := some (uniqueRootAttemptTyped d2) },
+          (some (suggestion "interval_unique_root" #[toString d2]))
+          (strategyId := .rootUniqueness),
+        solve := uniqueRootAttemptTyped d2 },
       { report := report intent "interval Newton contraction" cfg mode
           (.policy "checked Newton certificate arithmetic")
-          (some (suggestion "interval_unique_root" #[toString d3])),
-        solve := intervalUniqueRootCore d3
-        solveReportedResult := some (uniqueRootAttemptTyped d3) }]
+          (some (suggestion "interval_unique_root" #[toString d3]))
+          (strategyId := .rootUniqueness),
+        solve := uniqueRootAttemptTyped d3 }]
   | .noRoot => #[
       { report := report intent "zero-exclusion enclosure" cfg mode
           (.policy "checked interval tactic portfolio")
-          (some (suggestion "root_bound" #[toString d])),
-        solve := Auto.rootBoundCore d
-        solveReportedResult := some (noRootAttemptTyped d) },
+          (some (suggestion "root_bound" #[toString d]))
+          (strategyId := .rootExclusion),
+        solve := noRootAttemptTyped d },
       { report := report intent "zero-exclusion enclosure" cfg mode
           (.policy "checked interval tactic portfolio")
-          (some (suggestion "root_bound" #[toString d2])),
-        solve := Auto.rootBoundCore d2
-        solveReportedResult := some (noRootAttemptTyped d2) },
+          (some (suggestion "root_bound" #[toString d2]))
+          (strategyId := .rootExclusion),
+        solve := noRootAttemptTyped d2 },
       { report := report intent "zero-exclusion enclosure" cfg mode
           (.policy "checked interval tactic portfolio")
-          (some (suggestion "root_bound" #[toString d3])),
-        solve := Auto.rootBoundCore d3
-        solveReportedResult := some (noRootAttemptTyped d3) }]
+          (some (suggestion "root_bound" #[toString d3]))
+          (strategyId := .rootExclusion),
+        solve := noRootAttemptTyped d3 }]
   | .existentialMinimum => #[
       { report := report intent "guided lower-bound discovery and certification" cfg mode
           (.policy "guided optimization followed by checked interval certification")
           (some (suggestion "interval_minimize" #[toString d]))
-        solve := intervalMinimizeCore d
-        solveReportedResult := some (minimizeAttemptTyped d) },
+          (strategyId := .globalOptimization)
+        solve := minimizeAttemptTyped d },
       { report := report intent "multivariate lower-bound discovery and certification" cfg mode
           (.policy "guided Rational optimization followed by checked multivariate certification")
           (some (suggestion "interval_minimize_mv" #[toString d]))
-        solve := intervalMinimizeMvCore d
-        solveReportedResult := some (minimizeMvAttemptTyped d) },
+          (strategyId := .multivariateOptimization)
+        solve := minimizeMvAttemptTyped d },
       { report := report intent "guided lower-bound discovery and certification" cfg mode
           (.policy "guided optimization followed by checked interval certification")
           (some (suggestion "interval_minimize" #[toString d2]))
-        solve := intervalMinimizeCore d2
-        solveReportedResult := some (minimizeAttemptTyped d2) }]
+          (strategyId := .globalOptimization)
+        solve := minimizeAttemptTyped d2 }]
   | .existentialMaximum => #[
       { report := report intent "guided upper-bound discovery and certification" cfg mode
           (.policy "guided optimization followed by checked interval certification")
           (some (suggestion "interval_maximize" #[toString d]))
-        solve := intervalMaximizeCore d
-        solveReportedResult := some (maximizeAttemptTyped d) },
+          (strategyId := .globalOptimization)
+        solve := maximizeAttemptTyped d },
       { report := report intent "multivariate upper-bound discovery and certification" cfg mode
           (.policy "guided Rational optimization followed by checked multivariate certification")
           (some (suggestion "interval_maximize_mv" #[toString d]))
-        solve := intervalMaximizeMvCore d
-        solveReportedResult := some (maximizeMvAttemptTyped d) },
+          (strategyId := .multivariateOptimization)
+        solve := maximizeMvAttemptTyped d },
       { report := report intent "guided upper-bound discovery and certification" cfg mode
           (.policy "guided optimization followed by checked interval certification")
           (some (suggestion "interval_maximize" #[toString d2]))
-        solve := intervalMaximizeCore d2
-        solveReportedResult := some (maximizeAttemptTyped d2) }]
+          (strategyId := .globalOptimization)
+        solve := maximizeAttemptTyped d2 }]
   | .argmin => #[
       { report := report intent "attained minimum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
           (some (suggestion "interval_argmin" #[toString d]))
-        solve := intervalArgminCore d
-        solveReportedResult := some (argminAttemptTyped d) },
+          (strategyId := .attainedExtremum)
+        solve := argminAttemptTyped d },
       { report := report intent "attained minimum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
           (some (suggestion "interval_argmin" #[toString d2]))
-        solve := intervalArgminCore d2
-        solveReportedResult := some (argminAttemptTyped d2) }]
+          (strategyId := .attainedExtremum)
+        solve := argminAttemptTyped d2 }]
   | .argmax => #[
       { report := report intent "attained maximum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
           (some (suggestion "interval_argmax" #[toString d]))
-        solve := intervalArgmaxCore d
-        solveReportedResult := some (argmaxAttemptTyped d) },
+          (strategyId := .attainedExtremum)
+        solve := argmaxAttemptTyped d },
       { report := report intent "attained maximum certification" cfg mode
           (.policy "candidate search followed by checked bounds")
           (some (suggestion "interval_argmax" #[toString d2]))
-        solve := intervalArgmaxCore d2
-        solveReportedResult := some (argmaxAttemptTyped d2) }]
+          (strategyId := .attainedExtremum)
+        solve := argmaxAttemptTyped d2 }]
   | .finiteSum => #[
       { report := report intent "reflective finite-sum certificate" cfg mode
-          (.fixed .dyadicInterval) (some (suggestion "finsum_bound")),
-        solve := finSumBoundCore (-53) 10
-        solveReportedResult := some (finSumAttemptTyped (-53) 10) },
+          (.fixed .dyadicInterval) (some (suggestion "finsum_bound"))
+          (strategyId := .finiteSum),
+        solve := finSumAttemptTyped (-53) 10 },
       { report := report intent "reflective finite-sum certificate" cfg mode
-          (.fixed .dyadicInterval) (some (suggestion "finsum_bound" #["80"])),
-        solve := finSumBoundCore (-80) 10
-        solveReportedResult := some (finSumAttemptTyped (-80) 10) }]
+          (.fixed .dyadicInterval) (some (suggestion "finsum_bound" #["80"]))
+          (strategyId := .finiteSum),
+        solve := finSumAttemptTyped (-80) 10 }]
   | .certificateCheck => #[
       { report := report intent "closed Boolean certificate verification" cfg mode
-          .notApplicable,
-        solve := do
-          discard <| LeanCert.Tactic.closeCertificateGoal
-            (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
-            (tacticName := "leancert"),
-        solveReported := some do
-          let event ← LeanCert.Tactic.closeCertificateGoalReported
-            (← LeanCert.Tactic.VerificationConfig.current) (← getMainGoal)
-            (tacticName := "leancert")
-          return {
-            verificationUsage :=
-              Solver.VerificationUsage.ofEvents event.toUsage
-          }
+          .notApplicable (strategyId := .certificateCheck),
+        solve := certificateCheckAttemptTyped
         cost := 0 }]
   | .integralBound => #[
       { report := report intent "integral_exact" cfg mode (.fixed .exactRational)
           (some (suggestion "integral_exact")) (strategyId := .exactIntegral),
-        solve := integralExactCore
-        solveReportedResult := some integralExactAttemptTyped
+        solve := integralExactAttemptTyped
         cost := 0 },
       { report := report intent "integral_search 16 512" cfg mode
           (.fixed .checkedRationalPartitions) (strategyId := .partitionIntegral),
-        solve := integralSearchCore 16 512
-        solveReportedResult := some (integralSearchAttemptTyped 16 512) },
+        solve := integralSearchAttemptTyped 16 512 },
       { report := report intent "integral_search 16 4096" cfg mode
           (.fixed .checkedRationalPartitions) (strategyId := .partitionIntegral),
-        solve := integralSearchCore 16 4096
-        solveReportedResult := some (integralSearchAttemptTyped 16 4096) },
+        solve := integralSearchAttemptTyped 16 4096 },
       { report := report intent "integral_search 16 16384" cfg mode
           (.fixed .checkedRationalPartitions) (strategyId := .partitionIntegral),
-        solve := integralSearchCore 16 16384
-        solveReportedResult := some (integralSearchAttemptTyped 16 16384) }]
+        solve := integralSearchAttemptTyped 16 16384 }]
   | .conjunction => #[]
 
 private def Semantic.SemanticGoal.comparison? :
@@ -912,17 +895,8 @@ def enforceAttemptDisposition
 private def trySolver (spec : SolverSpec) : TacticM AttemptOutcome := do
   let goal ← getMainGoal
   let proposition ← goal.getType
-  match spec.solveReportedResult, spec.solveReported with
-  | some solve, _ =>
-      Solver.proveWithTacticReportedResult { spec.report with cost := spec.cost }
-        proposition solve
-        (if spec.legacyExceptionAdapter then .legacyInconclusive else .internalError)
-  | none, some solve =>
-      Solver.proveWithTacticReportedResult { spec.report with cost := spec.cost }
-        proposition (do return .ok (← solve))
-        (if spec.legacyExceptionAdapter then .legacyInconclusive else .internalError)
-  | none, none =>
-      Solver.proveWithTactic { spec.report with cost := spec.cost } proposition spec.solve
+  Solver.proveWithTypedSolver { spec.report with cost := spec.cost }
+    proposition spec.solve
 
 private partial def normalizedBoundProposition (spec : Semantic.BoundSpec) :
     MetaM Lean.Expr := do
@@ -973,18 +947,12 @@ private def canonicalExtremumProposition (spec : Semantic.ExtremumSpec) :
     let predicate ← mkAppM ``And #[xMembership, extremalBody]
     mkAppM ``Exists #[← mkLambdaFVars #[x] predicate]
 
-/-- Adapt a legacy numerical engine to the comparison normalized by the
+/-- Adapt a numerical engine to the comparison normalized by the
 semantic parser. The numerical engine sees `lhs - rhs ⋚ 0`; the resulting proof
 is transported back with the ordinary ordered-ring equivalence. -/
 private def trySolverFor (spec : SolverSpec) (semantic : Semantic.SemanticGoal) :
     TacticM AttemptOutcome := do
-  let runSpec : TacticM (Except AttemptFailure SolverExecution) :=
-    match spec.solveReportedResult, spec.solveReported with
-    | some solve, _ => solve
-    | none, some solve => do return .ok (← solve)
-    | none, none => do
-        spec.solve
-        return .ok {}
+  let runSpec := spec.solve
   let action ←
     match semantic with
     | .bound boundSpec =>
@@ -1022,17 +990,10 @@ private def trySolverFor (spec : SolverSpec) (semantic : Semantic.SemanticGoal) 
     | _ => pure runSpec
   let goal ← getMainGoal
   let proposition ← goal.getType
-  Solver.proveWithTacticReportedResult { spec.report with cost := spec.cost }
+  Solver.proveWithTypedSolver { spec.report with cost := spec.cost }
     proposition action
-    (if (spec.solveReportedResult.isNone && spec.solveReported.isNone) ||
-        spec.legacyExceptionAdapter then
-      .legacyInconclusive
-    else
-      .internalError)
 
-/-- Temporary adapter for the existing numerical engines. The production
-router speaks only the typed `SemanticSolver` protocol; individual engines can
-then migrate from this adapter to consuming prepared payloads directly. -/
+/-- Adapt a typed family solver to the semantic solver interface. -/
 def SolverSpec.toSemanticSolver (spec : SolverSpec) : SemanticSolver := {
   plan := { spec.report with cost := spec.cost }
   supports := spec.isApplicableTo
@@ -1189,7 +1150,9 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
   let normalizationSpec : SolverSpec := {
     report := normalizationReport
     cost := 0
-    solve := do evalTactic (← `(tactic| norm_num))
+    solve := exactTacticAttempt
+      "Exact normalization did not close the prepared proposition."
+      (do evalTactic (← `(tactic| norm_num)))
   }
   match ← trySolver normalizationSpec with
   | .proved artifact => return ← commitArtifact artifact
@@ -1213,14 +1176,9 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
   if let .allOf _ _ := semantic then
     let conjunctionSpec : SolverSpec := {
       report := report .conjunction "recursive semantic routing"
-        cfg verificationMode .notApplicable
+        cfg verificationMode .notApplicable (strategyId := .conjunction)
       cost := 0
       solve := do
-        evalTactic (← `(tactic| try simp only [forall_and]))
-        evalTactic (← `(tactic| constructor))
-        while !(← getGoals).isEmpty do
-          discard <| runLeanCert cfg verbosity
-      solveReportedResult := some do
         evalTactic (← `(tactic| try simp only [forall_and]))
         evalTactic (← `(tactic| constructor))
         let childGoals ← getGoals
@@ -1265,8 +1223,11 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
       let vacuitySpec : SolverSpec := {
         report := report .intervalBound "empty-domain normalization"
           cfg verificationMode .notApplicable
+          (strategyId := .exactNormalization)
         cost := 0
-        solve := do evalTactic (← `(tactic| simp [Set.mem_Icc]))
+        solve := exactTacticAttempt
+          "Empty-domain normalization did not close the prepared proposition."
+          (do evalTactic (← `(tactic| simp [Set.mem_Icc])))
       }
       match ← trySolver vacuitySpec
       with
@@ -1361,10 +1322,12 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
           (if spec.kind == .exists then .rootExists else .uniqueRoot)
           "exact rational root candidate" cfg verificationMode
           (.fixed .exactRational)
+          (strategyId := if spec.kind == .exists then .rootExistence else .rootUniqueness)
         let exactSpec : SolverSpec := {
           report := exactReport
           cost := 0
-          solve := do
+          solve := exactTacticAttempt
+            "The exact rational candidate did not prove the root proposition." do
             if spec.kind == .exists then
               evalTactic (← `(tactic|
                 refine ⟨$candidateSyntax, ?_, ?_⟩ <;>
@@ -1406,11 +1369,12 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
       let evtReport := report intent
         (if spec.kind == .minimum then "compact extreme-value theorem (minimum)"
          else "compact extreme-value theorem (maximum)")
-        cfg verificationMode .notApplicable
+        cfg verificationMode .notApplicable (strategyId := .attainedExtremum)
       let evtSpec : SolverSpec := {
         report := evtReport
         cost := 0
-        solve := do
+        solve := exactTacticAttempt
+          "The compact extreme-value theorem route could not construct the proof." do
           evalTactic (← `(tactic|
             suffices hnormalized : $canonicalSyntax by
               simpa only [and_comm] using hnormalized))
@@ -1461,10 +1425,13 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
       let equalityReport := report .finiteSum "exact finite-sum expansion"
         cfg verificationMode (.fixed .exactRational)
         (some (suggestion "finsum_expand"))
+        (strategyId := .finiteSum)
       let equalitySpec : SolverSpec := {
         report := equalityReport
         cost := 0
-        solve := do evalTactic (← `(tactic| finsum_expand; norm_num))
+        solve := exactTacticAttempt
+          "Exact finite-sum expansion did not close the proposition."
+          (do evalTactic (← `(tactic| finsum_expand; norm_num)))
       }
       match ← trySolver equalitySpec with
       | .proved artifact => return ← commitArtifact artifact

--- a/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
+++ b/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
@@ -165,12 +165,21 @@ structure IntegralPartitionStatistics where
 /-- Stable algorithm identity for reporting and failure classification.
 User-facing `strategy` text may be polished without changing control flow. -/
 inductive StrategyId where
-  | legacy
   | exactNormalization
-  | exactIntegral
-  | partitionIntegral
+  | certificateCheck
+  | pointEnclosure
+  | intervalEnclosure
   | subdivision
   | globalOptimization
+  | multivariateOptimization
+  | rootExistence
+  | rootUniqueness
+  | rootExclusion
+  | attainedExtremum
+  | finiteSum
+  | exactIntegral
+  | partitionIntegral
+  | conjunction
   deriving DecidableEq, Repr, Inhabited
 
 /-- Static solver intent.  It may state a backend policy, but cannot claim a
@@ -178,7 +187,7 @@ runtime winner. -/
 structure SolverPlan where
   intent : GoalIntent
   solver : Name
-  strategyId : StrategyId := .legacy
+  strategyId : StrategyId
   strategy : String
   strategyDetail : Option String := none
   cost : Nat
@@ -186,13 +195,9 @@ structure SolverPlan where
   dedicatedProof : Option ProofSuggestion := none
   backendPolicy : BackendPolicy := .unknown
   verificationRequested : VerificationMode := .native
-  checker : Option Name := none
-  verifier : Option Name := none
   deriving Inhabited
 
-/-- Runtime facts returned only by the successful isolated execution. Empty
-execution data is the honest compatibility result for a legacy `TacticM Unit`
-solver.
+/-- Runtime facts returned only by the successful isolated execution.
 
 Reporting invariants:
 
@@ -288,29 +293,6 @@ structure SemanticSolver where
   attempt : Semantic.PreparedGoal → LeanCertConfig →
     Elab.Tactic.TacticM AttemptOutcome
 
-private def backendInconclusiveDetail (plan : SolverPlan) : String :=
-  match plan.strategyId with
-  | .exactNormalization =>
-      "Exact normalization did not close the prepared proposition."
-  | .exactIntegral =>
-      "Exact integration did not recognize the integrand as a rational polynomial \
-        with supported constant divisions."
-  | .partitionIntegral =>
-      "Checked partition enclosures did not establish the requested integral comparison."
-  | .subdivision =>
-      "Subdivision reached its configured depth without obtaining a decisive enclosure."
-  | .globalOptimization =>
-      "Global optimization did not produce a verifier-ready bound within its iteration limit."
-  | .legacy =>
-      "The backend could not construct a complete certificate with the current settings."
-
-/-- Compatibility policy for exception-based legacy tactic cores. New reported
-cores must use `.internalError`; only the opaque `TacticM Unit` adapter may
-translate an exception into the historical inconclusive result. -/
-inductive ExceptionPolicy where
-  | internalError
-  | legacyInconclusive
-
 /-- Validate a proof against the immutable proposition prepared for the
 attempt, rather than trusting a proposition returned by solver code. -/
 def validateProofArtifact (preparedProposition : Lean.Expr)
@@ -342,9 +324,8 @@ def validateProofArtifact (preparedProposition : Lean.Expr)
 /-- Run a report-producing proof procedure on an isolated metavariable and turn
 a complete proof into a validated artifact. The execution metadata is retained
 only if the proof and all transport goals succeed. -/
-def proveWithTacticReportedResult (plan : SolverPlan) (proposition : Lean.Expr)
-    (solver : Elab.Tactic.TacticM (Except AttemptFailure SolverExecution))
-    (exceptionPolicy : ExceptionPolicy := .internalError) :
+def proveWithTypedSolver (plan : SolverPlan) (proposition : Lean.Expr)
+    (solver : Elab.Tactic.TacticM (Except AttemptFailure SolverExecution)) :
     Elab.Tactic.TacticM AttemptOutcome := do
   let originalGoals ← Elab.Tactic.getGoals
   let saved ← Elab.Tactic.saveState
@@ -358,16 +339,8 @@ def proveWithTacticReportedResult (plan : SolverPlan) (proposition : Lean.Expr)
       trace[LeanCert.solver] "{plan.strategy} checker output:\n\
         {detail}"
       saved.restore
-      match exceptionPolicy with
-      | .internalError =>
-          return .internalError plan.solver
-            s!"solver logged error diagnostics without returning a typed failure:\n{detail}"
-      | .legacyInconclusive =>
-          return .rejected {
-            checker := plan.checker
-            detail := "The generated certificate was not accepted at the current \
-              precision or strategy settings."
-          }
+      return .internalError plan.solver
+        s!"solver logged error diagnostics without returning a typed failure:\n{detail}"
     let some result := captured.result?
       | saved.restore
         return .internalError plan.solver
@@ -407,27 +380,6 @@ def proveWithTacticReportedResult (plan : SolverPlan) (proposition : Lean.Expr)
     let detail ← exception.toMessageData.toString
     trace[LeanCert.solver] "{plan.strategy} raised during speculative execution:\n{detail}"
     saved.restore
-    match exceptionPolicy with
-    | .internalError => return .internalError plan.solver detail
-    | .legacyInconclusive =>
-        return .inconclusive { detail := backendInconclusiveDetail plan }
-
-/-- Convenience wrapper for the common case where a reported solver can only
-fail through the ordinary tactic protocol. -/
-def proveWithTacticReported (plan : SolverPlan) (proposition : Lean.Expr)
-    (solver : Elab.Tactic.TacticM SolverExecution) :
-    Elab.Tactic.TacticM AttemptOutcome :=
-  proveWithTacticReportedResult plan proposition do
-    return .ok (← solver)
-
-/-- Compatibility adapter for legacy tactic cores that do not yet expose
-runtime metadata. Their static plan may describe a backend policy, but the
-execution remains explicitly unknown. -/
-def proveWithTactic (plan : SolverPlan) (proposition : Lean.Expr)
-    (solver : Elab.Tactic.TacticM Unit) :
-    Elab.Tactic.TacticM AttemptOutcome :=
-  proveWithTacticReportedResult plan proposition (do
-    solver
-    return .ok {}) .legacyInconclusive
+    return .internalError plan.solver detail
 
 end LeanCert.Tactic.Solver

--- a/LeanCert/Tactic/Verification.lean
+++ b/LeanCert/Tactic/Verification.lean
@@ -542,33 +542,17 @@ def VerificationFailure.message (tacticName : String) :
   | .internalError detail =>
       s!"{tacticName}: internal certificate verification error:\n{detail}"
 
-/-- Throwing compatibility wrapper for callers that have not yet migrated to
-the typed verification protocol. New reporting-aware callers should use
-`closeCertificateGoalTyped`. -/
-def closeCertificateGoalReported (cfg : VerificationConfig) (certGoal : MVarId)
-    (tacticName : String := "leancert") : TacticM VerificationEvent := do
-  match ← closeCertificateGoalTyped cfg certGoal tacticName with
-  | .accepted event => return event
-  | .rejected =>
-      throwError "{tacticName}: certificate checker evaluated to false"
-  | .failed failure =>
-      throwError (failure.message tacticName)
-
-/-- Compatibility wrapper returning only the route that closed the
-certificate. New reporting-aware callers should use
-`closeCertificateGoalReported`. -/
-def closeCertificateGoal (cfg : VerificationConfig) (certGoal : MVarId)
-    (tacticName : String := "leancert") : TacticM VerificationUsed := do
-  return (← closeCertificateGoalReported cfg certGoal tacticName).used
-
 /-- Close the current goal as a LeanCert certificate check according to the
 configured verification route (`leancert.trust`, or a `(trust := …)` override
 active via `withTrustMode`). For tactic implementations that embed certificate
 obligations inside quoted proof terms — `(by leancert_verify_cert)` — where
-`closeCertificateGoal` cannot be called directly. Not intended for end users. -/
+the typed boundary cannot be called directly. Not intended for end users. -/
 elab "leancert_verify_cert" : tactic => do
-  discard <| closeCertificateGoal (← VerificationConfig.current) (← getMainGoal)
-    (tacticName := "leancert")
+  match ← closeCertificateGoalTyped (← VerificationConfig.current) (← getMainGoal)
+      (tacticName := "leancert") with
+  | .accepted _ => pure ()
+  | .rejected => throwError "leancert: certificate checker evaluated to false"
+  | .failed failure => throwError (failure.message "leancert")
 
 /-! ## Public per-invocation syntax: `(trust := kernel|native|auto)`
 

--- a/LeanCert/Tactic/design-notes.md
+++ b/LeanCert/Tactic/design-notes.md
@@ -865,7 +865,7 @@ The canonical extractor (in `Meta/Numeral.lean`) handles all arithmetic patterns
 `HAdd`, `HMul`, `HSub`, `Neg`, `OfScientific`, etc.), so it correctly parses
 `HDiv.hDiv (OfNat 9) (OfNat 500)` as `9/500 : ℚ`.
 
-## BridgeNative: shared bridge+native_decide infrastructure (Mar 2026)
+## BridgeNative: shared transactional bridge infrastructure (Mar 2026)
 
 ### Problem
 
@@ -873,23 +873,26 @@ The "try defEq → suffices + converter → native_decide" pattern was duplicate
 **6 times** across `finSumBound{Icc,List}Core` and `finSumWitness{Icc,List,AutoIcc,AutoList}Core`
 (~35 lines each, ~210 total). Adding `finmatrix_bound` would create a 7th copy.
 
-### Solution: `closeBridgeWithNativeDecide`
+### Current solution: `closeBridgeWithVerificationTyped`
 
 Extracted into `Tactic/BridgeNative.lean`:
 
 ```lean
-def closeBridgeWithNativeDecide
+def closeBridgeWithVerificationTyped
     (goal : MVarId) (goalType : Lean.Expr)
     (proof checkMVar : Lean.Expr)
     (tacticName : String)
     (converterSteps : Array (TacticM Unit))
-    : TacticM Unit
+    : TacticM (Except BridgeFailure VerificationEvent)
 ```
 
 Logic:
 1. `inferType proof` → `proofTy`
-2. If `isDefEq proofTy goalType`: direct assign + `native_decide` on checkMVar
-3. Else: suffMVar + converterMVar pattern, try converterSteps in sequence
+2. Close `checkMVar` through the configured typed verification boundary.
+3. If `isDefEq proofTy goalType`, assign only after verification succeeds.
+4. Otherwise use the suffices/converter pattern and try converter steps.
+5. Restore the complete tactic state on rejection, verification failure, or
+   proof-transport failure.
 
 Each caller provides its own converter steps inline:
 - `finsum_bound`: `simp [Expr.eval, sumBodyRealEnv, ...] + norm_num`, then `push_cast + linarith`
@@ -897,8 +900,8 @@ Each caller provides its own converter steps inline:
 
 ### Refactored files
 
-- `FinSumBound.lean` — 2 blocks → 2 calls to `closeBridgeWithNativeDecide`
-- `FinSumWitness.lean` — 4 blocks → 4 calls to `closeBridgeWithNativeDecide`
+- `FinSumBound.lean` — 2 blocks → typed bridge calls
+- `FinSumWitness.lean` — 4 blocks → typed bridge calls
 - Net: ~210 lines of duplication → ~40-line shared helper
 
 ## finmatrix_bound: matrix norm tactic (Mar 2026)
@@ -932,7 +935,7 @@ The tactic:
 1. Elaborates the bridge term
 2. Infers its type — should be `(hle : X ≤ C) → goalType`
 3. Creates mvar for `hle`, applies `bridgeExpr checkMVar`
-4. Calls `closeBridgeWithNativeDecide` to close with `native_decide`
+4. Calls `closeBridgeWithVerificationTyped` using the selected trust mode
 
 ### Block extension (RadiiPolynomial — separate project)
 

--- a/LeanCert/Test/FinSumBound.lean
+++ b/LeanCert/Test/FinSumBound.lean
@@ -15,6 +15,11 @@ with O(1) proof size via `native_decide`. Covers auto-reify mode, witness mode
 
 namespace LeanCert.Test.FinSumBound
 
+open Lean Meta Elab Tactic
+open LeanCert.Tactic
+
+set_option linter.unusedTactic false
+
 /-! ### Basic Icc sums -/
 
 -- Sum of constants (upper)
@@ -289,8 +294,49 @@ This works when the evaluator returns singletons where membership reduces to
 def constOneEval (_k : Nat) (_cfg : DyadicConfig) : IntervalDyadic :=
   IntervalDyadic.singleton ⟨1, 0⟩
 
+/-- Deliberately excludes the constant body value, so auto-membership reaches
+the typed verifier and receives a conclusive rejection. -/
+def rejectingOneEval (_k : Nat) (_cfg : DyadicConfig) : IntervalDyadic :=
+  IntervalDyadic.singleton ⟨0, 0⟩
+
+/-- Deliberately noncomputable evaluator used to exercise membership
+verification infrastructure failure rather than ordinary synthesis failure. -/
+noncomputable def unavailableOneEval (_k : Nat) (_cfg : DyadicConfig) :
+    IntervalDyadic :=
+  Classical.choice (show Nonempty IntervalDyadic from
+    ⟨IntervalDyadic.singleton ⟨1, 0⟩⟩)
+
+elab "expect_auto_membership_rejected" : tactic => do
+  let original ← getMainGoal
+  let originalType ← original.getType
+  match ← finSumWitnessAutoCoreTyped (← `(term| rejectingOneEval)) (-53) with
+  | .error (.rejected _ _) =>
+      let restored ← getMainGoal
+      unless restored == original && (← isDefEq (← restored.getType) originalType) do
+        throwError "auto-membership rejection did not restore the original goal"
+  | .error failure =>
+      throwError "auto-membership rejection was misclassified: {repr failure}"
+  | .ok _ =>
+      throwError "invalid auto-membership certificate was accepted"
+
+elab "expect_auto_membership_verification_failure" : tactic => do
+  match ← finSumWitnessAutoCoreTyped (← `(term| unavailableOneEval)) (-53) with
+  | .error (.verificationFailure _) => pure ()
+  | .error failure =>
+      throwError "auto-membership infrastructure failure was misclassified: {repr failure}"
+  | .ok _ =>
+      throwError "noncomputable auto-membership certificate unexpectedly succeeded"
+
 -- Constant body, singleton evaluator
 example : ∑ _k ∈ Finset.Icc (1 : ℕ) 5, (1 : ℝ) ≤ 6 := by
+  finsum_bound auto constOneEval
+
+example : ∑ _k ∈ Finset.Icc (1 : ℕ) 5, (1 : ℝ) ≤ 6 := by
+  expect_auto_membership_rejected
+  finsum_bound auto constOneEval
+
+example : ∑ _k ∈ Finset.Icc (1 : ℕ) 5, (1 : ℝ) ≤ 6 := by
+  expect_auto_membership_verification_failure
   finsum_bound auto constOneEval
 
 /-! ### Rational bound targets (`extractRatFromReal` with `toRat?` fallback) -/

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -62,6 +62,30 @@ private def expectTypedAdapterFailure : TacticM Unit := do
 elab "expect_typed_adapter_failure" : tactic =>
   expectTypedAdapterFailure
 
+private def expectExactRouteExceptionTerminal : TacticM Unit := do
+  let goal ← getMainGoal
+  let proposition ← goal.getType
+  let plan : SolverPlan := {
+    intent := .pointInequality
+    solver := `syntheticExactRoute
+    strategyId := .exactNormalization
+    strategy := "synthetic throwing exact route"
+    cost := 0
+    backendPolicy := .notApplicable
+    verificationRequested := .kernel
+  }
+  match ← proveWithTypedSolver plan proposition <|
+      exactTacticAttemptTyped (throwError "synthetic exact-route exception") with
+  | .internalError solver detail =>
+      unless solver == `syntheticExactRoute &&
+          detail.contains "synthetic exact-route exception" do
+        throwError "exact-route exception lost its terminal diagnostic: {detail}"
+  | outcome =>
+      throwError "exact-route exception was not terminal: {repr outcome.disposition}"
+
+elab "expect_exact_route_exception_terminal" : tactic =>
+  expectExactRouteExceptionTerminal
+
 elab "expect_terminal_outcome_stops" : tactic => do
   let mut continued := false
   try
@@ -851,6 +875,10 @@ example : ∃ x ∈ Set.Icc (0 : ℝ) 1, x = 0 := by
 
 example : True := by
   expect_terminal_outcome_stops
+  trivial
+
+example : True := by
+  expect_exact_route_exception_terminal
   trivial
 
 example : Real.log 2 < Real.exp 1 := by

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -29,6 +29,7 @@ private def checkerIntervalNeg11 : LeanCert.Core.IntervalRat := ⟨-1, 1, by nor
 private def adapterTestPlan : SolverPlan := {
   intent := .pointInequality
   solver := `typedAdapterTest
+  strategyId := .pointEnclosure
   strategy := "typed adapter preservation test"
   cost := 0
   backendPolicy := .notApplicable
@@ -48,9 +49,7 @@ private def expectTypedAdapterFailure : TacticM Unit := do
     | .error failure => throwError "test goal did not prepare: {failure.detail}"
   let spec : SolverSpec := {
     report := adapterTestPlan
-    solve := throwError "legacy Unit adapter ran"
-    solveReported := some (throwError "legacy reported adapter ran")
-    solveReportedResult := some <| pure <|
+    solve := pure <|
       .error (.routerFailure (.internalError "typed result survived semantic transport"))
   }
   match ← spec.toSemanticSolver.attempt prepared {} with

--- a/LeanCert/Test/LeanCertSolverProtocol.lean
+++ b/LeanCert/Test/LeanCertSolverProtocol.lean
@@ -21,6 +21,7 @@ set_option linter.unusedTactic false
 private def testPlan : SolverPlan := {
   intent := .intervalBound
   solver := `syntheticSolver
+  strategyId := .intervalEnclosure
   strategy := "synthetic protocol test"
   cost := 0
   backendPolicy := .policy "Dyadic-first with Rational fallback"
@@ -37,17 +38,21 @@ private def localEnvironmentSize : TacticM Nat := do
 
 private def runSynthetic (solver : TacticM Unit) : TacticM AttemptOutcome := do
   let goal ← getMainGoal
-  proveWithTactic testPlan (← goal.getType) solver
+  proveWithTypedSolver testPlan (← goal.getType) do
+    solver
+    return .ok {}
 
-private def runSyntheticWithPlan (plan : SolverPlan) (solver : TacticM Unit) :
+private def runSyntheticWithPlan (plan : SolverPlan)
+    (solver : TacticM (Except AttemptFailure SolverExecution)) :
     TacticM AttemptOutcome := do
   let goal ← getMainGoal
-  proveWithTactic plan (← goal.getType) solver
+  proveWithTypedSolver plan (← goal.getType) solver
 
-private def runSyntheticReported (solver : TacticM SolverExecution) :
+private def runSyntheticExecution (solver : TacticM SolverExecution) :
     TacticM AttemptOutcome := do
   let goal ← getMainGoal
-  proveWithTacticReported testPlan (← goal.getType) solver
+  proveWithTypedSolver testPlan (← goal.getType) do
+    return .ok (← solver)
 
 elab "expect_partial_attempt" : tactic => do
   let before ← getGoals
@@ -67,43 +72,44 @@ elab "expect_throwing_attempt" : tactic => do
     evalTactic (← `(tactic| constructor))
     throwError "synthetic failure after mutation"
   match result with
-  | .inconclusive evidence =>
-      unless evidence.detail.contains "could not construct a complete certificate" do
-        throwError "expected a sanitized backend failure"
-  | _ => throwError "expected an inconclusive outcome"
+  | .internalError solver detail =>
+      unless solver == testPlan.solver &&
+          detail.contains "synthetic failure after mutation" do
+        throwError "unexpected exception diagnostic: {detail}"
+  | _ => throwError "unexpected solver exception was not classified as internal"
   assertOriginalGoals before
 
-elab "expect_reported_exception_is_internal" : tactic => do
+elab "expect_typed_exception_is_internal" : tactic => do
   let before ← getGoals
   let intended := before.head!
   let environmentSizeBefore ← localEnvironmentSize
-  let result ← runSyntheticReported do
+  let result ← runSyntheticExecution do
     evalTactic (← `(tactic| native_decide))
-    throwError "unexpected reported-core exception"
+    throwError "unexpected typed-core exception"
   match result with
   | .internalError solver detail =>
       unless solver == testPlan.solver &&
-          detail.contains "unexpected reported-core exception" do
-        throwError "reported exception lost its typed internal-error context"
-  | _ => throwError "reported-core exception was not classified as internal"
+          detail.contains "unexpected typed-core exception" do
+        throwError "typed exception lost its internal-error context"
+  | _ => throwError "typed-core exception was not classified as internal"
   assertOriginalGoals before
   if ← intended.isAssigned then
-    throwError "failed reported attempt assigned the caller's goal"
+    throwError "failed typed attempt assigned the caller's goal"
   let environmentSizeAfter ← localEnvironmentSize
   unless environmentSizeAfter == environmentSizeBefore do
     throwError "failed native attempt leaked a generated environment declaration"
 
-elab "expect_reported_error_message_is_internal" : tactic => do
+elab "expect_typed_error_message_is_internal" : tactic => do
   let before ← getGoals
-  let result ← runSyntheticReported do
-    logError "unexpected reported-core diagnostic"
+  let result ← runSyntheticExecution do
+    logError "unexpected typed-core diagnostic"
     return {}
   match result with
   | .internalError solver detail =>
       unless solver == testPlan.solver &&
-          detail.contains "unexpected reported-core diagnostic" do
-        throwError "reported error diagnostic lost its internal-error context"
-  | _ => throwError "reported-core error diagnostic was classified as rejection"
+          detail.contains "unexpected typed-core diagnostic" do
+        throwError "typed error diagnostic lost its internal-error context"
+  | _ => throwError "typed-core error diagnostic was classified as rejection"
   assertOriginalGoals before
 
 elab "expect_subdivision_failure_detail" : tactic => do
@@ -114,8 +120,9 @@ elab "expect_subdivision_failure_detail" : tactic => do
     -- Deliberately unrelated display text: diagnostics must use the stable kind.
     strategy := "polished user-facing name"
   }
-  let result ← runSyntheticWithPlan plan do
-    throwError "synthetic subdivision failure"
+  let result ← runSyntheticWithPlan plan <| pure <| .error <| .inconclusive {
+    detail := "Subdivision reached its configured depth."
+  }
   match result with
   | .inconclusive evidence =>
       unless evidence.detail.contains "configured depth" do
@@ -143,14 +150,14 @@ elab "close_with_artifact" : tactic => do
         throwError "successful solver returned the wrong report"
       match artifact.report.execution.backend with
       | none => pure ()
-      | _ => throwError "legacy compatibility solver fabricated execution metadata"
+      | _ => throwError "typed solver fabricated execution metadata"
       let goal ← getMainGoal
       goal.assign artifact.proof
       replaceMainGoal []
   | _ => throwError "isolated solver unexpectedly failed"
 
-elab "close_with_reported_artifact" : tactic => do
-  let result ← runSyntheticReported do
+elab "close_with_typed_artifact" : tactic => do
+  let result ← runSyntheticExecution do
     evalTactic (← `(tactic| exact True.intro))
     return {
       backend := some .rationalInterval
@@ -178,7 +185,7 @@ elab "close_with_reported_artifact" : tactic => do
 
 elab "expect_failed_metadata_isolated" : tactic => do
   let before ← getGoals
-  let failed ← runSyntheticReported do
+  let failed ← runSyntheticExecution do
     evalTactic (← `(tactic| constructor))
     return {
       backend := some .dyadicInterval
@@ -189,7 +196,7 @@ elab "expect_failed_metadata_isolated" : tactic => do
   | .inconclusive _ => pure ()
   | _ => throwError "expected the Dyadic attempt to be inconclusive"
   assertOriginalGoals before
-  let successful ← runSyntheticReported do
+  let successful ← runSyntheticExecution do
     evalTactic (← `(tactic| exact And.intro True.intro True.intro))
     return {
       backend := some .rationalInterval
@@ -278,10 +285,9 @@ elab "expect_metadata_irrelevant_to_acceptance" : tactic => do
     plan := {
       testPlan with
       intent := .uniqueRoot
+      strategyId := .rootUniqueness
       strategy := "deliberately false metadata"
       backendPolicy := .fixed .affineArithmetic
-      checker := some `NotARealChecker
-      verifier := some `NotAGoldenTheorem
     }
     execution := {
       backend := some .dyadicInterval
@@ -323,11 +329,11 @@ example : True ∧ True := by
   constructor <;> trivial
 
 example : True ∧ True := by
-  expect_reported_exception_is_internal
+  expect_typed_exception_is_internal
   constructor <;> trivial
 
 example : True := by
-  expect_reported_error_message_is_internal
+  expect_typed_error_message_is_internal
   trivial
 
 example : True := by
@@ -357,7 +363,7 @@ example : True := by
   trivial
 
 example : True := by
-  close_with_reported_artifact
+  close_with_typed_artifact
 
 example : True := by
   trivial

--- a/LeanCert/Test/PublicAPI/Isolation.lean
+++ b/LeanCert/Test/PublicAPI/Isolation.lean
@@ -14,7 +14,7 @@ open Lean Elab Command
 run_meta do
   let env ← getEnv
   for name in [
-      `LeanCert.Tactic.closeCertificateGoal,
+      `LeanCert.Tactic.closeCertificateGoalTyped,
       `LeanCert.Tactic.Auto.intervalDecideCore] do
     if env.contains name then
       throwError "programmatic API leaked tactic declaration {name}"

--- a/LeanCert/Test/TrustModes.lean
+++ b/LeanCert/Test/TrustModes.lean
@@ -8,7 +8,7 @@ import LeanCert.Tactic
 /-!
 # Trust-mode regression tests (`leancert.trust`)
 
-Guards the verification choke point (`LeanCert.Tactic.closeCertificateGoal`)
+Guards the verification choke point (`LeanCert.Tactic.closeCertificateGoalTyped`)
 behind `interval_decide`:
 
 * default (native) behavior is unchanged;
@@ -31,8 +31,12 @@ private def closeAndExpectVerificationEvent
     (used : LeanCert.Tactic.VerificationUsed)
     (cause : LeanCert.Tactic.VerificationCause) : TacticM Unit := do
   let goal ← getMainGoal
-  let event ← LeanCert.Tactic.closeCertificateGoalReported cfg goal
-    "trust telemetry test"
+  let event ←
+    match ← LeanCert.Tactic.closeCertificateGoalTyped cfg goal
+        "trust telemetry test" with
+    | .accepted event => pure event
+    | .rejected => throwError "trust telemetry certificate was rejected"
+    | .failed failure => throwError (failure.message "trust telemetry test")
   unless event.requested == requested do
     throwError "wrong requested verification mode: {repr event}"
   unless event.used == used do

--- a/README.md
+++ b/README.md
@@ -165,38 +165,31 @@ For programmatic use, start with the stable `LeanCert` APIs:
 - the checked AD, root, and integration APIs described in the
   [documentation](https://docs.leancert.io)
 
-## Honest limitations
+## Limitations
 
-- `leancert` is automation over a supported expression and goal fragment, not
-  a general decision procedure for real analysis.
-- Interval dependency and coarse enclosures can make a true tight bound
-  inconclusive. Increasing Taylor depth, subdividing, or choosing a dedicated
-  tactic may help, but success is not guaranteed.
-- Root existence by sign change misses even-multiplicity/tangent roots.
-  Uniqueness additionally needs the hypotheses certified by the Newton
-  contraction argument.
-- Exact integral equality automation is for rational polynomials. Other
-  supported integrands use certified partitions and are generally suited to
-  inequalities or enclosures rather than symbolic antiderivatives.
-- Partial functions require a certified valid domain; for example, logarithm
-  intervals must be positive and a denominator interval must exclude zero.
-- Kernel verification can be slower or exceed resources on large
-  certificates. The faster default native route explicitly adds trust in
-  Lean's compiler/runtime.
-- Some high-level frameworks require mathematical premises supplied by the
-  downstream project. In particular, theorem names in experimental optimized
-  ML components should not be read as end-to-end model soundness without
-  checking their exact statements.
-- The production imports are placeholder-free, but
-  `LeanCert.Examples.Li2Bounds` contains two explicitly allowlisted
-  compatibility placeholders. Their statements are matched in CI against the
-  separately built verified implementation; do not use that lightweight
-  interface as a trust-free production dependency.
+LeanCert provides sound automation for a supported fragment; it is not a
+complete decision procedure for real analysis. A failed or inconclusive search
+does not imply that the theorem is false.
 
-See [Verification Status](https://docs.leancert.io/architecture/verification-status/),
-[Choosing Tactics](https://docs.leancert.io/tactics/choosing-tactics/), and
+- Tight bounds can require greater Taylor depth, subdivision, or a dedicated
+  optimization tactic, and may still remain inconclusive.
+- Sign-change certificates miss even-multiplicity roots, while Newton
+  uniqueness requires additional certified hypotheses.
+- Exact integral equalities are automated for rational polynomials; other
+  supported integrands generally use certified partition bounds.
+- Supported evaluators may require domain certificates, such as positivity for
+  logarithms or exclusion of zero from denominator intervals.
+
+Native verification is faster but additionally trusts Lean's compiler/runtime;
+kernel-only verification may be substantially more expensive. See the
+[trust model](https://docs.leancert.io/architecture/trust-model/) and
+[verification status](https://docs.leancert.io/architecture/verification-status/)
+for precise trust boundaries, experimental subsystem qualifications, and the
+Li₂ compatibility exception.
+
+See [Choosing Tactics](https://docs.leancert.io/tactics/choosing-tactics/) and
 [Troubleshooting](https://docs.leancert.io/direct/troubleshooting/) for the
-full support matrix and audit details.
+full support matrix and practical guidance.
 
 ## Repository promises
 

--- a/docs/architecture/trust-model.md
+++ b/docs/architecture/trust-model.md
@@ -49,8 +49,9 @@ policy. A policy is not presented as the backend that actually ran.
 ## Qualifications
 
 Primary tactic paths and checked APIs use checker/Golden-Theorem boundaries.
-Some historical adapters are still being migrated to expose complete runtime
-metadata; their reports say that a route is unobserved instead of inferring it.
+Every semantic-router strategy uses a transactional typed result and reports
+only execution metadata observed on its retained successful path. Exact and
+normalization strategies may correctly retain zero Boolean-certificate checks.
 Exact polynomial integration constructs an ordinary kernel proof, so its trust
 selection is not applicable.
 
@@ -67,4 +68,3 @@ runs on every push and pull request. It rejects unauthorized axioms, `sorry`
 uses, and synthetic proof holes, then checks the exported trust manifest and
 representative Golden Theorems. Its README badge links to public run history;
 reviewers do not need to recreate CI locally.
-

--- a/docs/architecture/verification-status.md
+++ b/docs/architecture/verification-status.md
@@ -10,6 +10,11 @@ use two explicitly allowlisted placeholders. Their matching proofs are built in
 a separate CI target, but the aliases are not kernel-linked to those proof
 constants. See the final row for the exact qualification.
 
+At the tactic layer, every portfolio strategy returns a transactional typed
+result. Expected non-successes restore the caller state and are classified
+before the router decides whether to continue; unexpected exceptions and
+logged errors are terminal internal failures.
+
 ## Production Verification Status
 
 | Component | Checked entry point | Correctness bridge | Qualification |

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -44,10 +44,13 @@ imports retained for downstream users.
 
 ## Tactic changes
 
-The semantic router should return proof-bearing results and structured
-execution metadata. Strategy, numerical backend, and verification route are
-separate concepts. Failed speculative attempts must not leak proof state or
-telemetry. Prefer typed identifiers over matching user-facing display text.
+Every semantic-router extension returns
+`Except AttemptFailure SolverExecution`. Expected unsupported inputs,
+rejections, domain obstructions, and exhausted searches must not use
+exceptions. Strategy, numerical backend, and verification route are separate
+concepts. Failed speculative attempts must restore the complete tactic state
+and must not leak proof assignments or telemetry. Prefer typed identifiers over
+matching user-facing display text.
 
 Changes to a router path should normally include:
 

--- a/docs/direct/leancert.md
+++ b/docs/direct/leancert.md
@@ -30,9 +30,9 @@ example : ∃ x ∈ Set.Icc (1 : ℝ) 2, x ^ 2 = 2 := by
 
 It proves the same goal as `leancert` and reports the recognized theorem shape,
 winning strategy, numerical computation, certificate checker and verifier, and
-effective verification route. Legacy adapters that do not yet expose a runtime
-winner report their backend policy or leave it unspecified rather than
-guessing.
+effective verification route. Static backend policy and observed runtime
+metadata remain distinct; reports never infer a checker, verifier, or backend
+that the winning strategy did not retain.
 
 When ordinary `leancert` does not close a goal, retrying with `leancert?`
 requests the detailed diagnosis and attempted-strategy ledger. Enable the

--- a/docs/direct/roots.md
+++ b/docs/direct/roots.md
@@ -49,7 +49,8 @@ intervalUniqueRootCoreTyped
 rootBoundCoreTyped
 ```
 
-Their historical throwing entry points remain available for compatibility.
+Dedicated tactic syntax translates these typed failures into user-facing
+diagnostics at the elaborator boundary.
 
 ## Global algebraic simplicity and counts
 

--- a/docs/direct/troubleshooting.md
+++ b/docs/direct/troubleshooting.md
@@ -136,6 +136,10 @@ set_option trace.LeanCert.router true
 set_option trace.leancert.verification true
 ```
 
+Unexpected exceptions and error-level log messages are always classified as
+internal failures. They are never silently reinterpreted as certificate
+rejection or numerical exhaustion.
+
 Report the theorem, Lean/LeanCert revisions, full diagnostic, and relevant
 trace. Do not work around an artifact-validation failure by weakening the trust
 route.

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -105,11 +105,13 @@ spellings remain as deprecated compatibility aliases:
 The removed `LeanCert.Tactic.LeanCert.Types` and
 `LeanCert.Tactic.LeanCert.Transaction` modules were internal implementation
 details. Solver extensions use
-`LeanCert.Tactic.LeanCert.Solver.Protocol`, consume a proof-bearing
-`PreparedGoal`, return typed `AttemptOutcome` values, and hand back validated
-`ProofArtifact`s. Existing dedicated tactics enter this protocol through an
-internal adapter while their numerical engines are migrated to consume prepared
-payloads directly; this adapter is not a public compatibility API.
+`LeanCert.Tactic.LeanCert.Solver.Protocol`. Portfolio strategies return
+`Except AttemptFailure SolverExecution`; the sole protocol runner isolates the
+attempt, validates the resulting proof artifact, and converts it to an
+`AttemptOutcome`. Expected unsupported, rejected, exhausted, and domain cases
+must be returned as typed failures rather than exceptions. Dedicated tactic
+syntax calls the same typed family cores and translates failures only at the
+user-facing elaborator boundary.
 
 ## Checked automatic differentiation
 

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -659,7 +659,7 @@ complete caller tactic state.
 
 ### `interval_bound_adaptive`
 
-Runs the legacy branch-and-bound bound prover with an optional maximum
+Runs the original branch-and-bound bound prover with an optional maximum
 iteration count:
 
 ```text

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,18 +5,6 @@ LeanCert's current public claims are documented in the
 [verification-status table](architecture/verification-status.md). The items
 below are convergence work, not features claimed as complete.
 
-## Direct typed semantic solvers
-
-**Current state:** the semantic router has structured plans, reports, and
-execution metadata, while several historical tactics still enter through
-compatibility adapters.
-
-**Milestone:** migrate the remaining point, monolithic bound-fallback, and
-extrema paths to direct typed outcomes without changing public tactic syntax.
-
-**Evidence:** structural protocol tests show that failed attempts cannot leak
-proof state or telemetry, and reports identify observed execution only.
-
 ## Checked-backend capability parity
 
 **Current state:** Rational, Dyadic, and Affine backends deliberately have

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -43,7 +43,7 @@ module.
 | Example | Exact advanced control | Certificate/trust story | Median |
 | --- | --- | --- | ---: |
 | `log 2 < 0.7` | `interval_auto 10` | observed Dyadic checker; native default | 6.056 s |
-| nonlinear quantified bound | `certify_bound 10` | observed Rational fallback; legacy route unobserved | 6.198 s |
+| nonlinear quantified bound | `certify_bound 10` | observed Rational checker and verification route | 6.198 s |
 | two-variable box | `multivariate_bound` | checked branch-and-bound certificate | 6.311 s |
 | unique square root | `interval_unique_root` | checked interval-Newton certificate | 7.044 s |
 | polynomial integral | `integral_exact` | exact rational kernel proof | 6.149 s |

--- a/scripts/check_solver_protocol_policy.py
+++ b/scripts/check_solver_protocol_policy.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Reject reintroduction of retired solver-protocol compatibility APIs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_ROOT = ROOT / "LeanCert" / "Tactic"
+
+FORBIDDEN = (
+    "legacyExceptionAdapter",
+    "legacyInconclusive",
+    "solveReported",
+    "solveReportedResult",
+    "StrategyId.legacy",
+    "proveWithTactic",
+    "proveWithTacticReported",
+    "proveWithTacticReportedResult",
+    "closeCertificateGoalReported",
+    "closeCertificateGoal",
+    "closeBridgeWithVerificationReported",
+    "closeBridgeWithNativeDecide",
+    "intervalArgmaxCoreReported",
+    "intervalArgminCoreReported",
+    "intervalRootsCoreReported",
+    "intervalUniqueRootCoreReported",
+    "optBoundCoreReported",
+    "multivariateBoundCoreReported",
+    "rootBoundCoreReported",
+    "proveClosedExpressionBoundReported",
+    "tryDyadicBoundReported",
+    "intervalBoundCoreReported",
+    "finSumBoundCoreReported",
+    "integralExactCoreReported",
+    "integralSearchCoreReported",
+    "intervalBoundSubdivWithDepthReported",
+    "intervalArgmaxCore",
+    "intervalArgminCore",
+    "intervalRootsCore",
+    "intervalUniqueRootCore",
+    "intervalMinimizeCore",
+    "intervalMaximizeCore",
+    "intervalMinimizeMvCore",
+    "intervalMaximizeMvCore",
+    "optBoundCore",
+    "multivariateBoundCore",
+    "rootBoundCore",
+    "proveClosedExpressionBound",
+    "finSumWitnessCore",
+    "finSumWitnessAutoCore",
+    "finSumBoundCore",
+    "integralExactCore",
+    "integralSearchCore",
+    "intervalBoundSubdivWithDepth",
+)
+
+
+def violations(root: Path) -> list[tuple[Path, int, str]]:
+    found: list[tuple[Path, int, str]] = []
+    for path in sorted(root.rglob("*.lean")):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            for identifier in FORBIDDEN:
+                token = re.escape(identifier)
+                if re.search(
+                    rf"(?<![A-Za-z0-9_]){token}(?![A-Za-z0-9_])",
+                    line,
+                ):
+                    found.append((path, line_number, identifier))
+    return found
+
+
+def main() -> int:
+    found = violations(PRODUCTION_ROOT)
+    if found:
+        print("Retired solver-protocol identifiers found:", file=sys.stderr)
+        for path, line_number, identifier in found:
+            relative = path.relative_to(ROOT)
+            print(
+                f"  - {relative}:{line_number}: {identifier}",
+                file=sys.stderr,
+            )
+        return 1
+    print("Solver protocol policy check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_solver_protocol_policy.py
+++ b/scripts/tests/test_solver_protocol_policy.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts" / "check_solver_protocol_policy.py"
+SPEC = importlib.util.spec_from_file_location("solver_protocol_policy", CHECKER)
+assert SPEC is not None and SPEC.loader is not None
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+
+class SolverProtocolPolicyTests(unittest.TestCase):
+    def test_clean_typed_source_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Typed.lean").write_text(
+                "def solve := proveWithTypedSolver plan attempt\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(policy.violations(root), [])
+
+    def test_retired_identifier_is_reported_with_location(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = root / "Legacy.lean"
+            path.write_text(
+                "def first := true\n"
+                "def bad := legacyExceptionAdapter\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                policy.violations(root),
+                [(path, 2, "legacyExceptionAdapter")],
+            )
+
+    def test_unrelated_reported_state_is_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "State.lean").write_text(
+                "def autoFallbackReported := true\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(policy.violations(root), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Completes the typed solver-protocol migration by removing the remaining legacy adapters and throwing compatibility layers.

- Replaces the transitional multi-interface `SolverSpec` with one typed solver entry point.
- Routes every portfolio strategy through transactional `Except AttemptFailure SolverExecution` results.
- Adds explicit strategy identities for normalization, certificate checks, conjunctions, roots, extrema, finite sums, and integrals.
- Makes typed certificate and bridge verification the canonical internal APIs.
- Removes obsolete `*Reported`, throwing core wrappers, and stale legacy implementations.
- Ensures expected failures remain typed and resumable where appropriate, while unexpected exceptions and logged errors are terminal internal failures.
- Reports only checker, verifier, backend, and verification metadata observed during the retained successful execution.
- Adds a CI policy preventing retired protocol APIs from being reintroduced.
- Updates structural tests, public API isolation, diagnostics, architecture documentation, and the roadmap.