### PR TITLE
Feature/typed enclosure extensions

### DIFF
--- a/LeanCert/Tactic.lean
+++ b/LeanCert/Tactic.lean
@@ -11,6 +11,7 @@ import LeanCert.Tactic.FinSumWitness
 import LeanCert.Tactic.VecSimp
 import LeanCert.Tactic.LeanCert
 import LeanCert.Tactic.Discovery
+import LeanCert.Tactic.Extension
 
 /-!
 # LeanCert tactic API

--- a/LeanCert/Tactic/Extension.lean
+++ b/LeanCert/Tactic/Extension.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.Extension.Protocol
+import LeanCert.Tactic.Extension.Registry
+import LeanCert.Tactic.Extension.Command
+
+/-!
+# LeanCert downstream tactic extensions
+
+Stable import for registering and inspecting checked downstream enclosure rules.
+Automatic execution by `leancert` is intentionally provided by a separate layer.
+-/

--- a/LeanCert/Tactic/Extension/Command.lean
+++ b/LeanCert/Tactic/Extension/Command.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.Extension.Registry
+
+/-!
+# Inspection command for registered enclosure rules
+-/
+
+open Lean Elab Command
+
+namespace LeanCert.Tactic.Extension
+
+/-- Print every enclosure rule, or only rules registered for the supplied function. -/
+syntax (name := printLeanCertRules) "#print_leancert_rules" (ppSpace ident)? : command
+
+elab_rules : command
+  | `(command| #print_leancert_rules $[$functionStx:ident]?) => do
+      let env ← getEnv
+      let rules ← match functionStx with
+        | none => pure <| getAllUnaryEnclosureRules env
+        | some stx =>
+            let functionName ← resolveGlobalConstNoOverload stx
+            pure <| getUnaryEnclosureRules env functionName
+      if rules.isEmpty then
+        logInfo "No registered LeanCert enclosure rules."
+      else
+        let mut message : MessageData := "Registered LeanCert enclosure rules:"
+        for rule in rules do
+          message := message ++ m!"\n{rule.functionName}\n  theorem: {rule.theoremName}\n  \
+            checker: {rule.checkerName}\n  candidate: {rule.candidateName}\n  \
+            priority: {rule.rulePriority}\n  kind: unary ℝ → ℝ enclosure"
+        logInfo message
+
+end LeanCert.Tactic.Extension

--- a/LeanCert/Tactic/Extension/Execute.lean
+++ b/LeanCert/Tactic/Extension/Execute.lean
@@ -1,0 +1,341 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Engine.Eval.Core
+import LeanCert.Meta.Numeral
+import LeanCert.Tactic.Extension.Registry
+import LeanCert.Tactic.LeanCert.Bridge.ReifiedFunction
+import LeanCert.Tactic.LeanCert.Semantic.Prepare
+import LeanCert.Tactic.Verification
+
+/-!
+# Execution of registered unary enclosure rules
+
+This module is the tactic-side consumer of the persistent extension registry.
+It deliberately leaves candidate generation untrusted: only a successfully
+verified checker and its registered soundness theorem contribute to the proof.
+-/
+
+open Lean Meta Elab Tactic
+
+namespace LeanCert.Tactic.Extension
+
+open LeanCert.Core
+open LeanCert.Tactic.Semantic
+
+initialize registerTraceClass `LeanCert.extension
+
+/-- Expected, typed non-successes from registered enclosure execution. -/
+inductive RegisteredEnclosureFailure where
+  | notApplicable
+  | unsupported (expression detail : String)
+  | domainObstruction (operation detail : String)
+  | inconclusive (detail : String) (enclosure : Option IntervalRat := none)
+  | rejected (checker : Option Name) (enclosure : Option IntervalRat) (detail : String)
+  | verificationFailure (detail : String)
+  deriving Inhabited
+
+/-- One registered checker proof retained by successful execution. -/
+structure RegisteredEnclosureObservation where
+  rule : UnaryEnclosureRule
+  enclosure : IntervalRat
+  verification : LeanCert.Tactic.VerificationUsage
+  deriving Inhabited
+
+/-- Retained facts from a successful registered enclosure proof. -/
+structure RegisteredEnclosureOutcome where
+  enclosure : IntervalRat
+  observations : Array RegisteredEnclosureObservation
+  verification : LeanCert.Tactic.VerificationUsage
+  deriving Inhabited
+
+private structure EnclosedTerm where
+  value : Lean.Expr
+  interval : IntervalRat
+  intervalExpr : Lean.Expr
+  membership : Lean.Expr
+  observations : Array RegisteredEnclosureObservation := #[]
+  verification : LeanCert.Tactic.VerificationUsage := {}
+
+private def mkIntervalExpr (interval : IntervalRat) : MetaM Lean.Expr := do
+  let ordered ← mkDecideProof (← mkAppM ``LE.le #[toExpr interval.lo, toExpr interval.hi])
+  mkAppM ``IntervalRat.mk #[toExpr interval.lo, toExpr interval.hi, ordered]
+
+private def mkRequestExpr (input : Lean.Expr) (precision : Int)
+    (taylorDepth : Nat) : MetaM Lean.Expr :=
+  mkAppM ``UnaryEnclosureRequest.mk #[input, toExpr precision, toExpr taylorDepth]
+
+private def proveByNormNum (proposition : Lean.Expr) : TacticM Lean.Expr := do
+  let originalGoals ← getGoals
+  let saved ← saveState
+  let proof ← mkFreshExprMVar proposition MetavarKind.syntheticOpaque
+  setGoals [proof.mvarId!]
+  try
+    evalTactic (← `(tactic| norm_num [LeanCert.Core.IntervalRat.mem_def]))
+    unless (← getGoals).isEmpty do
+      throwError "exact rational comparison left proof obligations"
+    let proof ← instantiateMVars proof
+    if proof.hasMVar then
+      throwError "exact rational comparison contains metavariables"
+    setGoals originalGoals
+    return proof
+  catch exception =>
+    saved.restore
+    throw exception
+
+private def explicitMembership? (type : Lean.Expr) : Option (Lean.Expr × Lean.Expr) := do
+  guard <| type.getAppFn.constName? == some ``Membership.mem
+  let args := type.getAppArgs
+  guard <| 2 ≤ args.size
+  return (args[args.size - 1]!, args[args.size - 2]!)
+
+private def closeCheck (check : Lean.Expr) (role : String) :
+    TacticM (Except RegisteredEnclosureFailure (Lean.Expr × VerificationEvent)) := do
+  let proposition ← mkAppM ``Eq #[check, mkConst ``Bool.true]
+  let proof ← mkFreshExprMVar proposition MetavarKind.syntheticOpaque
+  let cfg ← VerificationConfig.current
+  match ← closeCertificateGoalTyped cfg proof.mvarId! (tacticName := role) with
+  | .accepted event =>
+      return .ok (← instantiateMVars proof, event)
+  | .rejected =>
+      return .error <| .rejected none none s!"{role} evaluated to false"
+  | .failed failure =>
+      return .error <| .verificationFailure (failure.message role)
+
+private def transportMembership (equality membership : Lean.Expr) : MetaM Lean.Expr := do
+  let equalityType ← inferType equality
+  let some (_, _, rhs) := equalityType.eq?
+    | throwError "registered enclosure transport expected an equality"
+  let membershipType ← inferType membership
+  let some (_, interval) := explicitMembership? membershipType
+    | throwError "registered enclosure transport expected interval membership"
+  let predicate ← withLocalDeclD `value (mkConst ``Real) fun value => do
+    let body ← mkAppM ``Membership.mem #[interval, value]
+    mkLambdaFVars #[value] body
+  let transportedEquality ← mkAppM ``congrArg #[predicate, equality]
+  let transported ← mkAppM ``Eq.mp #[transportedEquality, membership]
+  let expected ← mkAppM ``Membership.mem #[interval, rhs]
+  let actual ← inferType transported
+  unless ← isDefEq actual expected do
+    throwError "registered enclosure membership transport produced an unexpected type"
+  return transported
+
+private def encloseReified (x : Lean.Expr) (hx : Lean.Expr)
+    (inputExpr body : Lean.Expr)
+    (taylorDepth : Nat) : TacticM (Except RegisteredEnclosureFailure EnclosedTerm) := do
+  let function ← mkLambdaFVars #[x] body
+  try
+    discard <| LeanCert.Meta.reifyWithReport function
+  catch exception =>
+    return .error <| .unsupported (toString body)
+      (← exception.toMessageData.toString)
+  -- Once syntax reification succeeded, bridge-construction failures are
+  -- unexpected and must escape to the typed solver boundary as internal errors.
+  let reified ← LeanCert.Tactic.Bridge.reifyFunction function
+  let capabilities ← LeanCert.Tactic.Bridge.deriveCapabilities reified
+  let some supported := capabilities.supportedCore
+    | return .error <| .unsupported (toString body)
+        "the inner expression has no core interval-support proof"
+  let cfgExpr ← mkAppM ``LeanCert.Engine.EvalConfig.mk #[toExpr taylorDepth]
+  let check ← mkAppM ``LeanCert.Engine.checkDomainValid1 #[reified.ast, inputExpr, cfgExpr]
+  let checked ← closeCheck check "registered enclosure inner-domain check"
+  let (domainCheckProof, event) ←
+    match checked with
+    | .ok result => pure result
+    | .error (.rejected ..) =>
+        return .error <| .domainObstruction "inner expression"
+          "the checked interval evaluator rejected a partial operation"
+    | .error failure => return .error failure
+  let domainProof ← mkAppM ``LeanCert.Engine.checkDomainValid1_correct
+    #[reified.ast, inputExpr, cfgExpr, domainCheckProof]
+  let resultExpr ← mkAppM ``LeanCert.Internal.Rational.evalTotalCore1
+    #[reified.ast, inputExpr, cfgExpr]
+  let result ← unsafe evalExpr IntervalRat (mkConst ``IntervalRat) resultExpr
+  let evalMembership ← mkAppM ``LeanCert.Engine.evalIntervalCore1_correct
+    #[reified.ast, supported, x, inputExpr, hx, cfgExpr, domainProof]
+  let equality ← instantiateMVars (mkApp reified.evalEq x)
+  let membership ← transportMembership equality evalMembership
+  return .ok {
+    value := body
+    interval := result
+    intervalExpr := resultExpr
+    membership
+    verification := event.toUsage
+  }
+
+private unsafe def runCandidate (rule : UnaryEnclosureRule)
+    (request : UnaryEnclosureRequest) (requestExpr : Lean.Expr)
+    (argument : EnclosedTerm) :
+    TacticM (Except RegisteredEnclosureFailure EnclosedTerm) := do
+  let candidateFn ← evalExpr UnaryEnclosureCandidate
+    (mkConst ``UnaryEnclosureCandidate) (mkConst rule.candidateName)
+  let output ←
+    match candidateFn request with
+    | .ok output => pure output
+    | .error (.domainObstruction detail) =>
+        return .error <| .domainObstruction rule.functionName.toString detail
+    | .error (.inconclusive detail) =>
+        return .error <| .inconclusive detail
+  let outputExpr ← mkIntervalExpr output
+  let check ← mkAppM rule.checkerName #[requestExpr, outputExpr]
+  let checked ← closeCheck check s!"registered enclosure checker `{rule.checkerName}`"
+  let (checkProof, event) ←
+    match checked with
+    | .ok result => pure result
+    | .error (.rejected ..) =>
+        return .error <| .rejected (some rule.checkerName) (some output)
+          "The registered candidate was rejected by its checker."
+    | .error failure => return .error failure
+  let proof := mkAppN (mkConst rule.theoremName)
+    #[requestExpr, argument.value, outputExpr, argument.membership, checkProof]
+  discard <| inferType proof
+  return .ok {
+    value := mkApp (mkConst rule.functionName) argument.value
+    interval := output
+    intervalExpr := outputExpr
+    membership := proof
+    observations := argument.observations.push {
+      rule
+      enclosure := output
+      verification := event.toUsage
+    }
+    verification := argument.verification.combine event.toUsage
+  }
+
+private unsafe def encloseTerm (x : Lean.Expr) (hx : Lean.Expr)
+    (inputExpr body : Lean.Expr)
+    (precision : Int) (taylorDepth : Nat) :
+    TacticM (Except RegisteredEnclosureFailure EnclosedTerm) := do
+  let body := body.headBeta
+  let rules := body.getAppFn.constName?.map
+    (getUnaryEnclosureRules (← getEnv)) |>.getD #[]
+  if rules.isEmpty then
+    return ← encloseReified x hx inputExpr body taylorDepth
+  let arguments := body.getAppArgs
+  unless arguments.size == 1 do
+    return .error <| .unsupported (toString body)
+      "registered unary enclosure function was not applied to exactly one argument"
+  let argumentResult ← encloseTerm x hx inputExpr arguments[0]! precision taylorDepth
+  let argument ←
+    match argumentResult with
+    | .ok argument => pure argument
+    | .error failure => return .error failure
+  let request : UnaryEnclosureRequest := {
+    input := argument.interval
+    precision
+    taylorDepth
+  }
+  let requestExpr ← mkRequestExpr argument.intervalExpr precision taylorDepth
+  let mut lastFailure : Option RegisteredEnclosureFailure := none
+  for rule in rules do
+    match ← runCandidate rule request requestExpr argument with
+    | .ok result => return .ok result
+    | .error failure@(.domainObstruction ..) => return .error failure
+    | .error failure@(.verificationFailure ..) => return .error failure
+    | .error failure => lastFailure := some failure
+  return .error <| lastFailure.getD <| .inconclusive
+    s!"no registered enclosure rule for `{body.getAppFn}` produced a certificate"
+
+private def containsRegisteredFunction (env : Environment) (expression : Lean.Expr) : Bool :=
+  (expression.find? fun subterm =>
+    subterm.getAppFn.constName?.any fun name =>
+      !(getUnaryEnclosureRules env name).isEmpty).isSome
+
+private def finalComparisonProof (comparison : Comparison) (functionOnLeft : Bool)
+    (bound : ℚ) (boundExpr : Lean.Expr) (enclosed : EnclosedTerm) :
+    TacticM (Except RegisteredEnclosureFailure Lean.Expr) := do
+  let endpoint := if functionOnLeft then enclosed.interval.hi else enclosed.interval.lo
+  let comparisonHolds :=
+    match comparison, functionOnLeft with
+    | .le, true => decide (endpoint ≤ bound)
+    | .le, false => decide (bound ≤ endpoint)
+    | .lt, true => decide (endpoint < bound)
+    | .lt, false => decide (bound < endpoint)
+    | _, _ => false
+  unless comparisonHolds do
+    return .error <| .inconclusive
+      s!"registered enclosure [{enclosed.interval.lo}, {enclosed.interval.hi}] does not prove the requested bound"
+      (some enclosed.interval)
+  let endpointReal ← mkAppOptM ``Rat.cast #[mkConst ``Real, none, toExpr endpoint]
+  let endpointComparison ←
+    match comparison, functionOnLeft with
+    | .le, true => mkAppM ``LE.le #[endpointReal, boundExpr]
+    | .le, false => mkAppM ``LE.le #[boundExpr, endpointReal]
+    | .lt, true => mkAppM ``LT.lt #[endpointReal, boundExpr]
+    | .lt, false => mkAppM ``LT.lt #[boundExpr, endpointReal]
+    | _, _ => throwError "unsupported registered enclosure comparison"
+  let endpointProof ← proveByNormNum endpointComparison
+  let membershipType ← inferType enclosed.membership
+  let some (_, _) := explicitMembership? membershipType
+    | throwError "registered enclosure theorem did not produce interval membership"
+  let side ←
+    if functionOnLeft then mkAppM ``And.right #[enclosed.membership]
+    else mkAppM ``And.left #[enclosed.membership]
+  let proof ←
+    match comparison, functionOnLeft with
+    | .le, true => mkAppM ``le_trans #[side, endpointProof]
+    | .le, false => mkAppM ``le_trans #[endpointProof, side]
+    | .lt, true => mkAppM ``lt_of_le_of_lt #[side, endpointProof]
+    | .lt, false => mkAppM ``lt_of_lt_of_le #[endpointProof, side]
+    | _, _ => throwError "unsupported registered enclosure comparison"
+  return .ok proof
+
+/-- Try to prove a unary quantified bound through imported enclosure rules. -/
+unsafe def registeredEnclosureBoundCoreTyped (prepared : PreparedGoal)
+    (precision : Int) (taylorDepth : Nat) :
+    TacticM (Except RegisteredEnclosureFailure RegisteredEnclosureOutcome) := do
+  let .bound spec := prepared.semantic
+    | return .error .notApplicable
+  unless spec.boundVars.size == 1 && prepared.domains.size == 1 do
+    return .error .notApplicable
+  unless spec.comparison == .le || spec.comparison == .lt do
+    return .error .notApplicable
+  let .closedRat _ inputExpr membershipIff := prepared.domains[0]!
+    | return .error .notApplicable
+  let goal ← getMainGoal
+  let (xId, goal) ← goal.intro1P
+  let (hxSourceId, goal) ← goal.intro1P
+  setGoals [goal]
+  goal.withContext do
+    let x := mkFVar xId
+    let hxSource := mkFVar hxSourceId
+    let iffAt ← mkAppM' membershipIff #[x]
+    let hx ← mkAppM ``Iff.mp #[iffAt, hxSource]
+    trace[LeanCert.extension] "transported source membership"
+    let lhs := (mkApp spec.lhs x).headBeta
+    let rhs := (mkApp spec.rhs x).headBeta
+    let lhsUses := lhs.containsFVar x.fvarId!
+    let rhsUses := rhs.containsFVar x.fvarId!
+    if lhsUses == rhsUses then
+      return .error .notApplicable
+    let functionOnLeft := lhsUses
+    let functionBody := if functionOnLeft then lhs else rhs
+    let boundBody := if functionOnLeft then rhs else lhs
+    unless containsRegisteredFunction (← getEnv) functionBody do
+      return .error .notApplicable
+    let some bound ← LeanCert.Meta.Numeral.toRat? boundBody
+      | return .error <| .unsupported (toString boundBody)
+          "registered enclosure bounds currently require a rational constant on the other side"
+    let enclosed ←
+      match ← encloseTerm x hx inputExpr functionBody precision taylorDepth with
+      | .ok enclosed => pure enclosed
+      | .error failure => return .error failure
+    trace[LeanCert.extension] "constructed registered enclosure proof"
+    if enclosed.observations.isEmpty then
+      return .error .notApplicable
+    let finalProof ←
+      match ← finalComparisonProof spec.comparison functionOnLeft bound boundBody enclosed with
+      | .ok proof => pure proof
+      | .error failure => return .error failure
+    trace[LeanCert.extension] "constructed final comparison proof"
+    goal.assign finalProof
+    replaceMainGoal []
+    return .ok {
+      enclosure := enclosed.interval
+      observations := enclosed.observations
+      verification := enclosed.verification
+    }
+
+end LeanCert.Tactic.Extension

--- a/LeanCert/Tactic/Extension/Protocol.lean
+++ b/LeanCert/Tactic/Extension/Protocol.lean
@@ -12,8 +12,8 @@ This module defines the data shared by downstream unary enclosure rules.  Candid
 generation is deliberately untrusted: a candidate becomes usable only after its
 registered Boolean checker and soundness theorem validate it.
 
-Execution of registered rules is not part of this module.  The registry is the stable
-boundary consumed by the semantic tactic in a follow-up layer.
+Execution of registered rules is not part of this lightweight module. The registry is
+the stable boundary consumed by the semantic tactic in a separate execution layer.
 -/
 
 namespace LeanCert.Tactic.Extension

--- a/LeanCert/Tactic/Extension/Protocol.lean
+++ b/LeanCert/Tactic/Extension/Protocol.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Core.IntervalRat.Basic
+
+/-!
+# Downstream enclosure extension protocol
+
+This module defines the data shared by downstream unary enclosure rules.  Candidate
+generation is deliberately untrusted: a candidate becomes usable only after its
+registered Boolean checker and soundness theorem validate it.
+
+Execution of registered rules is not part of this module.  The registry is the stable
+boundary consumed by the semantic tactic in a follow-up layer.
+-/
+
+namespace LeanCert.Tactic.Extension
+
+open LeanCert.Core
+
+/-- Input and effort controls supplied to a unary enclosure candidate generator. -/
+structure UnaryEnclosureRequest where
+  input : IntervalRat
+  precision : Int := -53
+  taylorDepth : Nat := 10
+  deriving Repr
+
+/-- Expected, non-exceptional reasons why an untrusted candidate generator may stop. -/
+inductive EnclosureCandidateFailure where
+  | domainObstruction (detail : String)
+  | inconclusive (detail : String)
+  deriving Repr, Inhabited
+
+/-- An untrusted generator of a proposed output interval for a unary real function. -/
+abbrev UnaryEnclosureCandidate :=
+  UnaryEnclosureRequest → Except EnclosureCandidateFailure IntervalRat
+
+/-- An executable checker for a proposed unary enclosure. -/
+abbrev UnaryEnclosureChecker :=
+  UnaryEnclosureRequest → IntervalRat → Bool
+
+/-- Serializable metadata retained for a registered unary enclosure theorem. -/
+structure UnaryEnclosureRule where
+  functionName : Lean.Name
+  candidateName : Lean.Name
+  checkerName : Lean.Name
+  theoremName : Lean.Name
+  rulePriority : Nat := 1000
+  deriving Repr, Inhabited, BEq
+
+end LeanCert.Tactic.Extension

--- a/LeanCert/Tactic/Extension/Registry.lean
+++ b/LeanCert/Tactic/Extension/Registry.lean
@@ -10,7 +10,7 @@ import Lean.Elab.Term
 /-!
 # Persistent registry for downstream enclosure rules
 
-`@[leancert_enclosure candidate := c]` registers a theorem with the exact shape
+`@[leancert_enclosure c]` registers a theorem with the exact shape
 
 ```lean
 theorem rule
@@ -31,7 +31,7 @@ namespace LeanCert.Tactic.Extension
 open LeanCert.Core
 
 /-- Attribute syntax for registering a unary enclosure theorem and its candidate generator. -/
-syntax (name := leancertEnclosureAttr) "leancert_enclosure" ppSpace "candidate" " := " ident
+syntax (name := leancertEnclosureAttr) "leancert_enclosure" ppSpace ident
   ("," ppSpace "priority" " := " num)? : attr
 
 private def insertRule (rules : Array UnaryEnclosureRule) (rule : UnaryEnclosureRule) :
@@ -188,9 +188,9 @@ initialize registerBuiltinAttribute {
       throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: soundness theorem depends \
         on sorry declaration `{sorryDecl}`"
     let (candidateStx, rulePriority) ← match stx with
-      | `(attr| leancert_enclosure candidate := $candidateStx:ident) =>
+      | `(attr| leancert_enclosure $candidateStx:ident) =>
           pure (candidateStx, 1000)
-      | `(attr| leancert_enclosure candidate := $candidateStx:ident, priority := $priorityStx:num) =>
+      | `(attr| leancert_enclosure $candidateStx:ident, priority := $priorityStx:num) =>
           pure (candidateStx, priorityStx.getNat)
       | _ => throwUnsupportedSyntax
     let candidateName ← resolveGlobalConstNoOverload candidateStx

--- a/LeanCert/Tactic/Extension/Registry.lean
+++ b/LeanCert/Tactic/Extension/Registry.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.Extension.Protocol
+import Lean.Compiler.IR.CompilerM
+import Lean.Elab.Term
+
+/-!
+# Persistent registry for downstream enclosure rules
+
+`@[leancert_enclosure candidate := c]` registers a theorem with the exact shape
+
+```lean
+theorem rule
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checker request output = true) :
+    f x ∈ output
+```
+
+The attribute validates the candidate, checker, function, and theorem types before
+adding serializable declaration metadata to a persistent environment extension.
+-/
+
+open Lean Meta Elab
+
+namespace LeanCert.Tactic.Extension
+
+open LeanCert.Core
+
+/-- Attribute syntax for registering a unary enclosure theorem and its candidate generator. -/
+syntax (name := leancertEnclosureAttr) "leancert_enclosure" ppSpace "candidate" " := " ident
+  ("," ppSpace "priority" " := " num)? : attr
+
+private def insertRule (rules : Array UnaryEnclosureRule) (rule : UnaryEnclosureRule) :
+    Array UnaryEnclosureRule :=
+  rules.push rule
+
+/-- Persistent registry of downstream unary enclosure rules. -/
+initialize unaryEnclosureRuleExt :
+    SimplePersistentEnvExtension UnaryEnclosureRule (Array UnaryEnclosureRule) ←
+  registerSimplePersistentEnvExtension {
+    name := `unaryEnclosureRuleExt
+    addEntryFn := insertRule
+    addImportedFn := fun imported => imported.foldl (init := #[]) fun acc rules => acc ++ rules
+  }
+
+private def ruleLt (a b : UnaryEnclosureRule) : Bool :=
+  a.rulePriority > b.rulePriority ||
+    (a.rulePriority == b.rulePriority && a.theoremName.toString < b.theoremName.toString)
+
+/-- All registered unary enclosure rules, sorted deterministically. -/
+def getAllUnaryEnclosureRules (env : Environment) : Array UnaryEnclosureRule :=
+  (unaryEnclosureRuleExt.getState env).qsort ruleLt
+
+/-- Registered unary enclosure rules for a particular function head. -/
+def getUnaryEnclosureRules (env : Environment) (functionName : Name) :
+    Array UnaryEnclosureRule :=
+  (getAllUnaryEnclosureRules env).filter fun rule => rule.functionName == functionName
+
+private def ensureDefEq (actual expected : Expr) (message : MessageData) : MetaM Unit := do
+  unless ← isDefEq actual expected do
+    throwError message
+
+private def explicitMembership? (type : Expr) : Option (Expr × Expr) := do
+  guard <| type.getAppFn.constName? == some ``Membership.mem
+  let args := type.getAppArgs
+  guard <| 2 ≤ args.size
+  return (args[args.size - 1]!, args[args.size - 2]!)
+
+private def explicitEq? (type : Expr) : Option (Expr × Expr) := do
+  guard <| type.getAppFn.constName? == some ``Eq
+  let args := type.getAppArgs
+  guard <| 2 ≤ args.size
+  return (args[args.size - 2]!, args[args.size - 1]!)
+
+private def validateUnaryRule (theoremName candidateName : Name) (rulePriority : Nat) :
+    MetaM UnaryEnclosureRule := do
+  let candidateInfo ← getConstInfo candidateName
+  ensureDefEq candidateInfo.type (mkConst ``UnaryEnclosureCandidate)
+    m!"invalid @[leancert_enclosure] candidate `{candidateName}`: expected type \
+      `UnaryEnclosureCandidate`, found{indentExpr candidateInfo.type}"
+
+  let theoremInfo ← getConstInfo theoremName
+  unless theoremInfo matches .thmInfo _ do
+    throwError "invalid @[leancert_enclosure] declaration `{theoremName}`: soundness boundary must \
+      be a proved theorem, not an axiom or definition"
+  forallTelescopeReducing theoremInfo.type fun xs conclusion => do
+    unless xs.size == 5 do
+      throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: expected exactly \
+        three data binders and two hypotheses, but found {xs.size} binders"
+
+    let request := xs[0]!
+    let x := xs[1]!
+    let output := xs[2]!
+    let hx := xs[3]!
+    let hcheck := xs[4]!
+
+    ensureDefEq (← inferType request) (mkConst ``UnaryEnclosureRequest)
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: first binder must have type \
+        `UnaryEnclosureRequest`"
+    ensureDefEq (← inferType x) (mkConst ``Real)
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: second binder must have type `ℝ`"
+    ensureDefEq (← inferType output) (mkConst ``IntervalRat)
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: third binder must have type \
+        `IntervalRat`"
+
+    let input ← mkAppM ``UnaryEnclosureRequest.input #[request]
+    let some (hxValue, hxInterval) := explicitMembership? (← inferType hx)
+      | throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: fourth binder must \
+          prove `x ∈ request.input`"
+    ensureDefEq hxValue x
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: input-membership hypothesis \
+        must concern the theorem's real argument"
+    ensureDefEq hxInterval input
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: input-membership hypothesis \
+        must use `request.input`"
+
+    let some (checkValue, checkExpected) := explicitEq? (← inferType hcheck)
+      | throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: fifth binder must \
+          prove `checker request output = true`"
+    ensureDefEq checkExpected (mkConst ``Bool.true)
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: checker hypothesis must compare \
+        against `true`"
+    let checkerFn := checkValue.getAppFn
+    let some checkerName := checkerFn.constName?
+      | throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: checker must have a \
+          declaration head"
+    let checkerArgs := checkValue.getAppArgs
+    unless checkerArgs.size == 2 do
+      throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: checker must be applied \
+        exactly to `request` and `output`"
+    ensureDefEq checkerArgs[0]! request
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: checker must use the theorem's \
+        request"
+    ensureDefEq checkerArgs[1]! output
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: checker must use the theorem's \
+        output interval"
+    let checkerInfo ← getConstInfo checkerName
+    ensureDefEq checkerInfo.type (mkConst ``UnaryEnclosureChecker)
+      m!"invalid @[leancert_enclosure] checker `{checkerName}`: expected type \
+        `UnaryEnclosureChecker`, found{indentExpr checkerInfo.type}"
+
+    let some (resultValue, resultInterval) := explicitMembership? conclusion
+      | throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: conclusion must have \
+          the form `f x ∈ output`"
+    ensureDefEq resultInterval output
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: conclusion must use the theorem's \
+        output interval"
+    let functionFn := resultValue.getAppFn
+    let some functionName := functionFn.constName?
+      | throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: enclosed function \
+          must have a declaration head"
+    let functionArgs := resultValue.getAppArgs
+    unless functionArgs.size == 1 do
+      throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: enclosed function must \
+        be a unary `ℝ → ℝ` declaration"
+    ensureDefEq functionArgs[0]! x
+      m!"invalid @[leancert_enclosure] theorem `{theoremName}`: conclusion must apply the \
+        enclosed function to the theorem's real argument"
+    let functionInfo ← getConstInfo functionName
+    let expectedFunctionType ← mkArrow (mkConst ``Real) (mkConst ``Real)
+    ensureDefEq functionInfo.type expectedFunctionType
+      m!"invalid @[leancert_enclosure] function `{functionName}`: expected type `ℝ → ℝ`, \
+        found{indentExpr functionInfo.type}"
+
+    return {
+      functionName
+      candidateName
+      checkerName
+      theoremName
+      rulePriority
+    }
+
+initialize registerBuiltinAttribute {
+  name := `leancertEnclosureAttr
+  descr := "register a checked unary real enclosure rule"
+  applicationTime := .afterCompilation
+  add := fun theoremName stx kind => do
+    unless kind == AttributeKind.global do
+      throwError "invalid attribute 'leancert_enclosure': registration must be global"
+    let env ← getEnv
+    unless (env.getModuleIdxFor? theoremName).isNone do
+      throwError "invalid attribute 'leancert_enclosure': declaration is in an imported module"
+    if let some sorryDecl := IR.getSorryDep env theoremName then
+      throwError "invalid @[leancert_enclosure] theorem `{theoremName}`: soundness theorem depends \
+        on sorry declaration `{sorryDecl}`"
+    let (candidateStx, rulePriority) ← match stx with
+      | `(attr| leancert_enclosure candidate := $candidateStx:ident) =>
+          pure (candidateStx, 1000)
+      | `(attr| leancert_enclosure candidate := $candidateStx:ident, priority := $priorityStx:num) =>
+          pure (candidateStx, priorityStx.getNat)
+      | _ => throwUnsupportedSyntax
+    let candidateName ← resolveGlobalConstNoOverload candidateStx
+    let rule ← MetaM.run' <| validateUnaryRule theoremName candidateName rulePriority
+    let rules := getAllUnaryEnclosureRules env
+    if rules.any fun existing => existing.theoremName == theoremName then
+      throwError "duplicate @[leancert_enclosure] registration for theorem `{theoremName}`"
+    setEnv <| unaryEnclosureRuleExt.addEntry env rule
+    recordExtraRevUseOfCurrentModule
+}
+
+end LeanCert.Tactic.Extension

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -10,6 +10,7 @@ import LeanCert.Tactic.LeanCert.Integral
 import LeanCert.Tactic.LeanCert.Semantic.Parse
 import LeanCert.Tactic.LeanCert.Semantic.Prepare
 import LeanCert.Tactic.LeanCert.Solver.Protocol
+import LeanCert.Tactic.Extension.Execute
 import LeanCert.Tactic.Discovery
 import LeanCert.Tactic.FinSumExpand
 import LeanCert.Engine.Search.CounterExample
@@ -188,6 +189,43 @@ private def directBoundExecution (outcome : Auto.IntervalBoundOutcome) :
     verifier := outcome.verifier
     notes
   }
+
+private def registeredEnclosureExecution
+    (outcome : Extension.RegisteredEnclosureOutcome) : SolverExecution := {
+  backend := some .rationalInterval
+  verificationUsage := Solver.VerificationUsage.ofEvents outcome.verification
+  enclosure := some outcome.enclosure
+  certificates := outcome.observations.map fun observation => {
+    role := s!"registered enclosure `{observation.rule.functionName}`"
+    checker := observation.rule.checkerName
+    verifier := some observation.rule.theoremName
+    verificationUsage := Solver.VerificationUsage.ofEvents observation.verification
+    enclosure := some observation.enclosure
+  }
+  notes := outcome.observations.map fun observation =>
+    s!"extension used: {observation.rule.functionName} via {observation.rule.theoremName}"
+}
+
+private unsafe def registeredEnclosureAttemptTyped (prepared : Semantic.PreparedGoal)
+    (depth : Nat) : TacticM (Except AttemptFailure SolverExecution) := do
+  match ← Extension.registeredEnclosureBoundCoreTyped prepared (-53) depth with
+  | .ok outcome => return .ok (registeredEnclosureExecution outcome)
+  | .error .notApplicable => return .error .notApplicable
+  | .error (.unsupported expression detail) =>
+      return .error <| .unsupported { expression, detail := some detail }
+  | .error (.domainObstruction operation detail) =>
+      return .error <| .domainObstruction {
+        source := { original := mkConst ``True, kind := .intervalRat }
+        operation := some operation
+        reason := detail
+      }
+  | .error (.inconclusive detail enclosure) =>
+      return .error <| .inconclusive { detail, enclosure }
+  | .error (.rejected checker enclosure detail) =>
+      return .error <| .rejected { checker, enclosure, detail }
+  | .error (.verificationFailure detail) =>
+      return .error <| .internalError
+        `LeanCert.Tactic.Extension.registeredEnclosureBoundCoreTyped detail
 
 private unsafe def directBoundAttemptTyped (depth : Nat) :
     TacticM (Except AttemptFailure SolverExecution) := do
@@ -1170,6 +1208,8 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
             {failure.detail}\n\nThis is a LeanCert bug: semantic normalization failed \
             before any numerical strategy ran."
     return (semantic, prepared)
+  let mut preliminaryFailures : Array (String × AttemptOutcome) := #[]
+  let mut preliminarySpent := 0
 
   if let .allOf _ _ := semantic then
     let conjunctionSpec : SolverSpec := {
@@ -1265,26 +1305,46 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
           "  • at least one endpoint is symbolic; current certificate backends \
             require rational endpoints"
         ]
+    if cfg.budget > 0 then
+      let extensionPlan := report .intervalBound
+        "registered compositional enclosure" cfg verificationMode
+        (.fixed .rationalInterval)
+        none
+        (some "imported unary enclosure rule with a checked inner argument")
+        .registeredEnclosure
+      let extensionSpec : SolverSpec := {
+        report := extensionPlan
+        solve := registeredEnclosureAttemptTyped prepared cfg.taylorDepth
+      }
+      match ← trySolver extensionSpec with
+      | .proved artifact => return ← commitArtifact artifact
+      | .notApplicable => pure ()
+      | outcome =>
+          preliminarySpent := 1
+          preliminaryFailures := preliminaryFailures.push
+            (extensionPlan.strategy, outcome)
+          enforceAttemptDisposition verbosity .intervalBound outcome
     rejectUnsupportedPreparedFunctions prepared verbosity
     -- Domain validity is an executable precondition of the checked Rational
     -- evaluator. Diagnose its failure before treating a rejected certificate
     -- as mere numerical imprecision. This evaluation influences diagnostics
     -- only; proof acceptance still goes through the checked tactic core.
     for function in prepared.functions do
-      let source := match function with
-        | .ready source .. | .unsupported source .. | .deferred source .. => source
-      let ast := (← LeanCert.Meta.reifyWithReport source).expr
-      for domain in prepared.domains do
-        if let .closedRat _ interval _ := domain then
-          let cfgExpr ← mkAppM ``LeanCert.Engine.EvalConfig.mk
-            #[toExpr cfg.taylorDepth]
-          let check ← mkAppM ``LeanCert.Engine.checkDomainValid1
-            #[ast, interval, cfgExpr]
-          let valid ← unsafe evalExpr Bool (mkConst ``Bool) check
-          unless valid do
-            throwRouterFailure verbosity <|
-              Diagnostic.RouterFailure.domainObstruction .intervalBound
-                "the checked evaluator rejected a partial operation on this interval"
+      match function with
+      | .unsupported .. | .deferred .. => pure ()
+      | .ready source .. =>
+          let ast := (← LeanCert.Meta.reifyWithReport source).expr
+          for domain in prepared.domains do
+            if let .closedRat _ interval _ := domain then
+              let cfgExpr ← mkAppM ``LeanCert.Engine.EvalConfig.mk
+                #[toExpr cfg.taylorDepth]
+              let check ← mkAppM ``LeanCert.Engine.checkDomainValid1
+                #[ast, interval, cfgExpr]
+              let valid ← unsafe evalExpr Bool (mkConst ``Bool) check
+              unless valid do
+                throwRouterFailure verbosity <|
+                  Diagnostic.RouterFailure.domainObstruction .intervalBound
+                    "the checked evaluator rejected a partial operation on this interval"
 
   if let .root spec := semantic then
     if prepared.domains.any (fun domain => domain.isProvablyEmpty) then
@@ -1443,8 +1503,8 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
     | throwError "leancert: parsed a semantic goal whose solver has not been migrated"
 
   let solvers := (portfolio intent cfg verificationMode).map SolverSpec.toSemanticSolver
-  let mut failures : Array (String × AttemptOutcome) := #[]
-  let mut spent := 0
+  let mut failures : Array (String × AttemptOutcome) := preliminaryFailures
+  let mut spent := preliminarySpent
   for solver in solvers do
     unless solver.supports semantic do
       continue

--- a/LeanCert/Tactic/LeanCert/Semantic/Prepare.lean
+++ b/LeanCert/Tactic/LeanCert/Semantic/Prepare.lean
@@ -6,6 +6,7 @@ Authors: LeanCert Contributors
 import Mathlib.Tactic
 import LeanCert.Core.IntervalRat.Basic
 import LeanCert.Meta.Numeral
+import LeanCert.Tactic.Extension.Registry
 import LeanCert.Tactic.LeanCert.Bridge.ReifiedFunction
 import LeanCert.Tactic.LeanCert.Semantic.Goal
 
@@ -130,6 +131,12 @@ private def prepareFunction (function : Lean.Expr) : TacticM PreparedFunction :=
   try
     discard <| LeanCert.Meta.reifyWithReport function
   catch exception =>
+    let env ← getEnv
+    let containsRegisteredRule := function.find? fun expression =>
+      expression.getAppFn.constName?.any fun name =>
+        !(LeanCert.Tactic.Extension.getUnaryEnclosureRules env name).isEmpty
+    if containsRegisteredRule.isSome then
+      return .deferred function "contains a registered downstream enclosure function"
     return .unsupported function (← exception.toMessageData.toString)
   try
     let reified ← LeanCert.Tactic.Bridge.reifyFunction function

--- a/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
+++ b/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
@@ -166,6 +166,7 @@ inductive StrategyId where
   | certificateCheck
   | pointEnclosure
   | intervalEnclosure
+  | registeredEnclosure
   | subdivision
   | globalOptimization
   | multivariateOptimization

--- a/LeanCert/Test/DownstreamPatterns/Extension.lean
+++ b/LeanCert/Test/DownstreamPatterns/Extension.lean
@@ -26,7 +26,7 @@ def shiftedCandidate (request : UnaryEnclosureRequest) :
 def checkShifted (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
   decide (output = IntervalRat.add request.input (IntervalRat.singleton 1))
 
-@[leancert_enclosure candidate := shiftedCandidate, priority := 1200]
+@[leancert_enclosure shiftedCandidate, priority := 1200]
 theorem shifted_mem
     {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
     (hx : x ∈ request.input)
@@ -37,13 +37,53 @@ theorem shifted_mem
   rw [hout]
   simpa [shifted] using IntervalRat.mem_add hx (IntervalRat.mem_singleton 1)
 
-@[leancert_enclosure candidate := shiftedCandidate, priority := 100]
+@[leancert_enclosure shiftedCandidate, priority := 100]
 theorem shifted_mem_fallback
     {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
     (hx : x ∈ request.input)
     (hcheck : checkShifted request output = true) :
     shifted x ∈ output := by
   exact shifted_mem hx hcheck
+
+/-- A deliberately non-reifiable downstream function used to exercise the
+registered execution path rather than LeanCert's built-in expression bridge. -/
+noncomputable def positiveBranch (x : ℝ) : ℝ := if x ≤ 0 then 0 else x
+
+def positiveBranchCandidate (request : UnaryEnclosureRequest) :
+    Except EnclosureCandidateFailure IntervalRat :=
+  if 0 < request.input.lo then .ok request.input
+  else .error <| .domainObstruction "input interval is not strictly positive"
+
+def checkPositiveBranch (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
+  decide (0 < request.input.lo) && decide (output = request.input)
+
+/-- A higher-priority bad candidate checks the fallback path to the next
+registered rule without weakening the soundness boundary. -/
+def rejectedPositiveBranchCandidate (request : UnaryEnclosureRequest) :
+    Except EnclosureCandidateFailure IntervalRat := .ok request.input
+
+def rejectPositiveBranch (_request : UnaryEnclosureRequest) (_output : IntervalRat) : Bool :=
+  false
+
+@[leancert_enclosure rejectedPositiveBranchCandidate, priority := 1300]
+theorem rejected_positiveBranch_mem
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (_hx : x ∈ request.input)
+    (hcheck : rejectPositiveBranch request output = true) :
+    positiveBranch x ∈ output := by
+  simp [rejectPositiveBranch] at hcheck
+
+@[leancert_enclosure positiveBranchCandidate, priority := 1200]
+theorem positiveBranch_mem
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkPositiveBranch request output = true) :
+    positiveBranch x ∈ output := by
+  simp only [checkPositiveBranch, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨hpositive, rfl⟩
+  have hxpositive : 0 < x := by
+    exact lt_of_lt_of_le (by exact_mod_cast hpositive) hx.1
+  simpa [positiveBranch, not_le.mpr hxpositive] using hx
 
 run_meta do
   let env ← getEnv

--- a/LeanCert/Test/DownstreamPatterns/Extension.lean
+++ b/LeanCert/Test/DownstreamPatterns/Extension.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.Extension
+
+/-!
+# Downstream enclosure-extension pattern
+
+This module intentionally imports only the extension umbrella.  It models a downstream
+package registering a function without editing LeanCert's expression AST or router.
+-/
+
+namespace LeanCert.Test.DownstreamPatterns.Extension
+
+open Lean Elab Command
+open LeanCert.Core LeanCert.Tactic.Extension
+
+def shifted (x : ℝ) : ℝ := x + 1
+
+def shiftedCandidate (request : UnaryEnclosureRequest) :
+    Except EnclosureCandidateFailure IntervalRat :=
+  .ok <| IntervalRat.add request.input (IntervalRat.singleton 1)
+
+def checkShifted (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
+  decide (output = IntervalRat.add request.input (IntervalRat.singleton 1))
+
+@[leancert_enclosure candidate := shiftedCandidate, priority := 1200]
+theorem shifted_mem
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkShifted request output = true) :
+    shifted x ∈ output := by
+  have hout : output = IntervalRat.add request.input (IntervalRat.singleton 1) := by
+    exact of_decide_eq_true hcheck
+  rw [hout]
+  simpa [shifted] using IntervalRat.mem_add hx (IntervalRat.mem_singleton 1)
+
+@[leancert_enclosure candidate := shiftedCandidate, priority := 100]
+theorem shifted_mem_fallback
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkShifted request output = true) :
+    shifted x ∈ output := by
+  exact shifted_mem hx hcheck
+
+run_meta do
+  let env ← getEnv
+  let rules := getUnaryEnclosureRules env ``shifted
+  unless rules.size == 2 do
+    throwError "expected two downstream shifted rules, found {rules.size}"
+  unless rules[0]!.theoremName == ``shifted_mem && rules[0]!.rulePriority == 1200 do
+    throwError "highest-priority downstream rule was not ordered first"
+  for moduleName in env.header.moduleNames do
+    if (`LeanCert.Tactic.LeanCert.Router).isPrefixOf moduleName then
+      throwError "extension-only import leaked router module {moduleName}"
+
+end LeanCert.Test.DownstreamPatterns.Extension

--- a/LeanCert/Test/ExtensionExecution.lean
+++ b/LeanCert/Test/ExtensionExecution.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic
+import LeanCert.Test.DownstreamPatterns.Extension
+
+/-! # End-to-end execution of downstream enclosure rules -/
+
+namespace LeanCert.Test.ExtensionExecution
+
+open LeanCert.Test.DownstreamPatterns.Extension
+
+/-- Merely importing rules must not consume budget for ordinary expressions. -/
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, x ^ 2 ≤ 1 := by
+  leancert (budget := 1)
+
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, positiveBranch (x + 1) ≤ 2 := by
+  leancert
+
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, (1 : ℝ) ≤ positiveBranch (x + 1) := by
+  leancert
+
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    positiveBranch (positiveBranch (x + 1)) ≤ 2 := by
+  leancert
+
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, positiveBranch (x + 1) < 3 := by
+  leancert?
+
+/-- error: LeanCert recognized: univariate interval bound
+
+Domain obstruction:
+  input interval is not strictly positive
+
+Narrow the domain or prove the required positivity/nonzero condition. Increasing numerical precision does not repair an invalid domain. -/
+#guard_msgs in
+example : ∀ x ∈ Set.Icc (-1 : ℝ) 1, positiveBranch x ≤ 1 := by
+  leancert
+
+end LeanCert.Test.ExtensionExecution

--- a/LeanCert/Test/ExtensionProtocol.lean
+++ b/LeanCert/Test/ExtensionProtocol.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Test.DownstreamPatterns.Extension
+
+/-! # Typed enclosure-extension registry tests -/
+
+namespace LeanCert.Test.ExtensionProtocol
+
+open Lean Elab Command
+open LeanCert.Core LeanCert.Tactic.Extension
+open LeanCert.Test.DownstreamPatterns.Extension
+
+run_meta do
+  let rules := getUnaryEnclosureRules (← getEnv) ``shifted
+  unless rules.size == 2 do
+    throwError "persistent enclosure rules did not survive import"
+  unless rules[0]!.candidateName == ``shiftedCandidate &&
+      rules[0]!.checkerName == ``checkShifted &&
+      rules[0]!.theoremName == ``shifted_mem do
+    throwError "registered enclosure metadata did not match its declarations"
+
+#print_leancert_rules shifted
+
+def identity (x : ℝ) : ℝ := x
+
+def identityCandidate (request : UnaryEnclosureRequest) :
+    Except EnclosureCandidateFailure IntervalRat :=
+  .ok request.input
+
+def checkIdentity (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
+  decide (output = request.input)
+
+def wrongCandidate (_request : UnaryEnclosureRequest) : Nat := 0
+
+/-- error: invalid @[leancert_enclosure] candidate `LeanCert.Test.ExtensionProtocol.wrongCandidate`: expected type `UnaryEnclosureCandidate`, found
+  UnaryEnclosureRequest → ℕ -/
+#guard_msgs in
+@[leancert_enclosure candidate := wrongCandidate]
+theorem rejectsWrongCandidate
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkIdentity request output = true) :
+    identity x ∈ output := by
+  have hout : output = request.input := of_decide_eq_true hcheck
+  simpa [identity, hout] using hx
+
+def impossibleChecker (_request : UnaryEnclosureRequest) (_output : IntervalRat) : Bool := false
+
+/-- error: invalid @[leancert_enclosure] theorem `LeanCert.Test.ExtensionProtocol.rejectsWrongInput`: input-membership hypothesis must use `request.input` -/
+#guard_msgs in
+@[leancert_enclosure candidate := identityCandidate]
+theorem rejectsWrongInput
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ output)
+    (_hcheck : impossibleChecker request output = true) :
+    identity x ∈ output := by
+  simpa [identity] using hx
+
+def alwaysTrueChecker (_request : UnaryEnclosureRequest) (_output : IntervalRat) : Bool := true
+
+/-- error: invalid @[leancert_enclosure] theorem `LeanCert.Test.ExtensionProtocol.rejectsFalseComparison`: checker hypothesis must compare against `true` -/
+#guard_msgs in
+@[leancert_enclosure candidate := identityCandidate]
+theorem rejectsFalseComparison
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (_hx : x ∈ request.input)
+    (hcheck : alwaysTrueChecker request output = false) :
+    identity x ∈ output := by
+  simp [alwaysTrueChecker] at hcheck
+
+/-- error: invalid @[leancert_enclosure] declaration `LeanCert.Test.ExtensionProtocol.rejectsDefinition`: soundness boundary must be a proved theorem, not an axiom or definition -/
+#guard_msgs in
+@[leancert_enclosure candidate := identityCandidate]
+def rejectsDefinition
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkIdentity request output = true) :
+    identity x ∈ output := by
+  have hout : output = request.input := of_decide_eq_true hcheck
+  simpa [identity, hout] using hx
+
+end LeanCert.Test.ExtensionProtocol

--- a/LeanCert/Test/ExtensionProtocol.lean
+++ b/LeanCert/Test/ExtensionProtocol.lean
@@ -38,7 +38,7 @@ def wrongCandidate (_request : UnaryEnclosureRequest) : Nat := 0
 /-- error: invalid @[leancert_enclosure] candidate `LeanCert.Test.ExtensionProtocol.wrongCandidate`: expected type `UnaryEnclosureCandidate`, found
   UnaryEnclosureRequest → ℕ -/
 #guard_msgs in
-@[leancert_enclosure candidate := wrongCandidate]
+@[leancert_enclosure wrongCandidate]
 theorem rejectsWrongCandidate
     {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
     (hx : x ∈ request.input)
@@ -51,7 +51,7 @@ def impossibleChecker (_request : UnaryEnclosureRequest) (_output : IntervalRat)
 
 /-- error: invalid @[leancert_enclosure] theorem `LeanCert.Test.ExtensionProtocol.rejectsWrongInput`: input-membership hypothesis must use `request.input` -/
 #guard_msgs in
-@[leancert_enclosure candidate := identityCandidate]
+@[leancert_enclosure identityCandidate]
 theorem rejectsWrongInput
     {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
     (hx : x ∈ output)
@@ -63,7 +63,7 @@ def alwaysTrueChecker (_request : UnaryEnclosureRequest) (_output : IntervalRat)
 
 /-- error: invalid @[leancert_enclosure] theorem `LeanCert.Test.ExtensionProtocol.rejectsFalseComparison`: checker hypothesis must compare against `true` -/
 #guard_msgs in
-@[leancert_enclosure candidate := identityCandidate]
+@[leancert_enclosure identityCandidate]
 theorem rejectsFalseComparison
     {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
     (_hx : x ∈ request.input)
@@ -73,7 +73,7 @@ theorem rejectsFalseComparison
 
 /-- error: invalid @[leancert_enclosure] declaration `LeanCert.Test.ExtensionProtocol.rejectsDefinition`: soundness boundary must be a proved theorem, not an axiom or definition -/
 #guard_msgs in
-@[leancert_enclosure candidate := identityCandidate]
+@[leancert_enclosure identityCandidate]
 def rejectsDefinition
     {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
     (hx : x ∈ request.input)

--- a/LeanCert/Test/PublicAPI/Extension.lean
+++ b/LeanCert/Test/PublicAPI/Extension.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.Extension
+
+/-! # Stable downstream enclosure-extension API and import boundary -/
+
+open Lean Elab Command
+
+#check LeanCert.Tactic.Extension.UnaryEnclosureRequest
+#check LeanCert.Tactic.Extension.EnclosureCandidateFailure
+#check LeanCert.Tactic.Extension.UnaryEnclosureCandidate
+#check LeanCert.Tactic.Extension.UnaryEnclosureChecker
+#check LeanCert.Tactic.Extension.UnaryEnclosureRule
+#check LeanCert.Tactic.Extension.getUnaryEnclosureRules
+#check LeanCert.Tactic.Extension.getAllUnaryEnclosureRules
+
+run_meta do
+  let env ← getEnv
+  for name in [
+      `LeanCert.Tactic.LeanCert.trySolver,
+      `LeanCert.Tactic.LeanCert.proveWithTypedSolver] do
+    if env.contains name then
+      throwError "extension API leaked semantic-router declaration {name}"
+  for moduleName in env.header.moduleNames do
+    if (`LeanCert.Tactic.LeanCert.Router).isPrefixOf moduleName then
+      throwError "extension API imported semantic-router module {moduleName}"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The main verified numerical path includes:
 - Checked automatic differentiation and global bound certificates
 - Root existence, exclusion, and Newton-style uniqueness certificates
 - Exact rational polynomial integration and certified partition integration
+- Checked downstream unary enclosure rules consumed compositionally by `leancert`
 - Domain-specific Chebyshev, analytic-number-theory, q-product, table, and
   neural-network certificate infrastructure
 
@@ -179,6 +180,9 @@ does not imply that the theorem is false.
   supported integrands generally use certified partition bounds.
 - Supported evaluators may require domain certificates, such as positivity for
   logarithms or exclusion of zero from denominator intervals.
+- Downstream enclosure execution currently targets unary interval bounds with
+  checked, reifiable inner arguments; surrounding custom operations and
+  adaptive subdivision remain follow-up work.
 
 Native verification is faster but additionally trusts Lean's compiler/runtime;
 kernel-only verification may be substantially more expensive. See the

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -40,6 +40,23 @@ See [Supported Public API](../reference/public-api.md) for the exact boundary.
 - Remove superseded internal names when their callers migrate; public additions
   should have one canonical owner from the start.
 
+## Downstream enclosure extensions
+
+Unary real enclosure rules defined outside LeanCert register through
+`LeanCert.Tactic.Extension`. A registration stores declaration metadata in a
+persistent environment extension; it must not add downstream functions to
+`LeanCert.Core.Expr` or hard-code them in the router.
+
+The candidate generator is untrusted and returns
+`Except EnclosureCandidateFailure IntervalRat`. The registered checker and
+soundness theorem are the checked boundary. The attribute validates the exact
+theorem schema and rejects definitions, axioms, and theorems depending on
+`sorry`. Keep registry construction independent of the semantic router so
+downstream packages can declare rules through a lightweight import.
+
+Execution of a registered rule is a tactic strategy and therefore follows the
+typed transactional requirements below.
+
 ## Tactic changes
 
 Every semantic-router extension returns

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -1,0 +1,101 @@
+# Downstream enclosure extensions
+
+`LeanCert.Tactic.Extension` is the registration boundary for checked enclosure
+rules defined outside LeanCert. The initial protocol supports unary real
+functions. It lets a downstream package register a candidate generator, a
+Boolean checker, and a soundness theorem without extending LeanCert's internal
+expression datatype.
+
+Registration and inspection are available now. Automatic execution of these
+rules by `leancert` is a separate follow-up layer; registering a rule does not
+yet change tactic routing.
+
+## Trust boundary
+
+A rule has three parts:
+
+1. The **candidate generator** proposes an output interval. It is untrusted and
+   may return a typed domain obstruction or inconclusive result.
+2. The **Boolean checker** validates the proposed interval.
+3. The **soundness theorem** turns a successful check into semantic interval
+   membership.
+
+Only the theorem establishes the mathematical result. A wrong candidate is
+rejected by the checker; it cannot make the registered theorem unsound.
+
+## Registering a unary rule
+
+```lean
+import LeanCert.Tactic.Extension
+
+namespace DownstreamExtensionExample
+
+open LeanCert.Core LeanCert.Tactic.Extension
+
+def shifted (x : ℝ) : ℝ := x + 1
+
+def shiftedCandidate (request : UnaryEnclosureRequest) :
+    Except EnclosureCandidateFailure IntervalRat :=
+  .ok <| IntervalRat.add request.input (IntervalRat.singleton 1)
+
+def checkShifted (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
+  decide (output = IntervalRat.add request.input (IntervalRat.singleton 1))
+
+@[leancert_enclosure candidate := shiftedCandidate, priority := 1200]
+theorem shifted_mem
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkShifted request output = true) :
+    shifted x ∈ output := by
+  have hout : output = IntervalRat.add request.input (IntervalRat.singleton 1) :=
+    of_decide_eq_true hcheck
+  rw [hout]
+  simpa [shifted] using IntervalRat.mem_add hx (IntervalRat.mem_singleton 1)
+
+end DownstreamExtensionExample
+```
+
+The theorem schema is intentionally exact. The attribute validates:
+
+- a candidate of type `UnaryEnclosureCandidate`;
+- a checker of type `UnaryEnclosureChecker`;
+- a declared function of type `ℝ → ℝ`;
+- the input hypothesis `x ∈ request.input`;
+- the checker hypothesis `checker request output = true`;
+- the conclusion `f x ∈ output`;
+- that the soundness declaration is a proved, `sorry`-free theorem.
+
+Malformed rules fail where the attribute is declared, rather than later during
+tactic execution. Rules for the same function are ordered by descending
+priority and then deterministically by theorem name.
+
+## Inspecting the registry
+
+Use the command without an argument to list every imported rule, or provide a
+function to filter the output:
+
+```lean
+import LeanCert.Tactic.Extension
+
+#print_leancert_rules
+```
+
+```text
+Registered LeanCert enclosure rules:
+DownstreamExtensionExample.shifted
+  theorem: DownstreamExtensionExample.shifted_mem
+  checker: DownstreamExtensionExample.checkShifted
+  candidate: DownstreamExtensionExample.shiftedCandidate
+  priority: 1200
+  kind: unary ℝ → ℝ enclosure
+```
+
+Metaprogramming clients may query `getUnaryEnclosureRules` for one function or
+`getAllUnaryEnclosureRules` for the complete deterministic registry.
+
+## Current scope
+
+The first protocol deliberately covers only unary `ℝ → ℝ` enclosure rules.
+Binary operations, derivative rules, monotonicity rules, and automatic
+compositional execution are not implied by this interface. They can be added
+without changing the meaning of existing unary registrations.

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -6,9 +6,10 @@ functions. It lets a downstream package register a candidate generator, a
 Boolean checker, and a soundness theorem without extending LeanCert's internal
 expression datatype.
 
-Registration and inspection are available now. Automatic execution of these
-rules by `leancert` is a separate follow-up layer; registering a rule does not
-yet change tactic routing.
+The semantic `leancert` front door executes imported rules transactionally for
+unary interval bounds. The lightweight `LeanCert.Tactic.Extension` import still
+contains only registration and inspection; import `LeanCert.Tactic` where the
+tactic itself is used.
 
 ## Trust boundary
 
@@ -26,31 +27,37 @@ rejected by the checker; it cannot make the registered theorem unsound.
 ## Registering a unary rule
 
 ```lean
-import LeanCert.Tactic.Extension
+import LeanCert.Tactic
 
 namespace DownstreamExtensionExample
 
 open LeanCert.Core LeanCert.Tactic.Extension
 
-def shifted (x : ℝ) : ℝ := x + 1
+noncomputable def positiveBranch (x : ℝ) : ℝ :=
+  if x ≤ 0 then 0 else x
 
-def shiftedCandidate (request : UnaryEnclosureRequest) :
+def positiveBranchCandidate (request : UnaryEnclosureRequest) :
     Except EnclosureCandidateFailure IntervalRat :=
-  .ok <| IntervalRat.add request.input (IntervalRat.singleton 1)
+  if 0 < request.input.lo then .ok request.input
+  else .error <| .domainObstruction "input interval is not strictly positive"
 
-def checkShifted (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
-  decide (output = IntervalRat.add request.input (IntervalRat.singleton 1))
+def checkPositiveBranch (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
+  decide (0 < request.input.lo) && decide (output = request.input)
 
-@[leancert_enclosure candidate := shiftedCandidate, priority := 1200]
-theorem shifted_mem
+@[leancert_enclosure positiveBranchCandidate, priority := 1200]
+theorem positiveBranch_mem
     {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
     (hx : x ∈ request.input)
-    (hcheck : checkShifted request output = true) :
-    shifted x ∈ output := by
-  have hout : output = IntervalRat.add request.input (IntervalRat.singleton 1) :=
-    of_decide_eq_true hcheck
-  rw [hout]
-  simpa [shifted] using IntervalRat.mem_add hx (IntervalRat.mem_singleton 1)
+    (hcheck : checkPositiveBranch request output = true) :
+    positiveBranch x ∈ output := by
+  simp only [checkPositiveBranch, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨hpositive, rfl⟩
+  have hxpositive : 0 < x := by
+    exact lt_of_lt_of_le (by exact_mod_cast hpositive) hx.1
+  simpa [positiveBranch, not_le.mpr hxpositive] using hx
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, positiveBranch (x + 1) ≤ 2 := by
+  leancert (trust := kernel)
 
 end DownstreamExtensionExample
 ```
@@ -69,6 +76,13 @@ Malformed rules fail where the attribute is declared, rather than later during
 tactic execution. Rules for the same function are ordered by descending
 priority and then deterministically by theorem name.
 
+Candidate failures also participate in routing. Return `.inconclusive` when a
+particular rule cannot construct a useful enclosure and a lower-priority rule
+may still succeed. Reserve `.domainObstruction` for a genuine mathematical
+precondition failure: it is terminal and prevents LeanCert from masking an
+invalid domain by continuing with another strategy. Candidate exceptions and
+verification-infrastructure failures are terminal internal errors.
+
 ## Inspecting the registry
 
 Use the command without an argument to list every imported rule, or provide a
@@ -82,10 +96,10 @@ import LeanCert.Tactic.Extension
 
 ```text
 Registered LeanCert enclosure rules:
-DownstreamExtensionExample.shifted
-  theorem: DownstreamExtensionExample.shifted_mem
-  checker: DownstreamExtensionExample.checkShifted
-  candidate: DownstreamExtensionExample.shiftedCandidate
+DownstreamExtensionExample.positiveBranch
+  theorem: DownstreamExtensionExample.positiveBranch_mem
+  checker: DownstreamExtensionExample.checkPositiveBranch
+  candidate: DownstreamExtensionExample.positiveBranchCandidate
   priority: 1200
   kind: unary ℝ → ℝ enclosure
 ```
@@ -95,7 +109,10 @@ Metaprogramming clients may query `getUnaryEnclosureRules` for one function or
 
 ## Current scope
 
-The first protocol deliberately covers only unary `ℝ → ℝ` enclosure rules.
-Binary operations, derivative rules, monotonicity rules, and automatic
-compositional execution are not implied by this interface. They can be added
-without changing the meaning of existing unary registrations.
+The first protocol deliberately covers unary `ℝ → ℝ` enclosure rules in
+univariate interval bounds with rational endpoints and a rational constant on
+the other side of the comparison. Registered applications may be nested, and
+their innermost argument may use LeanCert's ordinary reifiable expression
+fragment. Surrounding unsupported operations, derivative rules, monotonicity
+rules, and adaptive subdivision of rejected or inconclusive downstream
+candidates remain future extensions.

--- a/docs/reference/imports.md
+++ b/docs/reference/imports.md
@@ -33,6 +33,7 @@ loading tactic elaborators.
 ```lean
 import LeanCert.Tactic.IntervalAuto
 import LeanCert.Tactic.Bound
+import LeanCert.Tactic.Extension
 import LeanCert.Discovery.Commands
 import LeanCert.Tactic.Discovery
 ```

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -71,6 +71,10 @@ verification without changing the numerical backend.
 `LeanCert.Tactic` exposes supported proof automation, including the semantic
 `leancert` / `leancert?` front door and the dedicated `interval_auto`,
 `interval_decide`, `certify_bound`, root, optimization, and finite-sum tactics.
+`LeanCert.Tactic.Extension` exposes the typed, persistent registry for
+downstream unary enclosure rules. Registration validates a candidate, checker,
+and soundness theorem but does not yet make the semantic router execute that
+rule. See [Downstream enclosure extensions](extensions.md).
 
 `LeanCert.CertifiedBounds` exposes stable numerical-result interfaces under:
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -73,8 +73,8 @@ verification without changing the numerical backend.
 `interval_decide`, `certify_bound`, root, optimization, and finite-sum tactics.
 `LeanCert.Tactic.Extension` exposes the typed, persistent registry for
 downstream unary enclosure rules. Registration validates a candidate, checker,
-and soundness theorem but does not yet make the semantic router execute that
-rule. See [Downstream enclosure extensions](extensions.md).
+and soundness theorem. The semantic `leancert` front door can execute imported
+rules for unary interval bounds. See [Downstream enclosure extensions](extensions.md).
 
 `LeanCert.CertifiedBounds` exposes stable numerical-result interfaces under:
 

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -106,6 +106,13 @@ to the theorem stated by the user. Numerical interval certificates currently
 operate over `ℝ`; another carrier is reported as an unsupported domain rather
 than an internal verifier failure.
 
+Imported unary enclosure rules registered through
+`LeanCert.Tactic.Extension` participate in univariate interval bounds. The
+router first certifies a reifiable inner argument, verifies the downstream
+Boolean checker under the requested trust policy, and applies the registered
+soundness theorem. `leancert?` reports every retained downstream checker and
+theorem. See [Downstream enclosure extensions](extensions.md).
+
 Expected checker rejection, unsupported expressions, inconclusive enclosures,
 and certified counterexamples are rendered as separate diagnostic categories.
 Raw checker propositions are available only through

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,14 +9,16 @@ below are convergence work, not features claimed as complete.
 
 **Current state:** downstream modules can register and inspect typed unary
 `ℝ → ℝ` enclosure candidates, Boolean checkers, and `sorry`-free soundness
-theorems without modifying LeanCert's internal expression datatype.
+theorems without modifying LeanCert's internal expression datatype. `leancert`
+executes imported rules for unary interval bounds whose registered applications
+have checked, reifiable inner arguments.
 
-**Milestone:** execute registered rules compositionally through `leancert`,
-with transactional typed failures, subdivision support, and complete
-`leancert?` provenance.
+**Milestone:** extend compositional execution through surrounding registered or
+built-in operations, then add adaptive subdivision for inconclusive downstream
+candidates.
 
 **Evidence:** an external function certified end to end through an imported
-rule, including rejected-candidate and unsupported-function reports.
+rule, with rejected-candidate fallback and complete `leancert?` provenance.
 
 ## Checked-backend capability parity
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,6 +5,19 @@ LeanCert's current public claims are documented in the
 [verification-status table](architecture/verification-status.md). The items
 below are convergence work, not features claimed as complete.
 
+## Extensible checked enclosures
+
+**Current state:** downstream modules can register and inspect typed unary
+`ℝ → ℝ` enclosure candidates, Boolean checkers, and `sorry`-free soundness
+theorems without modifying LeanCert's internal expression datatype.
+
+**Milestone:** execute registered rules compositionally through `leancert`,
+with transactional typed failures, subdivision support, and complete
+`leancert?` provenance.
+
+**Evidence:** an external function certified end to end through an imported
+rule, including rejected-candidate and unsupported-function reports.
+
 ## Checked-backend capability parity
 
 **Current state:** Rational, Dyadic, and Affine backends deliberately have

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -127,6 +127,7 @@ roots = [
   "LeanCert.Test.ChebyshevTheta",
   "LeanCert.Test.EulerMascheroni",
   "LeanCert.Test.ExtensionProtocol",
+  "LeanCert.Test.ExtensionExecution",
   "LeanCert.Test.FinSumBound",
   "LeanCert.Test.FinSumExpandTest",
   "LeanCert.Test.Hardening",

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -74,6 +74,7 @@ roots = [
   "LeanCert.Test.DownstreamPatterns.PNTCompilers",
   "LeanCert.Test.DownstreamPatterns.Table4Ext",
   "LeanCert.Test.DownstreamPatterns.Li2",
+  "LeanCert.Test.DownstreamPatterns.Extension",
 ]
 precompileModules = false
 
@@ -125,6 +126,7 @@ roots = [
   "LeanCert.Test.ChebyshevPsi",
   "LeanCert.Test.ChebyshevTheta",
   "LeanCert.Test.EulerMascheroni",
+  "LeanCert.Test.ExtensionProtocol",
   "LeanCert.Test.FinSumBound",
   "LeanCert.Test.FinSumExpandTest",
   "LeanCert.Test.Hardening",
@@ -145,6 +147,7 @@ roots = [
   "LeanCert.Test.PublicAPI.Bounds",
   "LeanCert.Test.PublicAPI.CertifiedBoundsImport",
   "LeanCert.Test.PublicAPI.DomainUmbrellas",
+  "LeanCert.Test.PublicAPI.Extension",
   "LeanCert.Test.PublicAPI.TrustAxes",
   "LeanCert.Test.ReadmeTest",
   "LeanCert.Test.ReleaseTest",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
     - Roadmap: roadmap.md
   - Reference:
     - Supported Public API: reference/public-api.md
+    - Downstream Enclosure Extensions: reference/extensions.md
     - Removed APIs and Migration: reference/compatibility.md
     - Imports: reference/imports.md
     - Tactics: reference/tactics.md


### PR DESCRIPTION
# feat: add extensible checked enclosure rules

LeanCert’s interval evaluator has historically had a closed function vocabulary: supporting a downstream function required modifying LeanCert’s expression datatype, evaluator, router, and proofs.

This PR adds a typed extension protocol so downstream packages can teach `leancert` new unary real functions without modifying LeanCert core. A downstream rule supplies an untrusted candidate generator, a Boolean checker, and a proved soundness theorem; LeanCert only accepts the resulting enclosure after checking the certificate and applying that theorem.

## Example

```lean
@[leancert_enclosure positiveBranchCandidate, priority := 1200]
theorem positiveBranch_mem
    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
    (hx : x ∈ request.input)
    (hcheck : checkPositiveBranch request output = true) :
    positiveBranch x ∈ output := by
  ...
```

Once imported, the rule is available through the ordinary semantic front door:

```lean
example : ∀ x ∈ Set.Icc (0 : ℝ) 1, positiveBranch (x + 1) ≤ 2 := by
  leancert
```

## Summary

- add the typed `UnaryEnclosureRequest`, candidate, checker, and rule protocol
- add `@[leancert_enclosure ...]` with declaration-time signature and soundness validation
- add persistent, deterministic rule registration with priorities
- add `#print_leancert_rules` for inspecting imported extensions
- execute registered rules compositionally through `leancert`
- support nested registered applications over ordinary reifiable expressions
- fall back to lower-priority rules after rejected or inconclusive candidates
- preserve terminal classification for domain and verification failures
- include extension provenance in `leancert?` reports
- keep the lightweight registration import separate from the semantic router
- document the extension API, trust boundary, routing behavior, and current limitations

Candidate generation remains untrusted. Successful proofs retain the checked Boolean certificate and registered Golden Theorem; unexpected candidate or verification exceptions remain terminal internal errors.

## Current scope

This first version supports unary `ℝ → ℝ` rules in univariate interval bounds with rational endpoints and a rational constant on the other side. Registered applications may be nested, and their innermost argument may use LeanCert’s existing expression fragment.
