### PR TITLE
feat: subdivide registered enclosure goals

### DIFF
--- a/LeanCert/Tactic/Extension/Execute.lean
+++ b/LeanCert/Tactic/Extension/Execute.lean
@@ -34,6 +34,8 @@ inductive RegisteredEnclosureFailure where
   | domainObstruction (operation detail : String)
   | inconclusive (detail : String) (enclosure : Option IntervalRat := none)
   | rejected (checker : Option Name) (enclosure : Option IntervalRat) (detail : String)
+  | exhausted (maxDepth boxesExamined deepestDepth certifiedLeaves : Nat)
+      (enclosure : Option IntervalRat) (detail : String)
   | verificationFailure (detail : String)
   deriving Inhabited
 
@@ -44,13 +46,45 @@ structure RegisteredEnclosureObservation where
   verification : LeanCert.Tactic.VerificationUsage
   deriving Inhabited
 
+/-- Runtime facts retained by adaptive registered-enclosure subdivision. -/
+structure RegisteredSubdivisionExecution where
+  taylorDepth : Nat
+  configuredMaxDepth : Nat
+  deepestDepthUsed : Nat := 0
+  boxesExamined : Nat := 0
+  certifiedLeaves : Nat := 0
+  deriving Inhabited
+
 /-- Retained facts from a successful registered enclosure proof. -/
 structure RegisteredEnclosureOutcome where
   enclosure : IntervalRat
   observations : Array RegisteredEnclosureObservation
   compositionSteps : Nat := 0
+  subdivision : Option RegisteredSubdivisionExecution := none
   verification : LeanCert.Tactic.VerificationUsage
   deriving Inhabited
+
+/-- Subdivision combines complete child theorems. It is independent of the
+internal expression AST, so downstream functions remain opaque to LeanCert. -/
+private theorem forall_mem_of_bisect
+    {predicate : ℝ → Prop} (interval : IntervalRat)
+    (left : ∀ x ∈ interval.bisect.1, predicate x)
+    (right : ∀ x ∈ interval.bisect.2, predicate x) :
+    ∀ x ∈ interval, predicate x := by
+  intro x hx
+  rcases IntervalRat.mem_bisect_or hx with hxLeft | hxRight
+  · exact left x hxLeft
+  · exact right x hxRight
+
+private structure RegisteredSubdivisionProof where
+  proof : Lean.Expr
+  enclosure : IntervalRat
+  observations : Array RegisteredEnclosureObservation
+  compositionSteps : Nat := 0
+  verification : LeanCert.Tactic.VerificationUsage := {}
+  deepestDepthUsed : Nat := 0
+  boxesExamined : Nat := 0
+  certifiedLeaves : Nat := 0
 
 private structure EnclosedTerm where
   value : Lean.Expr
@@ -454,6 +488,38 @@ private def containsRegisteredFunction (env : Environment) (expression : Lean.Ex
     subterm.getAppFn.constName?.any fun name =>
       !(getUnaryEnclosureRules env name).isEmpty).isSome
 
