### PR TITLE
feat: add fixed-cutoff eventual bounds

### DIFF
--- a/LeanCert/Tactic.lean
+++ b/LeanCert/Tactic.lean
@@ -8,6 +8,7 @@ import LeanCert.Tactic.Refute
 import LeanCert.Tactic.FinSumExpand
 import LeanCert.Tactic.FinSumBound
 import LeanCert.Tactic.FinSumWitness
+import LeanCert.Tactic.EventualBound
 import LeanCert.Tactic.VecSimp
 import LeanCert.Tactic.LeanCert
 import LeanCert.Tactic.Discovery

--- a/LeanCert/Tactic/EventualBound.lean
+++ b/LeanCert/Tactic/EventualBound.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic.IntervalAuto.Extract
+import LeanCert.Validity.Eventual
+
+/-!
+# Fixed-cutoff eventual-bound tactic
+
+`eventual_bound` closes an explicit natural-number tail bound using an
+executable LeanCert certificate.  The initial certificate language covers
+nonnegative rational multiples of reciprocal powers.
+-/
+
+open Lean Elab Tactic
+
+namespace LeanCert.Tactic
+
+open Lean Meta
+open LeanCert.Tactic.Auto
+
+private def binaryArgs? (e : Expr) (name : Name) : Option (Expr × Expr) :=
+  if !e.isAppOf name then none
+  else
+    let args := e.getAppArgs
+    if h : 2 ≤ args.size then
+      some (args[args.size - 2], args[args.size - 1])
+    else none
+
+private structure ParsedReciprocalPowerGoal where
+  coefficient : ℚ
+  bound : ℚ
+  exponent : Nat
+  cutoff : Nat
+
+private def parseReciprocalPowerGoal : TacticM ParsedReciprocalPowerGoal := do
+  let target ← instantiateMVars (← getMainTarget)
+  let .forallE _ _ tailBody _ := target
+    | throwError "expected `∀ n : Nat, N ≤ n → ...`"
+  let .forallE _ tailHypothesis conclusion _ := tailBody
+    | throwError "expected the tail hypothesis `N ≤ n`"
+  let cutoffExpr ←
+    match binaryArgs? tailHypothesis ``LE.le with
+    | some (cutoff, _) => pure cutoff
+    | none =>
+        match binaryArgs? tailHypothesis ``GE.ge with
+        | some (_, cutoff) => pure cutoff
+        | none => throwError "expected the tail hypothesis `N ≤ n`"
+  let some (lhs, boundExpr) := binaryArgs? conclusion ``LE.le
+    | throwError "expected an upper-bound inequality"
+  let some (qExpr, denominator) := binaryArgs? lhs ``HDiv.hDiv
+    | throwError "expected a quotient `q / (n : ℝ) ^ k`; got {lhs} with head {lhs.getAppFn.constName?}"
+  let exponent :=
+    match binaryArgs? denominator ``HPow.hPow with
+    | some (_, exponent) => exponent
+    | none => toExpr (1 : Nat)
+  let some q ← extractRatFromReal qExpr
+    | throwError "the reciprocal-power coefficient is not a rational literal"
+  let some bound ← extractRatFromReal boundExpr
+    | throwError "the comparison bound is not a rational literal"
+  let some exponent ← getNatValue? exponent
+    | throwError "the reciprocal-power exponent is not a natural-number literal"
+  let some cutoff ← getNatValue? cutoffExpr
+    | throwError "the cutoff is not a natural-number literal"
+  pure { coefficient := q, bound, exponent, cutoff }
+
+private def runEventualBound (cutoff? : Option (TSyntax `term))
+    (explain : Bool) : TacticM Unit := do
+  let saved ← saveState
+  try
+    if let some cutoff := cutoff? then
+      evalTactic (← `(tactic| refine ⟨$cutoff, ?_⟩))
+    let parsed ← parseReciprocalPowerGoal
+    unless 0 ≤ parsed.coefficient && 0 < parsed.exponent && 0 < parsed.cutoff &&
+        parsed.coefficient / (parsed.cutoff : ℚ) ^ parsed.exponent ≤ parsed.bound do
+      throwError "the reciprocal-power certificate was rejected"
+    let q ← Term.exprToSyntax (toExpr parsed.coefficient)
+    let bound ← Term.exprToSyntax (toExpr parsed.bound)
+    let exponent ← Term.exprToSyntax (toExpr parsed.exponent)
+    let cutoff ← Term.exprToSyntax (toExpr parsed.cutoff)
+    evalTactic (← `(tactic|
+      convert LeanCert.Validity.verify_reciprocal_power_upper
+        ($q : ℚ) ($bound : ℚ) $exponent $cutoff
+          (by norm_num [LeanCert.Validity.checkReciprocalPowerUpper]) using 1 <;>
+        norm_num))
+    unless (← getUnsolvedGoals).isEmpty do
+      throwError "the reciprocal-power certificate was rejected"
+    if explain then
+      let cutoffLine := cutoff?.map
+        (fun cutoff => s!"\nCutoff:\n  N = {cutoff}") |>.getD
+          "\nCutoff:\n  read from the universal goal"
+      logInfo m!"LeanCert recognized: fixed-cutoff eventual upper bound
+
+Selected strategy:
+  reciprocal-power tail certificate{cutoffLine}
+
+Tail rule:
+  nonnegative rational multiple of 1 / n^k
+  endpoint checked exactly; global decay proved symbolically
+
+Certificate verification:
+  kernel (`norm_num`)
+
+Suggested proof:
+  by
+    {if cutoff?.isSome then s!"eventual_bound using {cutoff?.get!}" else "eventual_bound"}"
+  catch exception =>
+    saved.restore
+    let detail ← exception.toMessageData.toString
+    throwError "Eventual bound certification failed.\n\n\
+      H1 currently accepts goals of the form\n  \
+      `∀ n : Nat, N ≤ n → q / (n : ℝ) ^ k ≤ c`\n\
+      with `q ≥ 0`, `k > 0`, and `N > 0`. For existential goals, write\n  \
+      `eventual_bound using N`.\n\n\
+      The cutoff may be too small, or the tail expression may be outside this\n\
+      initial certificate language.\n\nUnderlying elaboration detail:\n{detail}"
+
+syntax (name := eventualBoundTac) "eventual_bound" (" using " term)? : tactic
+syntax (name := eventualBoundQuestionTac) "eventual_bound?" (" using " term)? : tactic
+
+elab_rules : tactic
+  | `(tactic| eventual_bound $[using $cutoff]?) =>
+      runEventualBound cutoff false
+  | `(tactic| eventual_bound? $[using $cutoff]?) =>
+      runEventualBound cutoff true
+
+end LeanCert.Tactic

--- a/LeanCert/Test/EventualBound.lean
+++ b/LeanCert/Test/EventualBound.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Tactic
+
+/-! Regression tests for fixed-cutoff eventual bounds. -/
+
+#guard LeanCert.Validity.checkReciprocalPowerUpper 1 (1 / 100) 2 10
+#guard !LeanCert.Validity.checkReciprocalPowerUpper 1 (1 / 100) 2 9
+#guard !LeanCert.Validity.checkReciprocalPowerUpper 1 1 1 0
+
+example : ∀ n : Nat, 10 ≤ n → (1 : ℝ) / (n : ℝ) ^ 2 ≤ 1 / 100 := by
+  eventual_bound
+
+example : ∀ n : Nat, 100 ≤ n → (1 : ℝ) / n ≤ 1 / 100 := by
+  eventual_bound
+
+example : ∃ N : Nat, ∀ n : Nat, N ≤ n → (3 : ℝ) / (n : ℝ) ^ 2 ≤ 3 / 100 := by
+  eventual_bound using 10
+
+example : ∃ N : Nat, ∀ n ≥ N, (1 : ℝ) / n ≤ 1 / 100 := by
+  eventual_bound using 100
+
+example : ∀ n : Nat, 10 ≤ n → (2 : ℝ) / n ^ 2 ≤ 1 / 50 := by
+  eventual_bound?
+
+example : True := by
+  fail_if_success
+    have : ∀ n : Nat, 9 ≤ n → (1 : ℝ) / n ^ 2 ≤ 1 / 100 := by
+      eventual_bound
+  trivial

--- a/LeanCert/Test/ValidityExports.lean
+++ b/LeanCert/Test/ValidityExports.lean
@@ -31,6 +31,12 @@ namespace LeanCert.Test.ValidityExports
 #check LeanCert.Validity.Algebra.verify_cubic_root_radius
 #check LeanCert.Validity.Algebra.verify_cubic_separation_mesh
 #check LeanCert.Validity.Algebra.verify_cubic_distinct_roots_separated
+#check LeanCert.Validity.checkReciprocalPowerUpper
+#check LeanCert.Validity.ReciprocalPowerUpperCert
+#check LeanCert.Validity.EventualBoundCert
+#check LeanCert.Validity.EventualBoundCert.verify
+#check LeanCert.Validity.verify_reciprocal_power_upper
+#check LeanCert.Validity.verify_reciprocal_upper
 #check LeanCert.Engine.Algebra.cubic_root_gap_gt_of_discr_bound
 #check LeanCert.Engine.Algebra.cubic_roots_pairwise_gap_gt_of_discr_bound_and_radius
 

--- a/LeanCert/Validity.lean
+++ b/LeanCert/Validity.lean
@@ -15,6 +15,7 @@ import LeanCert.Validity.AffineBounds
 import LeanCert.Validity.AffineCover
 import LeanCert.Validity.Monotonicity
 import LeanCert.Validity.DirectedLimit
+import LeanCert.Validity.Eventual
 import LeanCert.Validity.Krawczyk
 import LeanCert.Validity.Algebra
 

--- a/LeanCert/Validity/Eventual.lean
+++ b/LeanCert/Validity/Eventual.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import Mathlib.Tactic
+
+/-!
+# Fixed-cutoff eventual bounds
+
+This module contains the first executable certificate family for quantitative
+asymptotics.  It deliberately starts with a small global tail language:
+nonnegative rational multiples of reciprocal powers.
+
+Candidate cutoffs are untrusted.  The Boolean checker validates the endpoint
+inequality and the Golden Theorem proves that the same inequality holds at
+every larger natural number.
+-/
+
+namespace LeanCert.Validity
+
+/-- Check the side conditions and cutoff value for
+`q / (n : ℝ) ^ k ≤ bound` on every `n ≥ cutoff`. -/
+def checkReciprocalPowerUpper
+    (q bound : ℚ) (k cutoff : Nat) : Bool :=
+  0 ≤ q && 0 < k && 0 < cutoff && q / (cutoff : ℚ) ^ k ≤ bound
+
+/-- Soundness-facing package for a fixed-cutoff reciprocal-power bound. -/
+structure ReciprocalPowerUpperCert
+    (q bound : ℚ) (k cutoff : Nat) where
+  checked : checkReciprocalPowerUpper q bound k cutoff = true
+
+/-- Self-contained fixed-cutoff certificate data. This is the stable payload
+that untrusted cutoff discovery can construct in a later layer. -/
+structure EventualBoundCert where
+  coefficient : ℚ
+  bound : ℚ
+  exponent : Nat
+  cutoff : Nat
+  checked :
+    checkReciprocalPowerUpper coefficient bound exponent cutoff = true
+
+/-- **Golden Theorem for fixed-cutoff reciprocal-power upper bounds.**
+
+The only computational premise is `checkReciprocalPowerUpper = true`.  Search
+for `cutoff` may therefore remain entirely untrusted. -/
+theorem verify_reciprocal_power_upper
+    (q bound : ℚ) (k cutoff : Nat)
+    (hcheck : checkReciprocalPowerUpper q bound k cutoff = true) :
+    ∀ n : Nat, cutoff ≤ n →
+      (q : ℝ) / (n : ℝ) ^ k ≤ (bound : ℝ) := by
+  simp only [checkReciprocalPowerUpper, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨⟨⟨hq, hk⟩, hcutoff⟩, hendpoint⟩
+  intro n hn
+  have hcutoffReal : (0 : ℝ) < cutoff := by exact_mod_cast hcutoff
+  have hnReal : (cutoff : ℝ) ≤ n := by exact_mod_cast hn
+  have hpow : (cutoff : ℝ) ^ k ≤ (n : ℝ) ^ k := by
+    exact pow_le_pow_left₀ (by positivity) hnReal k
+  have hqReal : (0 : ℝ) ≤ q := by exact_mod_cast hq
+  have htail : (q : ℝ) / (n : ℝ) ^ k ≤ (q : ℝ) / (cutoff : ℝ) ^ k := by
+    exact div_le_div_of_nonneg_left hqReal (by positivity) hpow
+  have hendpointReal :
+      (q : ℝ) / (cutoff : ℝ) ^ k ≤ (bound : ℝ) := by
+    exact_mod_cast hendpoint
+  exact htail.trans hendpointReal
+
+/-- Verify a packaged fixed-cutoff reciprocal-power certificate. -/
+theorem ReciprocalPowerUpperCert.verify
+    {q bound : ℚ} {k cutoff : Nat}
+    (cert : ReciprocalPowerUpperCert q bound k cutoff) :
+    ∀ n : Nat, cutoff ≤ n →
+      (q : ℝ) / (n : ℝ) ^ k ≤ (bound : ℝ) :=
+  verify_reciprocal_power_upper q bound k cutoff cert.checked
+
+/-- Semantic theorem represented by a self-contained eventual-bound
+certificate. -/
+theorem EventualBoundCert.verify (cert : EventualBoundCert) :
+    ∀ n : Nat, cert.cutoff ≤ n →
+      (cert.coefficient : ℝ) / (n : ℝ) ^ cert.exponent ≤
+        (cert.bound : ℝ) :=
+  verify_reciprocal_power_upper cert.coefficient cert.bound cert.exponent
+    cert.cutoff cert.checked
+
+/-- Convenient `k = 1` Golden Theorem for tails written as `q / n`. -/
+theorem verify_reciprocal_upper
+    (q bound : ℚ) (cutoff : Nat)
+    (hcheck : checkReciprocalPowerUpper q bound 1 cutoff = true) :
+    ∀ n : Nat, cutoff ≤ n →
+      (q : ℝ) / (n : ℝ) ≤ (bound : ℝ) := by
+  simpa using verify_reciprocal_power_upper q bound 1 cutoff hcheck
+
+end LeanCert.Validity

--- a/docs/reference/imports.md
+++ b/docs/reference/imports.md
@@ -34,6 +34,7 @@ loading tactic elaborators.
 import LeanCert.Tactic.IntervalAuto
 import LeanCert.Tactic.Bound
 import LeanCert.Tactic.Extension
+import LeanCert.Tactic.EventualBound
 import LeanCert.Discovery.Commands
 import LeanCert.Tactic.Discovery
 ```
@@ -61,6 +62,12 @@ import LeanCert.Engine.Chebyshev.Theta
 
 ```lean
 import LeanCert.Validity.Krawczyk
+```
+
+### Fixed-cutoff eventual bounds
+
+```lean
+import LeanCert.Validity.Eventual
 ```
 
 ### Algebraic Root Simplicity

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -110,6 +110,12 @@ Use `leancert` for portfolio routing and `certify_bound` when explicit interval
 engine control is desired. Trust is selected uniformly with
 `(trust := kernel)`, `(trust := native)`, or `(trust := auto)`.
 
+Use `eventual_bound` for explicit-cutoff natural-number tails in the initial
+reciprocal-power certificate language. The public validity boundary is
+`checkReciprocalPowerUpper` together with
+`verify_reciprocal_power_upper`; cutoff discovery is deliberately separate
+from this trusted checker and Golden Theorem.
+
 The removed `LeanCert.Tactic.LeanCert.Types` and
 `LeanCert.Tactic.LeanCert.Transaction` modules were internal implementation
 details. Solver extensions use

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -925,6 +925,30 @@ certificate-generating paths. It recognizes `Finset.Icc`, `Finset.Ico`,
 
 ## Common Patterns
 
+### Fixed-cutoff eventual bounds
+
+`eventual_bound` certifies natural-number tails of the form
+`q / (n : ℝ) ^ k ≤ c`, where `q` is nonnegative, `k` and the cutoff are
+positive, and all fixed values are rational. The endpoint comparison is
+checked exactly; monotonic decay of reciprocal powers proves the entire
+infinite tail.
+
+```lean
+import LeanCert.Tactic
+
+example : ∀ n : Nat, 100 ≤ n → (1 : ℝ) / n ≤ 1 / 100 := by
+  eventual_bound
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 3 / 100 := by
+  eventual_bound using 10
+```
+
+`eventual_bound?` proves the same goal and reports the selected tail rule and
+cutoff source. Existential goals require `using N`; automated cutoff discovery
+is not part of this fixed-cutoff boundary. General logarithmic/exponential
+tails and AD-based tail rules are also outside this initial certificate
+language.
+
 ### Proving a function is bounded
 
 ```lean

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,6 +32,21 @@ gaps without hiding backend selection or fallback.
 **Evidence:** backend-specific correctness tests and checked public API
 examples for each newly supported operation.
 
+## Quantitative asymptotics
+
+**Current state:** `eventual_bound` checks explicit positive cutoffs for
+natural-number upper bounds on nonnegative rational multiples of reciprocal
+powers. The endpoint is an executable exact-rational check, while the Golden
+Theorem proves the infinite tail by symbolic monotonicity. Existential goals
+accept an explicit witness through `eventual_bound using N`.
+
+**Possible next milestone:** add untrusted cutoff discovery over the same
+checker boundary, then grow the typed tail-rule language from demonstrated
+downstream needs.
+
+**Evidence:** fixed-cutoff and existential regression theorems, rejected
+cutoff tests, and `eventual_bound?` provenance.
+
 ## Stronger quantified ML theorems
 
 **Current state:** ML certificate components prove the precise structural and

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -126,6 +126,7 @@ roots = [
   "LeanCert.Test.ChebyshevPsi",
   "LeanCert.Test.ChebyshevTheta",
   "LeanCert.Test.EulerMascheroni",
+  "LeanCert.Test.EventualBound",
   "LeanCert.Test.ExtensionProtocol",
   "LeanCert.Test.ExtensionExecution",
   "LeanCert.Test.FinSumBound",


### PR DESCRIPTION
## Summary

This PR introduces LeanCert’s first executable certificate family for quantitative asymptotics.

It adds `eventual_bound`, a dedicated tactic for proving explicit natural-number tail bounds of the form

```lean
∀ n : Nat, N ≤ n → q / (n : ℝ) ^ k ≤ c
```

where `q ≥ 0`, `k > 0`, and `N > 0`.

```lean
example : ∀ n : Nat, 100 ≤ n → (1 : ℝ) / n ≤ 1 / 100 := by
  eventual_bound

example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 3 / 100 := by
  eventual_bound using 10
```

## Verification boundary

The new `checkReciprocalPowerUpper` checker validates the side conditions and endpoint inequality using exact rational arithmetic.

The Golden Theorem `verify_reciprocal_power_upper` then proves the complete infinite tail using monotonicity of reciprocal powers. Candidate cutoffs remain untrusted: only the executable checker and resulting Lean proof determine acceptance.

A self-contained `EventualBoundCert` payload is included so future untrusted cutoff discovery can reuse the same verification boundary.

## DevUX

- `eventual_bound` reads the cutoff from a universal goal.
- `eventual_bound using N` supplies a witness for an existential goal.
- `eventual_bound?` reports the selected tail rule, cutoff source, and verification path.
- Failed attempts restore the original tactic state.
- Rejected cutoffs and unsupported tail expressions produce a focused diagnostic.

Automated cutoff discovery is intentionally left for the next layer. This PR establishes the trusted fixed-cutoff foundation that discovery can repeatedly query.
