### PR TITLE
feat: compose registered enclosures through core expressions

### DIFF
--- a/LeanCert/Tactic/Extension/Execute.lean
+++ b/LeanCert/Tactic/Extension/Execute.lean
@@ -48,6 +48,7 @@ structure RegisteredEnclosureObservation where
 structure RegisteredEnclosureOutcome where
   enclosure : IntervalRat
   observations : Array RegisteredEnclosureObservation
+  compositionSteps : Nat := 0
   verification : LeanCert.Tactic.VerificationUsage
   deriving Inhabited
 
@@ -57,7 +58,101 @@ private structure EnclosedTerm where
   intervalExpr : Lean.Expr
   membership : Lean.Expr
   observations : Array RegisteredEnclosureObservation := #[]
+  compositionSteps : Nat := 0
   verification : LeanCert.Tactic.VerificationUsage := {}
+
+/-- Interval counterpart of `Bridge.realEnvironment`. -/
+private def intervalEnvironment (values : List IntervalRat) (index : Nat) : IntervalRat :=
+  match values with
+  | [value] => value
+  | _ => values.getD index (IntervalRat.singleton 0)
+
+private theorem getD_mem_environment
+    {values : List ℝ} {intervals : List IntervalRat}
+    (h : List.Forall₂ (fun value interval => value ∈ interval) values intervals) :
+    ∀ index, values.getD index 0 ∈ intervals.getD index (IntervalRat.singleton 0) := by
+  intro index
+  induction h generalizing index with
+  | nil => simpa using IntervalRat.mem_singleton (0 : ℚ)
+  | cons hmem _ ih =>
+      cases index with
+      | zero => simpa using hmem
+      | succ index => simpa using ih index
+
+private theorem environment_mem
+    {values : List ℝ} {intervals : List IntervalRat}
+    (h : List.Forall₂ (fun value interval => value ∈ interval) values intervals) :
+    LeanCert.Engine.envMem
+      (LeanCert.Tactic.Bridge.realEnvironment values)
+      (intervalEnvironment intervals) := by
+  intro index
+  cases h with
+  | nil =>
+      simpa [LeanCert.Tactic.Bridge.realEnvironment, intervalEnvironment] using
+        IntervalRat.mem_singleton (0 : ℚ)
+  | cons hmem htail =>
+      cases htail with
+      | nil =>
+          simpa [LeanCert.Tactic.Bridge.realEnvironment, intervalEnvironment] using hmem
+      | cons hmem' htail' =>
+          simpa [LeanCert.Tactic.Bridge.realEnvironment, intervalEnvironment] using
+            getD_mem_environment (.cons hmem (.cons hmem' htail')) index
+
+private def withRealLocals {α : Type} (count : Nat)
+    (continuation : Array Lean.Expr → TacticM α) : TacticM α := do
+  let rec loop (remaining : Nat) (locals : Array Lean.Expr) : TacticM α := do
+    match remaining with
+    | 0 => continuation locals
+    | remaining + 1 =>
+        withLocalDeclD `value (mkConst ``Real) fun value =>
+          loop remaining (locals.push value)
+  loop count #[]
+
+private partial def collectRegisteredRoots (env : Environment) (expression : Lean.Expr)
+    (roots : Array Lean.Expr := #[]) : Array Lean.Expr :=
+  if expression.getAppFn.constName?.any fun name =>
+      !(getUnaryEnclosureRules env name).isEmpty then
+    if roots.any (· == expression) then roots else roots.push expression
+  else
+    match expression with
+    | .app fn argument =>
+        collectRegisteredRoots env argument (collectRegisteredRoots env fn roots)
+    | .mdata _ body | .proj _ _ body => collectRegisteredRoots env body roots
+    | .letE _ type value body _ =>
+        collectRegisteredRoots env body <|
+          collectRegisteredRoots env value <| collectRegisteredRoots env type roots
+    | .lam _ type body _ | .forallE _ type body _ =>
+        collectRegisteredRoots env body (collectRegisteredRoots env type roots)
+    | _ => roots
+
+private def mkMembershipRelation : MetaM Lean.Expr := do
+  withLocalDeclD `value (mkConst ``Real) fun value =>
+    withLocalDeclD `interval (mkConst ``IntervalRat) fun interval => do
+      let membership ← mkAppM ``Membership.mem #[interval, value]
+      mkLambdaFVars #[value, interval] membership
+
+private def mkForall₂Membership (memberships : Array Lean.Expr) : MetaM Lean.Expr := do
+  let relation ← mkMembershipRelation
+  let emptyValues ← mkListLit (mkConst ``Real) []
+  let emptyIntervals ← mkListLit (mkConst ``IntervalRat) []
+  let mut values := emptyValues
+  let mut intervals := emptyIntervals
+  let mut proof ← mkAppOptM ``List.Forall₂.nil
+    #[some (mkConst ``Real), some (mkConst ``IntervalRat), some relation]
+  for membership in memberships.reverse do
+    let membershipType ← inferType membership
+    let arguments := membershipType.getAppArgs
+    if arguments.size < 2 then
+      throwError "registered enclosure atom did not have an explicit membership proposition"
+    let value := arguments[arguments.size - 1]!
+    let interval := arguments[arguments.size - 2]!
+    proof ← mkAppOptM ``List.Forall₂.cons #[
+      some (mkConst ``Real), some (mkConst ``IntervalRat), some relation,
+      some value, some interval, some values, some intervals,
+      some membership, some proof]
+    values ← mkAppM ``List.cons #[value, values]
+    intervals ← mkAppM ``List.cons #[interval, intervals]
+  return proof
 
 private def mkIntervalExpr (interval : IntervalRat) : MetaM Lean.Expr := do
   let ordered ← mkDecideProof (← mkAppM ``LE.le #[toExpr interval.lo, toExpr interval.hi])
@@ -81,6 +176,28 @@ private def proveByNormNum (proposition : Lean.Expr) : TacticM Lean.Expr := do
       throwError "exact rational comparison contains metavariables"
     setGoals originalGoals
     return proof
+  catch exception =>
+    saved.restore
+    throw exception
+
+private def proveRatCastComparison (rational real : Lean.Expr)
+    (rationalProof : Lean.Expr) : TacticM Lean.Expr := do
+  let originalGoals ← getGoals
+  let saved ← saveState
+  try
+    withLocalDeclD `h rational fun h => do
+      let proof ← mkFreshExprMVar real MetavarKind.syntheticOpaque
+      setGoals [proof.mvarId!]
+      let hSyntax ← Term.exprToSyntax h
+      evalTactic (← `(tactic| exact_mod_cast $hSyntax))
+      unless (← getGoals).isEmpty do
+        throwError "rational-cast comparison left proof obligations"
+      let proof ← instantiateMVars proof
+      if proof.hasMVar then
+        throwError "rational-cast comparison contains metavariables"
+      let implication ← mkLambdaFVars #[h] proof
+      setGoals originalGoals
+      return mkApp implication rationalProof
   catch exception =>
     saved.restore
     throw exception
@@ -121,6 +238,17 @@ private def transportMembership (equality membership : Lean.Expr) : MetaM Lean.E
   unless ← isDefEq actual expected do
     throwError "registered enclosure membership transport produced an unexpected type"
   return transported
+
+private def transportMembershipInterval (value membership targetInterval : Lean.Expr) : MetaM Lean.Expr := do
+  let membershipType ← inferType membership
+  let some (_, sourceInterval) := explicitMembership? membershipType
+    | throwError "registered enclosure interval transport expected interval membership"
+  let intervalEquality ← mkDecideProof (← mkAppM ``Eq #[sourceInterval, targetInterval])
+  let predicate ← withLocalDeclD `interval (mkConst ``IntervalRat) fun interval => do
+    let body ← mkAppM ``Membership.mem #[interval, value]
+    mkLambdaFVars #[interval] body
+  let transportedEquality ← mkAppM ``congrArg #[predicate, intervalEquality]
+  mkAppM ``Eq.mp #[transportedEquality, membership]
 
 private def encloseReified (x : Lean.Expr) (hx : Lean.Expr)
     (inputExpr body : Lean.Expr)
@@ -201,6 +329,7 @@ private unsafe def runCandidate (rule : UnaryEnclosureRule)
       enclosure := output
       verification := event.toUsage
     }
