### PR TITLE
feat: discover eventual-bound cutoffs

### DIFF
--- a/LeanCert/Tactic/EventualBound.lean
+++ b/LeanCert/Tactic/EventualBound.lean
@@ -7,11 +7,11 @@ import LeanCert.Tactic.IntervalAuto.Extract
 import LeanCert.Validity.Eventual
 
 /-!
-# Fixed-cutoff eventual-bound tactic
+# Eventual-bound certification and cutoff discovery
 
-`eventual_bound` closes an explicit natural-number tail bound using an
-executable LeanCert certificate.  The initial certificate language covers
-nonnegative rational multiples of reciprocal powers.
+The fixed-cutoff checker is trusted only through its Golden Theorem. Cutoff
+search is deterministic but untrusted: its sole output is a candidate fed back
+to `checkReciprocalPowerUpper` before proof construction.
 -/
 
 open Lean Elab Tactic
@@ -21,6 +21,47 @@ namespace LeanCert.Tactic
 open Lean Meta
 open LeanCert.Tactic.Auto
 
+/-- Expected failures of eventual-bound parsing, search, and certification. -/
+inductive EventualBoundFailure where
+  | unsupportedTail (expression detail : String)
+  | invalidParameters (detail : String)
+  | rejectedCutoff (cutoff : Nat)
+  | searchExhausted (checks lastCutoff : Nat)
+  | transportFailure (detail : String)
+  | internalFailure (detail : String)
+  deriving Inhabited, Repr
+
+/-- Search facts retained from the single candidate-generation run. -/
+structure EventualSearchStatistics where
+  cutoff : Nat
+  checks : Nat
+  configuredLimit : Nat
+  exponentialSteps : Nat
+  refinementSteps : Nat
+  lowerBracket : Nat
+  upperBracket : Nat
+  refinementComplete : Bool
+  deriving Inhabited, Repr
+
+/-- Runtime facts returned by successful eventual-bound certification. -/
+structure EventualBoundOutcome where
+  cutoff : Nat
+  discovered : Bool
+  checker : Name := ``LeanCert.Validity.checkReciprocalPowerUpper
+  verifier : Name := ``LeanCert.Validity.verify_reciprocal_power_upper
+  search : Option EventualSearchStatistics := none
+  deriving Inhabited, Repr
+
+private inductive CutoffRequest where
+  | fixed (cutoff : Nat)
+  | discover
+
+private structure ParsedReciprocalPowerGoal where
+  coefficient : ℚ
+  bound : ℚ
+  exponent : Nat
+  cutoff : CutoffRequest
+
 private def binaryArgs? (e : Expr) (name : Name) : Option (Expr × Expr) :=
   if !e.isAppOf name then none
   else
@@ -29,101 +70,239 @@ private def binaryArgs? (e : Expr) (name : Name) : Option (Expr × Expr) :=
       some (args[args.size - 2], args[args.size - 1])
     else none
 
-private structure ParsedReciprocalPowerGoal where
-  coefficient : ℚ
-  bound : ℚ
-  exponent : Nat
-  cutoff : Nat
-
-private def parseReciprocalPowerGoal : TacticM ParsedReciprocalPowerGoal := do
-  let target ← instantiateMVars (← getMainTarget)
-  let .forallE _ _ tailBody _ := target
-    | throwError "expected `∀ n : Nat, N ≤ n → ...`"
+private def parseUniversal (target : Expr) (request : CutoffRequest) :
+    MetaM (Except EventualBoundFailure ParsedReciprocalPowerGoal) := do
+  let .forallE _ indexType tailBody _ := target
+    | return .error (.unsupportedTail (toString target)
+        "expected `∀ n : Nat, N ≤ n → ...`")
+  unless indexType.isConstOf ``Nat do
+    return .error (.unsupportedTail (toString target)
+      "the tail index must have type `Nat`")
   let .forallE _ tailHypothesis conclusion _ := tailBody
-    | throwError "expected the tail hypothesis `N ≤ n`"
+    | return .error (.unsupportedTail (toString target)
+        "expected the tail hypothesis `N ≤ n`")
   let cutoffExpr ←
     match binaryArgs? tailHypothesis ``LE.le with
     | some (cutoff, _) => pure cutoff
     | none =>
         match binaryArgs? tailHypothesis ``GE.ge with
         | some (_, cutoff) => pure cutoff
-        | none => throwError "expected the tail hypothesis `N ≤ n`"
+        | none => return .error (.unsupportedTail (toString tailHypothesis)
+            "expected the tail hypothesis `N ≤ n`")
+  let request ←
+    match request with
+    | .discover => pure .discover
+    | .fixed _ =>
+        let some cutoff ← getNatValue? cutoffExpr
+          | return .error (.unsupportedTail (toString cutoffExpr)
+              "the cutoff is not a natural-number literal")
+        pure (.fixed cutoff)
   let some (lhs, boundExpr) := binaryArgs? conclusion ``LE.le
-    | throwError "expected an upper-bound inequality"
+    | return .error (.unsupportedTail (toString conclusion)
+        "expected an eventual upper-bound comparison")
   let some (qExpr, denominator) := binaryArgs? lhs ``HDiv.hDiv