+private def boundProposition (spec : BoundSpec) (interval : Lean.Expr) : MetaM Lean.Expr := do
+  withLocalDeclD spec.boundVars[0]!.userName (mkConst ``Real) fun x => do
+    let membership ← mkAppM ``Membership.mem #[interval, x]
+    withLocalDeclD `hmem membership fun hmem => do
+      let lhs := (mkApp spec.lhs x).headBeta
+      let rhs := (mkApp spec.rhs x).headBeta
+      let conclusion ←
+        match spec.comparison with
+        | .le => mkAppM ``LE.le #[lhs, rhs]
+        | .lt => mkAppM ``LT.lt #[lhs, rhs]
+        | _ => throwError "registered enclosure subdivision expected an inequality"
+      mkForallFVars #[x, hmem] conclusion
+
+private def preparedOnInterval (prepared : PreparedGoal) (spec : BoundSpec)
+    (interval : Lean.Expr) : TacticM PreparedGoal := do
+  let domainSyntax : IntervalSyntax := {
+    original := interval
+    kind := .intervalRat
+  }
+  let domain ← prepareInterval domainSyntax
+  let proposition ← boundProposition spec interval
+  let boundVar := spec.boundVars[0]!
+  return {
+    semantic := .bound {
+      spec with
+      original := proposition
+      boundVars := #[{ boundVar with binderId := none, domain := domainSyntax }]
+    }
+    domains := #[domain]
+    functions := prepared.functions
+  }
+
 private def finalComparisonProof (comparison : Comparison) (functionOnLeft : Bool)
     (bound : ℚ) (boundExpr : Lean.Expr) (enclosed : EnclosedTerm) :
     TacticM (Except RegisteredEnclosureFailure Lean.Expr) := do
@@ -574,5 +640,165 @@ unsafe def registeredEnclosureBoundCoreTyped (prepared : PreparedGoal)
       compositionSteps := enclosed.compositionSteps
       verification := enclosed.verification
     }
+
+private unsafe def proveRegisteredLeaf (prepared : PreparedGoal)
+    (precision : Int) (taylorDepth : Nat) :
+    TacticM (Except RegisteredEnclosureFailure
+      (Lean.Expr × RegisteredEnclosureOutcome)) := do
+  let originalGoals ← getGoals
+  let saved ← saveState
+  let proposition := prepared.semantic.original
+  let proof ← mkFreshExprMVar proposition MetavarKind.syntheticOpaque
+  setGoals [proof.mvarId!]
+  try
+    match ← registeredEnclosureBoundCoreTyped prepared precision taylorDepth with
+    | .error failure =>
+        saved.restore
+        return .error failure
+    | .ok outcome =>
+        unless (← getGoals).isEmpty do
+          saved.restore
+          return .error <| .verificationFailure
+            "registered enclosure leaf left unresolved proof obligations"
+        let proof ← instantiateMVars proof
+        if proof.hasMVar then
+          saved.restore
+          return .error <| .verificationFailure
+            "registered enclosure leaf proof contains metavariables"
+        setGoals originalGoals
+        return .ok (proof, outcome)
+  catch exception =>
+    saved.restore
+    throw exception
+
+private def addExhaustedStatistics (priorBoxes priorDeepest priorLeaves : Nat) :
+    RegisteredEnclosureFailure → RegisteredEnclosureFailure
+  | .exhausted maxDepth boxes deepest leaves enclosure detail =>
+      .exhausted maxDepth (priorBoxes + boxes) (max priorDeepest deepest)
+        (priorLeaves + leaves) enclosure detail
+  | failure => failure
+
+private unsafe def proveRegisteredWithSubdiv
+    (prepared : PreparedGoal) (spec : BoundSpec)
+    (intervalExpr : Lean.Expr) (interval : IntervalRat)
+    (precision : Int) (taylorDepth configuredMaxDepth remainingDepth depthUsed : Nat) :
+    TacticM (Except RegisteredEnclosureFailure RegisteredSubdivisionProof) := do
+  let childPrepared ← preparedOnInterval prepared spec intervalExpr
+  match ← proveRegisteredLeaf childPrepared precision taylorDepth with
+  | .ok (proof, outcome) =>
+      return .ok {
+        proof
+        enclosure := outcome.enclosure
+        observations := outcome.observations
+        compositionSteps := outcome.compositionSteps
+        verification := outcome.verification
+        deepestDepthUsed := depthUsed
+        boxesExamined := 1
+        certifiedLeaves := 1
+      }
+  | .error failure =>
+      let (retryable, lastEnclosure, detail) :=
+        match failure with
+        | .inconclusive detail enclosure => (true, enclosure, detail)
+        | .rejected _ enclosure detail => (true, enclosure, detail)
+        | _ => (false, none, "")
+      unless retryable do return .error failure
+      if remainingDepth == 0 then
+        return .error <| .exhausted configuredMaxDepth 1 depthUsed 0
+          lastEnclosure detail
+
+  let bisectExpr ← mkAppM ``IntervalRat.bisect #[intervalExpr]
+  let leftExpr ← mkAppM ``Prod.fst #[bisectExpr]
+  let rightExpr ← mkAppM ``Prod.snd #[bisectExpr]
+  let (leftInterval, rightInterval) := interval.bisect
+
+  let left ← proveRegisteredWithSubdiv prepared spec leftExpr leftInterval
+    precision taylorDepth configuredMaxDepth (remainingDepth - 1) (depthUsed + 1)
+  let left ←
+    match left with
+    | .ok proof => pure proof
+    | .error failure =>
+        return .error <| addExhaustedStatistics 1 depthUsed 0 failure
+
+  let right ← proveRegisteredWithSubdiv prepared spec rightExpr rightInterval
+    precision taylorDepth configuredMaxDepth (remainingDepth - 1) (depthUsed + 1)
+  let right ←
+    match right with
+    | .ok proof => pure proof
+    | .error failure =>
+        return .error <| addExhaustedStatistics
+          (1 + left.boxesExamined)
+          (max depthUsed left.deepestDepthUsed)
+          left.certifiedLeaves failure
+
+  let proof ← mkAppM ``forall_mem_of_bisect
+    #[intervalExpr, left.proof, right.proof]
+  return .ok {
+    proof
+    enclosure := {
+      lo := min left.enclosure.lo right.enclosure.lo
+      hi := max left.enclosure.hi right.enclosure.hi
+      le := le_trans (min_le_left _ _)
+        (le_trans left.enclosure.le (le_max_left _ _))
+    }
+    observations := left.observations ++ right.observations
+    compositionSteps := left.compositionSteps + right.compositionSteps
+    verification := left.verification.combine right.verification
+    deepestDepthUsed := max depthUsed
+      (max left.deepestDepthUsed right.deepestDepthUsed)
+    boxesExamined := 1 + left.boxesExamined + right.boxesExamined
+    certifiedLeaves := left.certifiedLeaves + right.certifiedLeaves
+  }
+
+/-- Try registered enclosure execution at each node, bisecting only after an
+inconclusive or rejected candidate. Every retained leaf is independently
+checked before its theorem is combined into the result. -/
+unsafe def registeredEnclosureBoundSubdivCoreTyped (prepared : PreparedGoal)
+    (precision : Int) (taylorDepth maxDepth : Nat) :
+    TacticM (Except RegisteredEnclosureFailure RegisteredEnclosureOutcome) := do
+  let original ← saveState
+  try
+    let .bound spec := prepared.semantic
+      | return .error .notApplicable
+    unless spec.boundVars.size == 1 && prepared.domains.size == 1 do
+      return .error .notApplicable
+    let .closedRat _ intervalExpr membershipIff := prepared.domains[0]!
+      | return .error .notApplicable
+    let interval ← unsafe evalExpr IntervalRat (mkConst ``IntervalRat) intervalExpr
+    match ← proveRegisteredWithSubdiv prepared spec intervalExpr interval
+        precision taylorDepth maxDepth maxDepth 0 with
+    | .error failure =>
+        original.restore
+        return .error failure
+    | .ok proof =>
+        let goal ← getMainGoal
+        let (xId, goal) ← goal.intro1P
+        let (hxSourceId, goal) ← goal.intro1P
+        setGoals [goal]
+        goal.withContext do
+          let x := mkFVar xId
+          let hxSource := mkFVar hxSourceId
+          let iffAt ← mkAppM' membershipIff #[x]
+          let hx ← mkAppM ``Iff.mp #[iffAt, hxSource]
+          let pointProof := mkAppN proof.proof #[x, hx]
+          discard <| inferType pointProof
+          goal.assign pointProof
+          replaceMainGoal []
+        return .ok {
+          enclosure := proof.enclosure
+          observations := proof.observations
+          compositionSteps := proof.compositionSteps
+          subdivision := if proof.deepestDepthUsed == 0 then none else some {
+            taylorDepth
+            configuredMaxDepth := maxDepth
+            deepestDepthUsed := proof.deepestDepthUsed
+            boxesExamined := proof.boxesExamined
+            certifiedLeaves := proof.certifiedLeaves
+          }
+          verification := proof.verification
+        }
+  catch exception =>
+    original.restore
+    throw exception
 
 end LeanCert.Tactic.Extension

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -195,6 +195,13 @@ private def registeredEnclosureExecution
   backend := some .rationalInterval
   verificationUsage := Solver.VerificationUsage.ofEvents outcome.verification
   enclosure := some outcome.enclosure
+  subdivision := outcome.subdivision.map fun subdivision => {
+    taylorDepth := subdivision.taylorDepth
+    configuredMaxDepth := subdivision.configuredMaxDepth
+    deepestDepthUsed := subdivision.deepestDepthUsed
+    boxesExamined := subdivision.boxesExamined
+    certifiedLeaves := subdivision.certifiedLeaves
+  }
   certificates := outcome.observations.map fun observation => {
     role := s!"registered enclosure `{observation.rule.functionName}`"
     checker := observation.rule.checkerName
@@ -209,8 +216,9 @@ private def registeredEnclosureExecution
 }
 
 private unsafe def registeredEnclosureAttemptTyped (prepared : Semantic.PreparedGoal)
-    (depth : Nat) : TacticM (Except AttemptFailure SolverExecution) := do
-  match ← Extension.registeredEnclosureBoundCoreTyped prepared (-53) depth with
+    (depth maxDepth : Nat) : TacticM (Except AttemptFailure SolverExecution) := do
+  match ← Extension.registeredEnclosureBoundSubdivCoreTyped
+      prepared (-53) depth maxDepth with
   | .ok outcome => return .ok (registeredEnclosureExecution outcome)
   | .error .notApplicable => return .error .notApplicable
   | .error (.unsupported expression detail) =>
@@ -225,9 +233,16 @@ private unsafe def registeredEnclosureAttemptTyped (prepared : Semantic.Prepared
       return .error <| .inconclusive { detail, enclosure }
   | .error (.rejected checker enclosure detail) =>
       return .error <| .rejected { checker, enclosure, detail }
+  | .error (.exhausted maxDepth boxes deepest leaves enclosure detail) =>
+      return .error <| .inconclusive {
+        enclosure
+        detail := s!"Registered enclosure subdivision reached its configured depth \
+          {maxDepth} after examining {boxes} boxes (deepest depth {deepest}; \
+          {leaves} certified leaves). Last failure: {detail}"
+      }
   | .error (.verificationFailure detail) =>
       return .error <| .internalError
-        `LeanCert.Tactic.Extension.registeredEnclosureBoundCoreTyped detail
+        `LeanCert.Tactic.Extension.registeredEnclosureBoundSubdivCoreTyped detail
 
 private unsafe def directBoundAttemptTyped (depth : Nat) :
     TacticM (Except AttemptFailure SolverExecution) := do
@@ -1312,11 +1327,12 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
         "registered compositional enclosure" cfg verificationMode
         (.fixed .rationalInterval)
         none
-        (some "imported unary enclosure rules with proof-carrying core composition")
+        (some "imported unary enclosure rules with proof-carrying core composition \
+          and adaptive subdivision")
         .registeredEnclosure
       let extensionSpec : SolverSpec := {
         report := extensionPlan
-        solve := registeredEnclosureAttemptTyped prepared cfg.taylorDepth
+        solve := registeredEnclosureAttemptTyped prepared cfg.taylorDepth cfg.subdivisions
       }
       match ← trySolver extensionSpec with
       | .proved artifact => return ← commitArtifact artifact

--- a/LeanCert/Test/DownstreamPatterns/Extension.lean
+++ b/LeanCert/Test/DownstreamPatterns/Extension.lean
@@ -85,6 +85,26 @@ theorem positiveBranch_mem
     exact lt_of_lt_of_le (by exact_mod_cast hpositive) hx.1
   simpa [positiveBranch, not_le.mpr hxpositive] using hx
 
+/-- A deliberately width-sensitive rule used to demonstrate that candidate
+rejection on a broad interval can be repaired by checked subdivision. -/
+noncomputable def narrowIdentity (x : ℝ) : ℝ := x
+
+def narrowIdentityCandidate (request : UnaryEnclosureRequest) :
+    Except EnclosureCandidateFailure IntervalRat := .ok request.input
+
+def checkNarrowIdentity (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
+  decide (request.input.hi - request.input.lo ≤ 1) && decide (output = request.input)
+
+@[leancert_enclosure narrowIdentityCandidate]
+theorem narrowIdentity_mem
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkNarrowIdentity request output = true) :
+    narrowIdentity x ∈ output := by
+  simp only [checkNarrowIdentity, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨_, rfl⟩
+  simpa [narrowIdentity] using hx
+
 run_meta do
   let env ← getEnv
   let rules := getUnaryEnclosureRules env ``shifted

--- a/LeanCert/Test/ExtensionExecution.lean
+++ b/LeanCert/Test/ExtensionExecution.lean
@@ -64,6 +64,42 @@ example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
     Real.exp (positiveBranch (x + 1)) + x < 9 := by
   leancert?
 
+/- A registered checker that rejects the initial width succeeds on the two
+bisected leaves. -/
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 2, narrowIdentity x ≤ 2 := by
+  leancert?
+
+/- Subdivision also retries when the registered certificates are valid but
+their composed enclosure is too coarse for the requested comparison. -/
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 2, shifted x - x ≤ 2 := by
+  leancert (subdivisions := 1)
+
+/-- error: LeanCert recognized: univariate interval bound
+
+Attempts:
+  1. registered compositional enclosure
+     Registered enclosure subdivision reached its configured depth 0 after examining 1 boxes (deepest depth 0; 0 certified leaves). Last failure: The registered candidate was rejected by its checker.
+
+Budget: spent 1 of 1
+
+Next steps:
+• Check whether the requested statement is true.
+• Increase `(taylorDepth := ...)`, `(subdivisions := ...)`, or `(maxIterations := ...)` when the corresponding attempt was inconclusive.
+• Use `interval_refute` to search for a certified counterexample. -/
+#guard_msgs in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 2, narrowIdentity x ≤ 2 := by
+  leancert? (budget := 1) (subdivisions := 0)
+
+/- Exhausted speculative subdivision restores the caller's complete tactic
+state before another proof is attempted. -/
+example : ∀ x ∈ Set.Icc (0 : ℝ) 2, narrowIdentity x ≤ 2 := by
+  first
+  | leancert (budget := 1) (subdivisions := 0)
+  | intro x hx
+    simpa [narrowIdentity] using hx.2
+
 /-- error: LeanCert recognized: univariate interval bound
 
 Domain obstruction:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ does not imply that the theorem is false.
   logarithms or exclusion of zero from denominator intervals.
 - Downstream enclosure execution currently targets unary interval bounds.
   Existing core operations may surround proof-carrying registered subterms;
-  unsupported custom operations and adaptive subdivision are not yet covered.
+  rejected or inconclusive candidates are retried on rational bisections.
+  Unsupported custom operations are not yet covered.
 
 Native verification is faster but additionally trusts Lean's compiler/runtime;
 kernel-only verification may be substantially more expensive. See the

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -62,6 +62,12 @@ in a separately reified core expression; `evalIntervalCore_correct` composes
 their enclosures. Do not splice unchecked candidate values directly into a
 semantic bridge.
 
+Adaptive execution retries only typed rejected or inconclusive results. Each
+retained child is a complete theorem over its child interval, and a generic
+predicate-level bisection theorem combines the children. Domain obstructions,
+unsupported syntax, and verification failures remain terminal. Failed or
+exhausted recursion must restore the complete caller tactic state.
+
 ## Tactic changes
 
 Every semantic-router extension returns

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -121,6 +121,14 @@ surrounding expression against those atoms, so ordinary supported arithmetic
 and transcendental operations may appear outside registered calls. The
 quantified variable may also occur independently elsewhere in that expression.
 
-Operations outside LeanCert's core expression fragment and adaptive
-subdivision of rejected or inconclusive downstream candidates are not yet
-covered.
+When a registered candidate is rejected, or when its checked enclosure is too
+coarse to prove the final comparison, `leancert` bisects the rational input
+interval and retries up to the configured `(subdivisions := n)` depth. Every
+retained leaf closes its own registered checker, and the resulting complete
+child theorems are combined by a generic interval-cover theorem. `leancert?`
+reports the configured and deepest depths, boxes examined, certified leaves,
+and each retained downstream certificate. Domain obstructions and unsupported
+operations remain terminal rather than being reclassified as numerical
+imprecision.
+
+Operations outside LeanCert's core expression fragment are not yet covered.

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -75,7 +75,8 @@ verification without changing the numerical backend.
 downstream unary enclosure rules. Registration validates a candidate, checker,
 and soundness theorem. The semantic `leancert` front door can execute imported
 rules for unary interval bounds and compose their checked enclosures through
-ordinary supported expressions. See [Downstream enclosure extensions](extensions.md).
+ordinary supported expressions, with checked adaptive subdivision for rejected
+or inconclusive candidates. See [Downstream enclosure extensions](extensions.md).
 
 `LeanCert.CertifiedBounds` exposes stable numerical-result interfaces under:
 

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -113,7 +113,9 @@ checker under the requested trust policy, and applies the registered soundness
 theorem. Checked results become proof-carrying atoms for the ordinary core
 evaluator, allowing supported operations around them. `leancert?` reports every
 retained downstream checker and theorem together with any surrounding
-composition. See [Downstream enclosure extensions](extensions.md).
+composition. Rejected or comparison-inconclusive registered candidates are
+retried by rational bisection up to `(subdivisions := n)`; domain obstructions
+remain terminal. See [Downstream enclosure extensions](extensions.md).
 
 Expected checker rejection, unsupported expressions, inconclusive enclosures,
 and certified counterexamples are rendered as separate diagnostic categories.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,10 +12,11 @@ below are convergence work, not features claimed as complete.
 theorems without modifying LeanCert's internal expression datatype. `leancert`
 executes imported rules for unary interval bounds, supports nested registered
 applications, and composes their checked results through ordinary core
-expressions.
+expressions. Rejected or comparison-inconclusive candidates are retried through
+checked rational subdivision with retained leaf provenance.
 
-**Possible next milestone:** add adaptive subdivision for inconclusive
-downstream candidates without weakening typed failure classification.
+**Possible next milestone:** extend the protocol beyond enclosure rules only
+when downstream use cases establish a concrete need for additional rule kinds.
 
 **Evidence:** an external function certified end to end through an imported
 rule, with rejected-candidate fallback and complete `leancert?` provenance.


### PR DESCRIPTION
## Summary

This completes the initial downstream enclosure execution path by adding
adaptive rational subdivision.

When a registered candidate is rejected, or when its checked enclosure is too
coarse to establish the requested comparison, `leancert` bisects the input
interval and retries up to `(subdivisions := n)`.

Each retained leaf is independently certified through its registered checker
and soundness theorem. The resulting complete child theorems are combined by a
generic predicate-level interval-cover theorem, without adding downstream
functions to LeanCert's internal expression AST.

## Behavior

- retries typed rejected and inconclusive results
- preserves domain obstructions, unsupported syntax, and verification failures
  as terminal outcomes
- succeeds only when every required leaf is certified
- restores the complete tactic state after exhaustion or failure
- reports configured and deepest depth, boxes examined, certified leaves, and
  every retained downstream certificate through `leancert?`
- uses the existing `(subdivisions := n)` configuration

For example, a checker that rejects `[0, 2]` because it only accepts intervals
of width at most one can now certify the theorem through `[0, 1]` and `[1, 2]`.

## Soundness boundary

Subdivision combines complete child theorems rather than unchecked candidate
values. Untrusted candidate generation continues to influence search only;
every leaf used by the final proof passes through its registered Boolean
checker and soundness theorem.