+    compositionSteps := argument.compositionSteps
     verification := argument.verification.combine event.toUsage
   }
 
@@ -209,10 +338,92 @@ private unsafe def encloseTerm (x : Lean.Expr) (hx : Lean.Expr)
     (precision : Int) (taylorDepth : Nat) :
     TacticM (Except RegisteredEnclosureFailure EnclosedTerm) := do
   let body := body.headBeta
+  let env ← getEnv
   let rules := body.getAppFn.constName?.map
-    (getUnaryEnclosureRules (← getEnv)) |>.getD #[]
+    (getUnaryEnclosureRules env) |>.getD #[]
   if rules.isEmpty then
-    return ← encloseReified x hx inputExpr body taylorDepth
+    let roots := collectRegisteredRoots env body
+    if roots.isEmpty then
+      return ← encloseReified x hx inputExpr body taylorDepth
+    let mut enclosedRoots : Array EnclosedTerm := #[]
+    for root in roots do
+      match ← encloseTerm x hx inputExpr root precision taylorDepth with
+      | .ok enclosed => enclosedRoots := enclosedRoots.push enclosed
+      | .error failure => return .error failure
+    -- This temporary tree is inspected only for free-variable occurrence. The
+    -- placeholder prevents variables inside registered roots from being counted;
+    -- it is never elaborated or used to construct a proof.
+    let bodyWithoutRoots := body.replace fun expression =>
+      if roots.any (· == expression) then some (mkConst ``True) else none
+    let needsInput := bodyWithoutRoots.containsFVar x.fvarId!
+    let localCount := roots.size + if needsInput then 1 else 0
+    return ← withRealLocals localCount fun locals => do
+      let transformed := body.replace fun expression =>
+        match roots.findIdx? (· == expression) with
+        | some index => some locals[index]!
+        | none =>
+            if needsInput && expression.isFVar && expression.fvarId! == x.fvarId! then
+              some locals[roots.size]!
+            else
+              none
+      let function ← mkLambdaFVars locals transformed
+      let reified ← LeanCert.Tactic.Bridge.reifyFunction function
+      let capabilities ← LeanCert.Tactic.Bridge.deriveCapabilities reified
+      let some supported := capabilities.supportedCore
+        | return .error <| .unsupported (toString body)
+            "the expression surrounding registered applications is not supported by the core evaluator"
+      let mut values := enclosedRoots.map (·.value)
+      let mut intervals := enclosedRoots.map (·.intervalExpr)
+      let mut memberships := enclosedRoots.map (·.membership)
+      if needsInput then
+        values := values.push x
+        intervals := intervals.push inputExpr
+        memberships := memberships.push hx
+      let valuesList ← mkListLit (mkConst ``Real) values.toList
+      let intervalsList ← mkListLit (mkConst ``IntervalRat) intervals.toList
+      let realEnv ← mkAppM ``LeanCert.Tactic.Bridge.realEnvironment #[valuesList]
+      let intervalEnv ← mkAppM ``intervalEnvironment #[intervalsList]
+      let membershipList ← mkForall₂Membership memberships
+      let environmentMembership ← mkAppM ``environment_mem #[membershipList]
+      let cfgExpr ← mkAppM ``LeanCert.Engine.EvalConfig.mk #[toExpr taylorDepth]
+      let check ← mkAppM ``LeanCert.Engine.checkDomainValid
+        #[reified.ast, intervalEnv, cfgExpr]
+      let checked ← closeCheck check "registered enclosure composition-domain check"
+      let (domainCheckProof, event) ←
+        match checked with
+        | .ok result => pure result
+        | .error (.rejected ..) =>
+            return .error <| .domainObstruction "surrounding expression"
+              "the checked interval evaluator rejected a partial operation"
+        | .error failure => return .error failure
+      let domainProof ← mkAppM ``LeanCert.Engine.checkDomainValid_correct
+        #[reified.ast, intervalEnv, cfgExpr, domainCheckProof]
+      let resultExpr ← mkAppM ``LeanCert.Internal.Rational.evalTotalCore
+        #[reified.ast, intervalEnv, cfgExpr]
+      let result ← unsafe evalExpr IntervalRat (mkConst ``IntervalRat) resultExpr
+      let explicitResultExpr ← mkIntervalExpr result
+      let evalMembership ← mkAppM ``LeanCert.Engine.evalIntervalCore_correct
+        #[reified.ast, supported, realEnv, intervalEnv, environmentMembership,
+          cfgExpr, domainProof]
+      let equality ← instantiateMVars (mkAppN reified.evalEq values)
+      let membership ← transportMembership equality evalMembership
+      let membership ← transportMembershipInterval body membership explicitResultExpr
+      let observations := enclosedRoots.foldl
+        (fun accumulated enclosed => accumulated ++ enclosed.observations) #[]
+      let compositionSteps := enclosedRoots.foldl
+        (fun accumulated enclosed => accumulated + enclosed.compositionSteps) 1
+      let verification := enclosedRoots.foldl
+        (fun accumulated enclosed => accumulated.combine enclosed.verification)
+        event.toUsage
+      return .ok {
+        value := body
+        interval := result
+        intervalExpr := explicitResultExpr
+        membership
+        observations
+        compositionSteps
+        verification
+      }
   let arguments := body.getAppArgs
   unless arguments.size == 1 do
     return .error <| .unsupported (toString body)