-    | throwError "expected a quotient `q / (n : ℝ) ^ k`; got {lhs} with head {lhs.getAppFn.constName?}"
-  let exponent :=
+    | return .error (.unsupportedTail (toString lhs)
+        "expected a quotient `q / (n : ℝ) ^ k`")
+  let exponentExpr :=
     match binaryArgs? denominator ``HPow.hPow with
     | some (_, exponent) => exponent
     | none => toExpr (1 : Nat)
-  let some q ← extractRatFromReal qExpr
-    | throwError "the reciprocal-power coefficient is not a rational literal"
+  let some coefficient ← extractRatFromReal qExpr
+    | return .error (.unsupportedTail (toString qExpr)
+        "the coefficient is not a rational literal")
   let some bound ← extractRatFromReal boundExpr
-    | throwError "the comparison bound is not a rational literal"
-  let some exponent ← getNatValue? exponent
-    | throwError "the reciprocal-power exponent is not a natural-number literal"
-  let some cutoff ← getNatValue? cutoffExpr
-    | throwError "the cutoff is not a natural-number literal"
-  pure { coefficient := q, bound, exponent, cutoff }
+    | return .error (.unsupportedTail (toString boundExpr)
+        "the comparison bound is not a rational literal")
+  let some exponent ← getNatValue? exponentExpr
+    | return .error (.unsupportedTail (toString exponentExpr)
+        "the reciprocal-power exponent is not a natural-number literal")
+  return .ok { coefficient, bound, exponent, cutoff := request }
 