@@ -259,14 +470,39 @@ private def finalComparisonProof (comparison : Comparison) (functionOnLeft : Boo
       s!"registered enclosure [{enclosed.interval.lo}, {enclosed.interval.hi}] does not prove the requested bound"
       (some enclosed.interval)
   let endpointReal ← mkAppOptM ``Rat.cast #[mkConst ``Real, none, toExpr endpoint]
-  let endpointComparison ←
+  let boundReal ← mkAppOptM ``Rat.cast #[mkConst ``Real, none, toExpr bound]
+  let rationalComparison ←
     match comparison, functionOnLeft with
-    | .le, true => mkAppM ``LE.le #[endpointReal, boundExpr]
-    | .le, false => mkAppM ``LE.le #[boundExpr, endpointReal]
-    | .lt, true => mkAppM ``LT.lt #[endpointReal, boundExpr]
-    | .lt, false => mkAppM ``LT.lt #[boundExpr, endpointReal]
+    | .le, true => mkAppM ``LE.le #[toExpr endpoint, toExpr bound]
+    | .le, false => mkAppM ``LE.le #[toExpr bound, toExpr endpoint]
+    | .lt, true => mkAppM ``LT.lt #[toExpr endpoint, toExpr bound]
+    | .lt, false => mkAppM ``LT.lt #[toExpr bound, toExpr endpoint]
     | _, _ => throwError "unsupported registered enclosure comparison"
-  let endpointProof ← proveByNormNum endpointComparison
+  let rationalProof ← mkDecideProof rationalComparison
+  let castComparison ←
+    match comparison, functionOnLeft with
+    | .le, true => mkAppM ``LE.le #[endpointReal, boundReal]
+    | .le, false => mkAppM ``LE.le #[boundReal, endpointReal]
+    | .lt, true => mkAppM ``LT.lt #[endpointReal, boundReal]
+    | .lt, false => mkAppM ``LT.lt #[boundReal, endpointReal]
+    | _, _ => throwError "unsupported registered enclosure comparison"
+  let castProof ← proveRatCastComparison rationalComparison castComparison rationalProof
+  let boundEquality ← proveByNormNum (← mkAppM ``Eq #[boundReal, boundExpr])
+  let predicate ← withLocalDeclD `bound (mkConst ``Real) fun boundValue => do
+    let proposition ←
+      if functionOnLeft then
+        match comparison with
+        | .le => mkAppM ``LE.le #[endpointReal, boundValue]
+        | .lt => mkAppM ``LT.lt #[endpointReal, boundValue]
+        | _ => throwError "unsupported registered enclosure comparison"
+      else
+        match comparison with
+        | .le => mkAppM ``LE.le #[boundValue, endpointReal]
+        | .lt => mkAppM ``LT.lt #[boundValue, endpointReal]
+        | _ => throwError "unsupported registered enclosure comparison"
+    mkLambdaFVars #[boundValue] proposition
+  let endpointProof ← mkAppM ``Eq.mp
+    #[← mkAppM ``congrArg #[predicate, boundEquality], castProof]
   let membershipType ← inferType enclosed.membership
   let some (_, _) := explicitMembership? membershipType
     | throwError "registered enclosure theorem did not produce interval membership"
@@ -335,6 +571,7 @@ unsafe def registeredEnclosureBoundCoreTyped (prepared : PreparedGoal)
     return .ok {
       enclosure := enclosed.interval
       observations := enclosed.observations
+      compositionSteps := enclosed.compositionSteps
       verification := enclosed.verification
     }
 

--- a/LeanCert/Tactic/LeanCert/Bridge/Environment.lean
+++ b/LeanCert/Tactic/LeanCert/Bridge/Environment.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Core.IntervalRat.Basic
+
+/-! # Environments shared by proof-carrying reification -/
+
+namespace LeanCert.Tactic.Bridge
+
+/-- Real environment used by proof-carrying reification. The unary case keeps
+the historical constant-environment convention; higher arities use zero beyond
+the supplied arguments. -/
+def realEnvironment (values : List ℝ) (index : Nat) : ℝ :=
+  match values with
+  | [value] => value
+  | _ => values.getD index 0
+
+end LeanCert.Tactic.Bridge

--- a/LeanCert/Tactic/LeanCert/Bridge/ReifiedFunction.lean
+++ b/LeanCert/Tactic/LeanCert/Bridge/ReifiedFunction.lean
@@ -35,17 +35,8 @@ structure FunctionCapabilities where
   deriving Inhabited
 
 private def mkEnvironment (arguments : Array Lean.Expr) : MetaM Lean.Expr := do
-  if arguments.size == 1 then
-    withLocalDeclD `i (mkConst ``Nat) fun i => do
-      mkLambdaFVars #[i] arguments[0]!
-  else
-  withLocalDeclD `i (mkConst ``Nat) fun i => do
-    let zeroRat := toExpr (0 : ℚ)
-    let mut body ← mkAppOptM ``Rat.cast #[mkConst ``Real, none, zeroRat]
-    for index in (List.range arguments.size).reverse do
-      let condition ← mkAppM ``Eq #[i, toExpr index]
-      body ← mkAppM ``ite #[condition, arguments[index]!, body]
-    mkLambdaFVars #[i] body
+  let values ← mkListLit (mkConst ``Real) arguments.toList
+  mkAppM ``LeanCert.Tactic.Bridge.realEnvironment #[values]
 
 private def closeBridgeGoal (report : LeanCert.Meta.ReifyReport)
     (proposition : Lean.Expr) : TacticM Lean.Expr := do

--- a/LeanCert/Tactic/LeanCert/Normalize.lean
+++ b/LeanCert/Tactic/LeanCert/Normalize.lean
@@ -5,6 +5,7 @@ Authors: LeanCert Contributors
 -/
 import Mathlib.Tactic
 import LeanCert.Meta.ToExpr
+import LeanCert.Tactic.LeanCert.Bridge.Environment
 
 /-!
 # Reification Bridge Normalization
@@ -57,6 +58,7 @@ def closeReificationBridge (report : LeanCert.Meta.ReifyReport) : TacticM Unit :
         LeanCert.Core.Expr.eval_tanh,
         LeanCert.Core.Expr.eval_sqrt,
         LeanCert.Core.Expr.eval_namedConst,
+        LeanCert.Tactic.Bridge.realEnvironment,
         LeanCert.Core.Expr.eval_sub,
         LeanCert.Core.Expr.eval_div,
         LeanCert.Core.Expr.eval_pow,

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -202,8 +202,10 @@ private def registeredEnclosureExecution
     verificationUsage := Solver.VerificationUsage.ofEvents observation.verification
     enclosure := some observation.enclosure
   }
-  notes := outcome.observations.map fun observation =>
-    s!"extension used: {observation.rule.functionName} via {observation.rule.theoremName}"
+  notes := (outcome.observations.map fun observation =>
+    s!"extension used: {observation.rule.functionName} via {observation.rule.theoremName}") ++
+    if outcome.compositionSteps == 0 then #[] else
+      #[s!"proof-carrying composition: {outcome.compositionSteps} surrounding core layer(s)"]
 }
 
 private unsafe def registeredEnclosureAttemptTyped (prepared : Semantic.PreparedGoal)
@@ -1310,7 +1312,7 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
         "registered compositional enclosure" cfg verificationMode
         (.fixed .rationalInterval)
         none
-        (some "imported unary enclosure rule with a checked inner argument")
+        (some "imported unary enclosure rules with proof-carrying core composition")
         .registeredEnclosure
       let extensionSpec : SolverSpec := {
         report := extensionPlan

--- a/LeanCert/Test/ExtensionExecution.lean
+++ b/LeanCert/Test/ExtensionExecution.lean
@@ -29,8 +29,39 @@ example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
     positiveBranch (positiveBranch (x + 1)) ≤ 2 := by
   leancert
 
+/- Ordinary supported operations may surround a registered application, and
+the original quantified variable may occur independently outside it. -/
 set_option leancert.trust "kernel" in
-example : ∀ x ∈ Set.Icc (0 : ℝ) 1, positiveBranch (x + 1) < 3 := by
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1, positiveBranch (x + 1) + x ≤ 3 := by
+  leancert
+
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    positiveBranch (x + 1) * positiveBranch (x + 1) ≤ 4 := by
+  leancert
+
+/- Distinct registered subterms become independent proof-carrying holes in
+the surrounding core expression. -/
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    positiveBranch (x + 1) + shifted x ≤ 4 := by
+  leancert
+
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp (positiveBranch (x + 1)) < 8 := by
+  leancert
+
+/- Composition works recursively inside the argument of another registered
+application. -/
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    positiveBranch (Real.exp (positiveBranch (x + 1))) < 8 := by
+  leancert
+
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp (positiveBranch (x + 1)) + x < 9 := by
   leancert?
 
 /-- error: LeanCert recognized: univariate interval bound
@@ -41,6 +72,17 @@ Domain obstruction:
 Narrow the domain or prove the required positivity/nonzero condition. Increasing numerical precision does not repair an invalid domain. -/
 #guard_msgs in
 example : ∀ x ∈ Set.Icc (-1 : ℝ) 1, positiveBranch x ≤ 1 := by
+  leancert
+
+/-- error: LeanCert recognized: univariate interval bound
+
+Domain obstruction:
+  the checked interval evaluator rejected a partial operation
+
+Narrow the domain or prove the required positivity/nonzero condition. Increasing numerical precision does not repair an invalid domain. -/
+#guard_msgs in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.log (positiveBranch (x + 1) - 2) ≤ 0 := by
   leancert
 
 end LeanCert.Test.ExtensionExecution

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ does not imply that the theorem is false.
   supported integrands generally use certified partition bounds.
 - Supported evaluators may require domain certificates, such as positivity for
   logarithms or exclusion of zero from denominator intervals.
-- Downstream enclosure execution currently targets unary interval bounds with
-  checked, reifiable inner arguments; surrounding custom operations and
-  adaptive subdivision remain follow-up work.
+- Downstream enclosure execution currently targets unary interval bounds.
+  Existing core operations may surround proof-carrying registered subterms;
+  unsupported custom operations and adaptive subdivision are not yet covered.
 
 Native verification is faster but additionally trusts Lean's compiler/runtime;
 kernel-only verification may be substantially more expensive. See the

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -55,7 +55,12 @@ theorem schema and rejects definitions, axioms, and theorems depending on
 downstream packages can declare rules through a lightweight import.
 
 Execution of a registered rule is a tactic strategy and therefore follows the
-typed transactional requirements below.
+typed transactional requirements below. When registered calls occur inside an
+ordinary supported expression, execution first produces a membership proof for
+each maximal registered subterm. Those results become proof-carrying variables
+in a separately reified core expression; `evalIntervalCore_correct` composes
+their enclosures. Do not splice unchecked candidate values directly into a
+semantic bridge.
 
 ## Tactic changes
 

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -59,6 +59,10 @@ theorem positiveBranch_mem
 example : ∀ x ∈ Set.Icc (0 : ℝ) 1, positiveBranch (x + 1) ≤ 2 := by
   leancert (trust := kernel)
 
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp (positiveBranch (x + 1)) + x < 9 := by
+  leancert (trust := kernel)
+
 end DownstreamExtensionExample
 ```
 
@@ -111,8 +115,12 @@ Metaprogramming clients may query `getUnaryEnclosureRules` for one function or
 
 The first protocol deliberately covers unary `ℝ → ℝ` enclosure rules in
 univariate interval bounds with rational endpoints and a rational constant on
-the other side of the comparison. Registered applications may be nested, and
-their innermost argument may use LeanCert's ordinary reifiable expression
-fragment. Surrounding unsupported operations, derivative rules, monotonicity
-rules, and adaptive subdivision of rejected or inconclusive downstream
-candidates remain future extensions.
+the other side of the comparison. Registered applications may be nested.
+LeanCert treats their checked results as proof-carrying atoms and reifies the
+surrounding expression against those atoms, so ordinary supported arithmetic
+and transcendental operations may appear outside registered calls. The
+quantified variable may also occur independently elsewhere in that expression.
+
+Operations outside LeanCert's core expression fragment and adaptive
+subdivision of rejected or inconclusive downstream candidates are not yet
+covered.

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -74,7 +74,8 @@ verification without changing the numerical backend.
 `LeanCert.Tactic.Extension` exposes the typed, persistent registry for
 downstream unary enclosure rules. Registration validates a candidate, checker,
 and soundness theorem. The semantic `leancert` front door can execute imported
-rules for unary interval bounds. See [Downstream enclosure extensions](extensions.md).
+rules for unary interval bounds and compose their checked enclosures through
+ordinary supported expressions. See [Downstream enclosure extensions](extensions.md).
 
 `LeanCert.CertifiedBounds` exposes stable numerical-result interfaces under:
 

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -108,10 +108,12 @@ than an internal verifier failure.
 
 Imported unary enclosure rules registered through
 `LeanCert.Tactic.Extension` participate in univariate interval bounds. The
-router first certifies a reifiable inner argument, verifies the downstream
-Boolean checker under the requested trust policy, and applies the registered
-soundness theorem. `leancert?` reports every retained downstream checker and
-theorem. See [Downstream enclosure extensions](extensions.md).
+router certifies each registered application, verifies its downstream Boolean
+checker under the requested trust policy, and applies the registered soundness
+theorem. Checked results become proof-carrying atoms for the ordinary core
+evaluator, allowing supported operations around them. `leancert?` reports every
+retained downstream checker and theorem together with any surrounding
+composition. See [Downstream enclosure extensions](extensions.md).
 
 Expected checker rejection, unsupported expressions, inconclusive enclosures,
 and certified counterexamples are rendered as separate diagnostic categories.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,12 +10,12 @@ below are convergence work, not features claimed as complete.
 **Current state:** downstream modules can register and inspect typed unary
 `ℝ → ℝ` enclosure candidates, Boolean checkers, and `sorry`-free soundness
 theorems without modifying LeanCert's internal expression datatype. `leancert`
-executes imported rules for unary interval bounds whose registered applications
-have checked, reifiable inner arguments.
+executes imported rules for unary interval bounds, supports nested registered
+applications, and composes their checked results through ordinary core
+expressions.
 
-**Milestone:** extend compositional execution through surrounding registered or
-built-in operations, then add adaptive subdivision for inconclusive downstream
-candidates.
+**Possible next milestone:** add adaptive subdivision for inconclusive
+downstream candidates without weakening typed failure classification.
 
 **Evidence:** an external function certified end to end through an imported
 rule, with rejected-candidate fallback and complete `leancert?` provenance.


### PR DESCRIPTION
## Summary

This extends the downstream enclosure protocol introduced in #97 from direct
and nested registered applications to ordinary mixed LeanCert expressions.

Registered applications are first certified independently. Their resulting
membership proofs are then treated as proof-carrying inputs to a separately
reified core expression, whose enclosure is established using the existing
`evalIntervalCore_correct` theorem.

This allows goals such as:

```lean
example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
    Real.exp (positiveBranch (x + 1)) + x < 9 := by
  leancert