-private def runEventualBound (cutoff? : Option (TSyntax `term))
-    (explain : Bool) : TacticM Unit := do
+/-- Parse either a fixed universal goal or an existential cutoff goal. -/
+private def parseReciprocalPowerGoal : TacticM
+    (Except EventualBoundFailure ParsedReciprocalPowerGoal) := do
+  let target ← instantiateMVars (← getMainTarget)
+  if target.isAppOfArity ``Exists 2 then
+    let args := target.getAppArgs
+    unless args[0]!.isConstOf ``Nat do
+      return .error (.unsupportedTail (toString target)
+        "the cutoff witness must have type `Nat`")
+    let .lam _ _ body _ := args[1]!
+      | return .error (.unsupportedTail (toString target)
+          "could not inspect the existential cutoff body")
+    parseUniversal (body.instantiate1 (toExpr (1 : Nat))) .discover
+  else
+    parseUniversal target (.fixed 0)
+
+private def accepts (q bound : ℚ) (k cutoff : Nat) : Bool :=
+  LeanCert.Validity.checkReciprocalPowerUpper q bound k cutoff
+
+private partial def exponentialSearch (q bound : ℚ) (k : Nat)
+    (limit checks lo hi steps : Nat) :
+    Except EventualBoundFailure (Nat × Nat × Nat × Nat) :=
+  if checks ≥ limit then .error (.searchExhausted checks lo)
+  else if accepts q bound k hi then .ok (lo, hi, checks + 1, steps + 1)
+  else exponentialSearch q bound k limit (checks + 1) hi (2 * hi) (steps + 1)
+
+private partial def binaryRefine (q bound : ℚ) (k limit : Nat)
+    (checks lo hi steps : Nat) : Nat × Nat × Nat × Nat × Bool :=
+  if lo + 1 ≥ hi then (lo, hi, checks, steps, true)
+  else if checks ≥ limit then (lo, hi, checks, steps, false)
+  else
+    let mid := (lo + hi) / 2
+    if accepts q bound k mid then
+      binaryRefine q bound k limit (checks + 1) lo mid (steps + 1)
+    else
+      binaryRefine q bound k limit (checks + 1) mid hi (steps + 1)
+
+/-- Untrusted exponential search followed by bounded binary refinement. Every
+accepted result is independently replayed by the H1 checker. -/
+def discoverReciprocalPowerCutoff (q bound : ℚ) (k maxChecks : Nat) :
+    Except EventualBoundFailure EventualSearchStatistics := do
+  if q < 0 then throw (.invalidParameters "the coefficient must be nonnegative")
+  if k = 0 then throw (.invalidParameters "the exponent must be positive")
+  if maxChecks = 0 then throw (.searchExhausted 0 0)
+  if accepts q bound k 1 then
+    return {
+      cutoff := 1
+      checks := 1
+      configuredLimit := maxChecks
+      exponentialSteps := 0
+      refinementSteps := 0
+      lowerBracket := 0
+      upperBracket := 1
+      refinementComplete := true
+    }
+  if bound < 0 || (0 < q && bound = 0) then
+    throw (.invalidParameters
+      "a nonnegative reciprocal-power tail cannot satisfy this upper bound")
+  let (lo, hi, checks, exponentialSteps) ←
+    exponentialSearch q bound k maxChecks 1 1 2 0
+  let (lo, hi, checks, refinementSteps, complete) :=
+    binaryRefine q bound k maxChecks checks lo hi 0
+  return {
+    cutoff := hi
+    checks
+    configuredLimit := maxChecks
+    exponentialSteps
+    refinementSteps
+    lowerBracket := lo
+    upperBracket := hi
+    refinementComplete := complete
+  }
+
+private def closeWithCutoff (parsed : ParsedReciprocalPowerGoal) (cutoff : Nat) :
+    TacticM Unit := do
+  unless accepts parsed.coefficient parsed.bound parsed.exponent cutoff do
+    throwError "the final reciprocal-power certificate was rejected"
+  if let .discover := parsed.cutoff then
+    let cutoffSyntax ← Term.exprToSyntax (toExpr cutoff)
+    evalTactic (← `(tactic| refine ⟨$cutoffSyntax, ?_⟩))
+  let q ← Term.exprToSyntax (toExpr parsed.coefficient)
+  let bound ← Term.exprToSyntax (toExpr parsed.bound)
+  let exponent ← Term.exprToSyntax (toExpr parsed.exponent)
+  let cutoff ← Term.exprToSyntax (toExpr cutoff)
+  evalTactic (← `(tactic|
+    convert LeanCert.Validity.verify_reciprocal_power_upper
+      ($q : ℚ) ($bound : ℚ) $exponent $cutoff
+        (by norm_num [LeanCert.Validity.checkReciprocalPowerUpper]) using 1 <;>
+      norm_num))
+  unless (← getUnsolvedGoals).isEmpty do
+    throwError "eventual-bound proof transport left unsolved goals"
+
+/-- Reporting-aware core shared by the dedicated tactic and semantic router. -/
+def eventualBoundCoreTyped (cutoff? : Option Nat) (maxChecks : Nat := 1000) :
+    TacticM (Except EventualBoundFailure EventualBoundOutcome) := do
   let saved ← saveState
   try
     if let some cutoff := cutoff? then
-      evalTactic (← `(tactic| refine ⟨$cutoff, ?_⟩))
-    let parsed ← parseReciprocalPowerGoal
-    unless 0 ≤ parsed.coefficient && 0 < parsed.exponent && 0 < parsed.cutoff &&
-        parsed.coefficient / (parsed.cutoff : ℚ) ^ parsed.exponent ≤ parsed.bound do
-      throwError "the reciprocal-power certificate was rejected"
-    let q ← Term.exprToSyntax (toExpr parsed.coefficient)
-    let bound ← Term.exprToSyntax (toExpr parsed.bound)
-    let exponent ← Term.exprToSyntax (toExpr parsed.exponent)
-    let cutoff ← Term.exprToSyntax (toExpr parsed.cutoff)
-    evalTactic (← `(tactic|
-      convert LeanCert.Validity.verify_reciprocal_power_upper
-        ($q : ℚ) ($bound : ℚ) $exponent $cutoff
-          (by norm_num [LeanCert.Validity.checkReciprocalPowerUpper]) using 1 <;>
-        norm_num))
-    unless (← getUnsolvedGoals).isEmpty do
-      throwError "the reciprocal-power certificate was rejected"
-    if explain then
-      let cutoffLine := cutoff?.map
-        (fun cutoff => s!"\nCutoff:\n  N = {cutoff}") |>.getD
-          "\nCutoff:\n  read from the universal goal"
-      logInfo m!"LeanCert recognized: fixed-cutoff eventual upper bound
+      let cutoffSyntax ← Term.exprToSyntax (toExpr cutoff)
+      evalTactic (← `(tactic| refine ⟨$cutoffSyntax, ?_⟩))
+    let parsed ←
+      match ← parseReciprocalPowerGoal with
+      | .ok parsed => pure parsed
+      | .error failure => saved.restore; return .error failure
+    let (cutoff, search?) ←
+      match cutoff?, parsed.cutoff with
+      | some cutoff, _ => pure (cutoff, none)
+      | none, .fixed cutoff => pure (cutoff, none)
+      | none, .discover =>
+          match discoverReciprocalPowerCutoff parsed.coefficient parsed.bound
+              parsed.exponent maxChecks with
+          | .ok statistics => pure (statistics.cutoff, some statistics)
+          | .error failure => saved.restore; return .error failure
+    unless accepts parsed.coefficient parsed.bound parsed.exponent cutoff do
+      saved.restore
+      return .error (.rejectedCutoff cutoff)
+    try closeWithCutoff parsed cutoff
+    catch exception =>
+      saved.restore
+      return .error (.transportFailure (← exception.toMessageData.toString))
+    return .ok { cutoff, discovered := search?.isSome, search := search? }
+  catch exception =>
+    saved.restore
+    return .error (.internalFailure (← exception.toMessageData.toString))
+
+private def failureMessage : EventualBoundFailure → String
+  | .unsupportedTail expression detail =>
+      s!"Unsupported eventual tail:\n  {expression}\n\n{detail}\n\nThe current certificate language supports nonnegative rational multiples of reciprocal powers."
+  | .invalidParameters detail => s!"Eventual-bound parameters are invalid: {detail}."
+  | .rejectedCutoff cutoff => s!"The eventual-bound checker rejected cutoff N = {cutoff}."
+  | .searchExhausted checks last =>
+      s!"Cutoff discovery exhausted its check budget after {checks} candidate(s); last cutoff: {last}. Try `(maxIterations := ...)` or provide `using N`."
+  | .transportFailure detail => s!"Eventual-bound proof transport failed:\n{detail}"
+  | .internalFailure detail => s!"Eventual-bound certification encountered an internal error:\n{detail}"
+
+private def runEventualBound (cutoff? : Option (TSyntax `term))
+    (maxChecks : Nat) (explain : Bool) : TacticM Unit := do
+  let cutoffValue? ← cutoff?.mapM fun cutoff => do
+    let expression ← Term.elabTerm cutoff (some (mkConst ``Nat))
+    let some value ← getNatValue? expression
+      | throwErrorAt cutoff "the cutoff must be a natural-number literal"
+    pure value
+  match ← eventualBoundCoreTyped cutoffValue? maxChecks with
+  | .error failure => throwError (failureMessage failure)
+  | .ok outcome =>
+      if explain then
+        let search := match outcome.search with
+          | none => "  Source: explicit cutoff"
+          | some statistics =>
+              s!"  Source: automatic discovery\n  Candidates checked: {statistics.checks}\n  Discovered cutoff: N = {statistics.cutoff}\n  Minimality refinement complete: {statistics.refinementComplete}"
+        logInfo m!"LeanCert recognized: eventual natural-number upper bound
 
 Selected strategy:
-  reciprocal-power tail certificate{cutoffLine}
+  reciprocal-power tail certificate
 
-Tail rule:
-  nonnegative rational multiple of 1 / n^k
-  endpoint checked exactly; global decay proved symbolically
+Cutoff:
+{search}
 
 Certificate verification:
   kernel (`norm_num`)
 
-Suggested proof:
+Suggested stable proof:
   by
-    {if cutoff?.isSome then s!"eventual_bound using {cutoff?.get!}" else "eventual_bound"}"
-  catch exception =>
-    saved.restore
-    let detail ← exception.toMessageData.toString
-    throwError "Eventual bound certification failed.\n\n\
-      H1 currently accepts goals of the form\n  \
-      `∀ n : Nat, N ≤ n → q / (n : ℝ) ^ k ≤ c`\n\
-      with `q ≥ 0`, `k > 0`, and `N > 0`. For existential goals, write\n  \
-      `eventual_bound using N`.\n\n\
-      The cutoff may be too small, or the tail expression may be outside this\n\
-      initial certificate language.\n\nUnderlying elaboration detail:\n{detail}"
+    eventual_bound using {outcome.cutoff}"
 
-syntax (name := eventualBoundTac) "eventual_bound" (" using " term)? : tactic
-syntax (name := eventualBoundQuestionTac) "eventual_bound?" (" using " term)? : tactic
+declare_syntax_cat eventualBoundConfigItem
+syntax "(" &"maxIterations" " := " num ")" : eventualBoundConfigItem
+syntax (name := eventualBoundTac) "eventual_bound" (" using " term)?
+  eventualBoundConfigItem* : tactic
+syntax (name := eventualBoundQuestionTac) "eventual_bound?" (" using " term)?
+  eventualBoundConfigItem* : tactic
+
+private def parseMaxChecks (items : Array Syntax) : TacticM Nat := do
+  let mut maxChecks := 1000
+  for item in items do
+    match item with
+    | `(eventualBoundConfigItem| (maxIterations := $n:num)) =>
+        maxChecks := n.getNat
+    | _ => throwUnsupportedSyntax
+  return maxChecks
 
 elab_rules : tactic
-  | `(tactic| eventual_bound $[using $cutoff]?) =>
-      runEventualBound cutoff false
-  | `(tactic| eventual_bound? $[using $cutoff]?) =>
-      runEventualBound cutoff true
+  | `(tactic| eventual_bound $[using $cutoff]? $items:eventualBoundConfigItem*) => do
+      runEventualBound cutoff (← parseMaxChecks items) false
+  | `(tactic| eventual_bound? $[using $cutoff]? $items:eventualBoundConfigItem*) => do
+      runEventualBound cutoff (← parseMaxChecks items) true
 
 end LeanCert.Tactic

--- a/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
+++ b/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
@@ -50,6 +50,7 @@ def intentLabel : GoalIntent → String
   | .multivariateBound => "multivariate bound"
   | .intervalBound => "univariate interval bound"
   | .pointInequality => "closed numerical comparison"
+  | .eventualBound => "eventual natural-number upper bound"
   | .certificateCheck => "closed certificate check"
   | .conjunction => "conjunction of numerical theorems"
 
@@ -278,6 +279,21 @@ private def renderIntegralPartitions
         Maximum: {statistics.maximumPartitions}\n  Selected: {statistics.chosenPartitions}\n  \
         Attempts: {statistics.attempts}"
 
+private def renderEventualBound (statistics : Option EventualBoundStatistics) : String :=
+  match statistics with
+  | none => ""
+  | some statistics =>
+      s!"\n\nCutoff search:\n  Configured check limit: {statistics.configuredLimit}\n  \
+        Candidates checked: {statistics.checks}\n  Exponential steps: {statistics.exponentialSteps}\n  \
+        Final bracket: [{statistics.lowerBracket}, {statistics.upperBracket}]\n  \
+        Binary refinement steps: {statistics.refinementSteps}\n  \
+        Discovered cutoff: N = {statistics.cutoff}\n  \
+        Minimality refinement complete: {statistics.refinementComplete}
+
+Stable explicit proof:
+  by
+    eventual_bound using {statistics.cutoff}"
+
 private def renderCertificates
     (certificates : Array CertificateObservation) : String :=
   if certificates.isEmpty then ""
@@ -325,13 +341,14 @@ def successReport (report : SolverReport) : String :=
   let subdivision := renderSubdivision report.execution.subdivision
   let finiteSum := renderFiniteSum report.execution.finiteSum
   let integralPartitions := renderIntegralPartitions report.execution.integralPartitions
+  let eventualBound := renderEventualBound report.execution.eventualBound
   let certificates := renderCertificates report.execution.certificates
   let advanced :=
     plan.dedicatedProof.map (fun proof =>
       s!"\n\nAdvanced control:\n  {renderProof proof}") |>.getD ""
   s!"LeanCert recognized: {intentLabel plan.intent}\n\n\
     Selected strategy:\n  {plan.strategy}{detail}{executionNotes}{backend}{verification}\
-    {checker}{verifier}{optimization}{subdivision}{finiteSum}{integralPartitions}{certificates}\n\n\
+    {checker}{verifier}{optimization}{subdivision}{finiteSum}{integralPartitions}{eventualBound}{certificates}\n\n\
     Suggested proof:\n  {renderProof plan.primaryProof}\
     {advanced}{renderChildren report.execution.children}"
 

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -13,6 +13,7 @@ import LeanCert.Tactic.LeanCert.Solver.Protocol
 import LeanCert.Tactic.Extension.Execute
 import LeanCert.Tactic.Discovery
 import LeanCert.Tactic.FinSumExpand
+import LeanCert.Tactic.EventualBound
 import LeanCert.Engine.Search.CounterExample
 
 /-!
@@ -696,6 +697,52 @@ private def certificateCheckAttemptTyped :
       return .error <| .internalError `LeanCert.Tactic.leancert
         (failure.message "leancert")
 
+private def eventualFailure : EventualBoundFailure → AttemptFailure
+  | .unsupportedTail expression detail =>
+      .unsupported { expression, detail := some detail }
+  | .invalidParameters detail =>
+      .rejected { detail }
+  | .rejectedCutoff cutoff =>
+      .rejected {
+        checker := some ``LeanCert.Validity.checkReciprocalPowerUpper
+        detail := s!"The fixed-cutoff checker rejected candidate N = {cutoff}."
+      }
+  | .searchExhausted checks lastCutoff =>
+      .inconclusive {
+        requested := some s!"at most {checks} candidate checks"
+        detail := s!"Cutoff discovery exhausted its configured check budget after \
+          {checks} candidate(s); last cutoff: {lastCutoff}. Increase \
+          `(maxIterations := ...)` or use `eventual_bound using N`."
+      }
+  | .transportFailure detail =>
+      .internalError `LeanCert.Tactic.eventualBoundCoreTyped detail
+  | .internalFailure detail =>
+      .internalError `LeanCert.Tactic.eventualBoundCoreTyped detail
+
+private def eventualBoundAttemptTyped (maxChecks : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← eventualBoundCoreTyped none maxChecks with
+  | .error failure => return .error (eventualFailure failure)
+  | .ok outcome =>
+      let statistics := outcome.search.map fun search => ({
+        cutoff := search.cutoff
+        checks := search.checks
+        configuredLimit := search.configuredLimit
+        exponentialSteps := search.exponentialSteps
+        refinementSteps := search.refinementSteps
+        lowerBracket := search.lowerBracket
+        upperBracket := search.upperBracket
+        refinementComplete := search.refinementComplete
+      } : Solver.EventualBoundStatistics)
+      return .ok {
+        backend := some .exactRational
+        verificationUsage := { kernelChecks := 1 }
+        checker := some outcome.checker
+        verifier := some outcome.verifier
+        eventualBound := statistics
+        notes := if outcome.discovered then #[] else #[s!"Explicit cutoff: N = {outcome.cutoff}"]
+      }
+
 /-- The deterministic strategy portfolio for a recognized goal intent. -/
 private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
     (mode : VerificationMode) : Array SolverSpec :=
@@ -703,6 +750,12 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
   let d2 := d + 10
   let d3 := d + 20
   match intent with
+  | .eventualBound => #[
+      { report := report intent "reciprocal-power tail certificate"
+          cfg mode (.fixed .exactRational)
+          none
+          (strategyId := .eventualBound),
+        solve := eventualBoundAttemptTyped cfg.maxIterations }]
   | .pointInequality => #[
       { report := report intent "exact normalization" cfg mode .notApplicable
           (some (suggestion "norm_num")) (strategyId := .exactNormalization),
@@ -1174,6 +1227,7 @@ private def intentOfSemanticGoal (goal : Semantic.SemanticGoal) : MetaM (Option 
   | .finiteSum _ => return some .finiteSum
   | .certificateCheck .. => return some .certificateCheck
   | .allOf .. => return some .conjunction
+  | .eventualBound _ => return some .eventualBound
   | .bound spec =>
       return some (if spec.boundVars.size > 1 then .multivariateBound else .intervalBound)
   | .root spec =>

--- a/LeanCert/Tactic/LeanCert/Semantic/Goal.lean
+++ b/LeanCert/Tactic/LeanCert/Semantic/Goal.lean
@@ -32,6 +32,7 @@ inductive GoalIntent where
   | multivariateBound
   | intervalBound
   | pointInequality
+  | eventualBound
   | certificateCheck
   | conjunction
   deriving Repr, BEq, Inhabited
@@ -133,6 +134,14 @@ structure FiniteSumSpec where
   rhs : Lean.Expr
   deriving Inhabited
 
+/-- A natural-number tail theorem. The eventual-bound solver performs the
+certificate-language check so unsupported tails still receive semantic
+diagnostics instead of falling through to generic existential discovery. -/
+structure EventualBoundSpec where
+  original : Lean.Expr
+  discoverCutoff : Bool
+  deriving Inhabited
+
 /-- Mathematical theorem shapes understood by the semantic front door. -/
 inductive SemanticGoal where
   | point (spec : PointSpec)
@@ -142,6 +151,7 @@ inductive SemanticGoal where
   | discovery (spec : DiscoverySpec)
   | integral (spec : IntegralSpec)
   | finiteSum (spec : FiniteSumSpec)
+  | eventualBound (spec : EventualBoundSpec)
   | certificateCheck (original checker : Lean.Expr)
   | allOf (original : Lean.Expr) (children : Array SemanticGoal)
   deriving Inhabited
@@ -155,6 +165,7 @@ def SemanticGoal.original : SemanticGoal → Lean.Expr
   | .discovery spec => spec.original
   | .integral spec => spec.original
   | .finiteSum spec => spec.original
+  | .eventualBound spec => spec.original
   | .certificateCheck original _ => original
   | .allOf original _ => original
 

--- a/LeanCert/Tactic/LeanCert/Semantic/Parse.lean
+++ b/LeanCert/Tactic/LeanCert/Semantic/Parse.lean
@@ -196,6 +196,26 @@ private def parseBound? (goal : Lean.Expr) : MetaM (Option BoundSpec) := do
     return some spec
   return none
 
+private def parseEventualUniversal? (original goal : Lean.Expr)
+    (discoverCutoff : Bool) : Option EventualBoundSpec := do
+  let .forallE _ indexType tailBody _ := goal | none
+  guard (indexType.isConstOf (Name.mkSimple "Nat"))
+  let .forallE _ tailHypothesis conclusion _ := tailBody | none
+  let hypothesisHead := tailHypothesis.getAppFn
+  guard (hypothesisHead.isConstOf ``LE.le || hypothesisHead.isConstOf ``GE.ge)
+  let comparison ← parseRawComparison? conclusion
+  guard (comparison.comparison == .le)
+  some { original, discoverCutoff }
+
+private def parseEventual? (goal : Lean.Expr) : Option EventualBoundSpec := do
+  if goal.isAppOfArity ``Exists 2 then
+    let args := goal.getAppArgs
+    guard (args[0]!.isConstOf (Name.mkSimple "Nat"))
+    let .lam _ _ body _ := args[1]! | none
+    parseEventualUniversal? goal (body.instantiate1 (toExpr (1 : Nat))) true
+  else
+    parseEventualUniversal? goal goal false
+
 private def isZero (expression : Lean.Expr) : MetaM Bool := do
   return (← LeanCert.Meta.Numeral.toRealRatNormalized? expression) == some 0
 
@@ -423,6 +443,7 @@ partial def parseGoal (goal : Lean.Expr) : MetaM (Except ParseFailure SemanticGo
   if let some root ← parseRootExists? goal then return .ok (.root root)
   if let some root ← parseNoRoot? goal then return .ok (.root root)
   if let some extremum ← parseExtremum? goal then return .ok (.extremum extremum)
+  if let some eventual := parseEventual? goal then return .ok (.eventualBound eventual)
   if let some discovery ← parseDiscovery? goal then return .ok (.discovery discovery)
   if let some finiteSum := parseFiniteSum? goal then return .ok (.finiteSum finiteSum)
   if let some checker := parseCertificateCheck? goal then

--- a/LeanCert/Tactic/LeanCert/Semantic/Prepare.lean
+++ b/LeanCert/Tactic/LeanCert/Semantic/Prepare.lean
@@ -179,6 +179,8 @@ partial def prepareGoal (semantic : SemanticGoal) :
     | .integral _ =>
         let functions ← (functionsOf semantic).mapM prepareFunction
         return .ok { semantic, functions }
+    | .eventualBound _ =>
+        return .ok { semantic }
     | .allOf _ children =>
         let preparedChildren ← children.mapM prepareGoal
         let mut domains := #[]

--- a/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
+++ b/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
@@ -159,6 +159,18 @@ structure IntegralPartitionStatistics where
   attempts : Nat
   deriving Inhabited, Repr
 
+/-- Structured facts from eventual-cutoff candidate generation. -/
+structure EventualBoundStatistics where
+  cutoff : Nat
+  checks : Nat
+  configuredLimit : Nat
+  exponentialSteps : Nat
+  refinementSteps : Nat
+  lowerBracket : Nat
+  upperBracket : Nat
+  refinementComplete : Bool
+  deriving Inhabited, Repr
+
 /-- Stable algorithm identity for reporting and failure classification.
 User-facing `strategy` text may be polished without changing control flow. -/
 inductive StrategyId where
@@ -177,6 +189,7 @@ inductive StrategyId where
   | finiteSum
   | exactIntegral
   | partitionIntegral
+  | eventualBound
   | conjunction
   deriving DecidableEq, Repr, Inhabited
 
@@ -215,6 +228,7 @@ structure SolverExecution where
   subdivision : Option SubdivisionStatistics := none
   finiteSum : Option FiniteSumStatistics := none
   integralPartitions : Option IntegralPartitionStatistics := none
+  eventualBound : Option EventualBoundStatistics := none
   /-- Constituent checker proofs retained by composite artifacts. The singular
   `checker`/`verifier` fields describe ordinary one-certificate solvers. -/
   certificates : Array CertificateObservation := #[]

--- a/LeanCert/Test/EventualBound.lean
+++ b/LeanCert/Test/EventualBound.lean
@@ -5,11 +5,21 @@ Authors: LeanCert Contributors
 -/
 import LeanCert.Tactic
 
-/-! Regression tests for fixed-cutoff eventual bounds. -/
+/-! Regression tests for fixed and discovered-cutoff eventual bounds. -/
 
 #guard LeanCert.Validity.checkReciprocalPowerUpper 1 (1 / 100) 2 10
 #guard !LeanCert.Validity.checkReciprocalPowerUpper 1 (1 / 100) 2 9
 #guard !LeanCert.Validity.checkReciprocalPowerUpper 1 1 1 0
+
+#guard (LeanCert.Tactic.discoverReciprocalPowerCutoff 3 (1 / 1000) 2 64).toOption.map
+  (·.cutoff) == some 55
+#guard (LeanCert.Tactic.discoverReciprocalPowerCutoff 0 0 7 1).toOption.map
+  (·.cutoff) == some 1
+#guard (LeanCert.Tactic.discoverReciprocalPowerCutoff 3 (1 / 1000) 2 7).toOption.map
+  (fun result => (result.cutoff, result.refinementComplete)) == some (64, false)
+#guard match LeanCert.Tactic.discoverReciprocalPowerCutoff 0 (-1) 2 64 with
+  | .error _ => true
+  | .ok _ => false
 
 example : ∀ n : Nat, 10 ≤ n → (1 : ℝ) / (n : ℝ) ^ 2 ≤ 1 / 100 := by
   eventual_bound
@@ -22,6 +32,46 @@ example : ∃ N : Nat, ∀ n : Nat, N ≤ n → (3 : ℝ) / (n : ℝ) ^ 2 ≤ 3 
 
 example : ∃ N : Nat, ∀ n ≥ N, (1 : ℝ) / n ≤ 1 / 100 := by
   eventual_bound using 100
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  eventual_bound
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  eventual_bound (maxIterations := 64)
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  leancert
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  leancert (maxIterations := 7)
+
+example : ∀ n : Nat, 100 ≤ n → (1 : ℝ) / n ≤ 1 / 100 := by
+  leancert
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  leancert?
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  eventual_bound?
+
+example : True := by
+  fail_if_success
+    have : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+      eventual_bound (maxIterations := 1)
+  trivial
+
+example : True := by
+  fail_if_success
+    have : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+      leancert (maxIterations := 1)
+  trivial
+
+example : True := by
+  fail_if_success
+    have : ∃ N : Nat, ∀ n ≥ N,
+        Real.log (n : ℝ) / (n : ℝ) ≤ 1 / 100 := by
+      leancert
+  trivial
 
 example : ∀ n : Nat, 10 ≤ n → (2 : ℝ) / n ^ 2 ≤ 1 / 50 := by
   eventual_bound?

--- a/LeanCert/Validity/Eventual.lean
+++ b/LeanCert/Validity/Eventual.lean
@@ -31,7 +31,7 @@ structure ReciprocalPowerUpperCert
   checked : checkReciprocalPowerUpper q bound k cutoff = true
 
 /-- Self-contained fixed-cutoff certificate data. This is the stable payload
-that untrusted cutoff discovery can construct in a later layer. -/
+that untrusted cutoff discovery may construct before checker replay. -/
 structure EventualBoundCert where
   coefficient : ℚ
   bound : ℚ

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -110,11 +110,14 @@ Use `leancert` for portfolio routing and `certify_bound` when explicit interval
 engine control is desired. Trust is selected uniformly with
 `(trust := kernel)`, `(trust := native)`, or `(trust := auto)`.
 
-Use `eventual_bound` for explicit-cutoff natural-number tails in the initial
-reciprocal-power certificate language. The public validity boundary is
-`checkReciprocalPowerUpper` together with
-`verify_reciprocal_power_upper`; cutoff discovery is deliberately separate
-from this trusted checker and Golden Theorem.
+Use `eventual_bound` for natural-number tails in the reciprocal-power
+certificate language. Universal goals take their cutoff from the theorem;
+existential goals may use `eventual_bound using N` or ask LeanCert to discover
+a cutoff. The public validity boundary is `checkReciprocalPowerUpper` together
+with `verify_reciprocal_power_upper`. `discoverReciprocalPowerCutoff` is an
+untrusted candidate generator: its result is always replayed through that
+checker before proof construction. The `leancert` router recognizes the same
+eventual-bound goal family.
 
 The removed `LeanCert.Tactic.LeanCert.Types` and
 `LeanCert.Tactic.LeanCert.Transaction` modules were internal implementation

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -925,7 +925,7 @@ certificate-generating paths. It recognizes `Finset.Icc`, `Finset.Ico`,
 
 ## Common Patterns
 
-### Fixed-cutoff eventual bounds
+### Eventual bounds and cutoff discovery
 
 `eventual_bound` certifies natural-number tails of the form
 `q / (n : ℝ) ^ k ≤ c`, where `q` is nonnegative, `k` and the cutoff are
@@ -941,13 +941,27 @@ example : ∀ n : Nat, 100 ≤ n → (1 : ℝ) / n ≤ 1 / 100 := by
 
 example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 3 / 100 := by
   eventual_bound using 10
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  eventual_bound
+
+-- The semantic router recognizes the same existential theorem shape.
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  leancert
 ```
 
 `eventual_bound?` proves the same goal and reports the selected tail rule and
-cutoff source. Existential goals require `using N`; automated cutoff discovery
-is not part of this fixed-cutoff boundary. General logarithmic/exponential
-tails and AD-based tail rules are also outside this initial certificate
-language.
+cutoff source. For an existential goal without `using N`, LeanCert performs an
+untrusted exponential search followed by bounded binary refinement. The
+resulting cutoff is replayed through the exact checker before the Golden
+Theorem constructs the proof. Use `(maxIterations := n)` to bound candidate
+checks; if refinement exhausts the budget after finding a valid upper bracket,
+LeanCert safely returns the verified upper cutoff rather than claiming
+minimality.
+
+The current certificate language remains deliberately narrow: nonnegative
+rational multiples of reciprocal powers over `Nat`. General
+logarithmic/exponential tails and AD-based tail rules are follow-up work.
 
 ### Proving a function is bounded
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,18 +34,21 @@ examples for each newly supported operation.
 
 ## Quantitative asymptotics
 
-**Current state:** `eventual_bound` checks explicit positive cutoffs for
-natural-number upper bounds on nonnegative rational multiples of reciprocal
-powers. The endpoint is an executable exact-rational check, while the Golden
-Theorem proves the infinite tail by symbolic monotonicity. Existential goals
-accept an explicit witness through `eventual_bound using N`.
+**Current state:** `eventual_bound` checks explicit positive cutoffs and can
+discover witnesses for existential natural-number upper bounds on nonnegative
+rational multiples of reciprocal powers. Discovery uses bounded exponential
+search and binary refinement, then replays the candidate through the same
+exact-rational checker. The Golden Theorem proves the infinite tail by
+symbolic monotonicity. The `leancert` router recognizes this theorem family,
+and reports preserve the cutoff and search provenance.
 
-**Possible next milestone:** add untrusted cutoff discovery over the same
-checker boundary, then grow the typed tail-rule language from demonstrated
-downstream needs.
+**Possible next milestone:** grow the typed tail-rule language from
+demonstrated downstream needs, starting with compositional domination rules or
+carefully scoped logarithmic and exponential tails.
 
-**Evidence:** fixed-cutoff and existential regression theorems, rejected
-cutoff tests, and `eventual_bound?` provenance.
+**Evidence:** fixed-cutoff and discovered-cutoff regression theorems, exact and
+budget-limited search tests, rejected cutoff tests, semantic-router coverage,
+and `eventual_bound?`/`leancert?` provenance.
 
 ## Stronger quantified ML theorems
 


### PR DESCRIPTION
## Summary

This PR adds automatic cutoff discovery for LeanCert’s eventual-bound certificate family.

Existential reciprocal-power tail goals can now be proved without manually supplying a witness:

~~~lean
example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
  eventual_bound

example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
  leancert
~~~

Cutoff discovery remains untrusted. It only proposes a candidate, which is replayed through the exact checker introduced in the previous PR before the Golden Theorem constructs the final proof.

## What changed

- add bounded exponential search for an initial valid cutoff
- refine the resulting bracket using binary search
- preserve a verified upper cutoff when the refinement budget is exhausted
- route eventual-bound goals through the main `leancert` semantic front end
- add `(maxIterations := n)` control to `eventual_bound`
- report the discovered cutoff, search statistics, and whether minimality refinement completed
- suggest a stable explicit proof using `eventual_bound using N`
- add typed, transactional failures for exhausted searches, rejected cutoffs, and unsupported tails
- update the tactic reference, public API documentation, and roadmap

## Trust boundary

The search procedure does not participate in soundness:

~~~text
untrusted cutoff search
→ candidate N
→ checkReciprocalPowerUpper
→ verify_reciprocal_power_upper
→ ordinary Lean theorem
~~~

Even when binary refinement stops early, LeanCert only returns a cutoff that has passed the exact checker. It does not claim that cutoff is minimal.

## Current scope

The certificate language remains intentionally narrow:

- domain: `Nat`
- nonnegative rational coefficients
- positive natural exponents
- upper bounds on reciprocal-power tails of the form `q / n^k ≤ c`

Logarithmic, exponential, and more general compositional tail rules remain follow-up work.
