### PR TITLE
Fix/semantic normalization polish

### DIFF
--- a/LeanCert/Tactic/Extension/Execute.lean
+++ b/LeanCert/Tactic/Extension/Execute.lean
@@ -202,7 +202,9 @@ private def proveByNormNum (proposition : Lean.Expr) : TacticM Lean.Expr := do
   let proof ← mkFreshExprMVar proposition MetavarKind.syntheticOpaque
   setGoals [proof.mvarId!]
   try
-    evalTactic (← `(tactic| norm_num [LeanCert.Core.IntervalRat.mem_def]))
+    evalTactic (← `(tactic|
+      norm_num [LeanCert.Core.IntervalRat.mem_def, Rat.divInt_eq_div] <;>
+        norm_num [Rat.divInt_eq_div]))
     unless (← getGoals).isEmpty do
       throwError "exact rational comparison left proof obligations"
     let proof ← instantiateMVars proof

--- a/LeanCert/Tactic/LeanCert/Semantic/Prepare.lean
+++ b/LeanCert/Tactic/LeanCert/Semantic/Prepare.lean
@@ -53,9 +53,11 @@ private def proveByNormNum (proposition : Lean.Expr) : TacticM Lean.Expr := do
   setGoals [proof.mvarId!]
   try
     evalTactic (← `(tactic|
-      norm_num [Set.mem_Icc, LeanCert.Core.IntervalRat.mem_def]))
+      norm_num [Set.mem_Icc, LeanCert.Core.IntervalRat.mem_def, Rat.divInt_eq_div] <;>
+        norm_num [Rat.divInt_eq_div]))
     unless (← getGoals).isEmpty do
-      throwError "normalization left proof obligations"
+      let remaining ← getGoals >>= (·.mapM fun goal => goal.getType)
+      throwError "normalization left proof obligations:\n{remaining}"
     let proof ← instantiateMVars proof
     if proof.hasMVar then
       throwError "normalization proof contains metavariables"

--- a/LeanCert/Test/DownstreamPatterns/Extension.lean
+++ b/LeanCert/Test/DownstreamPatterns/Extension.lean
@@ -105,6 +105,37 @@ theorem narrowIdentity_mem
   rcases hcheck with ⟨_, rfl⟩
   simpa [narrowIdentity] using hx
 
+/- A sound but deliberately widened enclosure. It exercises correlation loss,
+subdivision, and domain propagation through a registered atom. -/
+noncomputable def fatPositive (x : ℝ) : ℝ := if x ≤ 0 then 0 else x
+
+def fatPositiveOutput (input : IntervalRat) : IntervalRat where
+  lo := input.lo - 1 / 10
+  hi := input.hi + 1 / 10
+  le := by linarith [input.le]
+
+def fatPositiveCandidate (request : UnaryEnclosureRequest) :
+    Except EnclosureCandidateFailure IntervalRat :=
+  if 0 < request.input.lo then .ok (fatPositiveOutput request.input)
+  else .error <| .domainObstruction "input interval is not strictly positive"
+
+def checkFatPositive (request : UnaryEnclosureRequest) (output : IntervalRat) : Bool :=
+  decide (0 < request.input.lo) && decide (output = fatPositiveOutput request.input)
+
+@[leancert_enclosure fatPositiveCandidate]
+theorem fatPositive_mem
+    {request : UnaryEnclosureRequest} {x : ℝ} {output : IntervalRat}
+    (hx : x ∈ request.input)
+    (hcheck : checkFatPositive request output = true) :
+    fatPositive x ∈ output := by
+  simp only [checkFatPositive, Bool.and_eq_true, decide_eq_true_eq] at hcheck
+  rcases hcheck with ⟨hpositive, rfl⟩
+  have hxpositive : 0 < x := lt_of_lt_of_le (by exact_mod_cast hpositive) hx.1
+  simp only [fatPositive, if_neg (not_le.mpr hxpositive), IntervalRat.mem_def,
+    fatPositiveOutput]
+  simp only [IntervalRat.mem_def] at hx
+  constructor <;> push_cast <;> linarith [hx.1, hx.2]
+
 run_meta do
   let env ← getEnv
   let rules := getUnaryEnclosureRules env ``shifted

--- a/LeanCert/Test/EventualBound.lean
+++ b/LeanCert/Test/EventualBound.lean
@@ -21,6 +21,32 @@ import LeanCert.Tactic
   | .error _ => true
   | .ok _ => false
 
+private def discoveredCutoffIsSound (q bound : ℚ) (k maxChecks : Nat) : Bool :=
+  match LeanCert.Tactic.discoverReciprocalPowerCutoff q bound k maxChecks with
+  | .error _ => false
+  | .ok result =>
+      LeanCert.Validity.checkReciprocalPowerUpper q bound k result.cutoff
+
+private def completedDiscoveryIsMinimal (q bound : ℚ) (k maxChecks : Nat) : Bool :=
+  match LeanCert.Tactic.discoverReciprocalPowerCutoff q bound k maxChecks with
+  | .error _ => false
+  | .ok result =>
+      !result.refinementComplete || result.cutoff = 1 ||
+        !LeanCert.Validity.checkReciprocalPowerUpper q bound k (result.cutoff - 1)
+
+/- Exact-square, just-above-square, deep-search, and bounded-refinement cases
+exercise the untrusted search independently of tactic proof construction. -/
+#guard (LeanCert.Tactic.discoverReciprocalPowerCutoff 1 (1 / 100) 2 64).toOption.map
+  (·.cutoff) == some 10
+#guard (LeanCert.Tactic.discoverReciprocalPowerCutoff 1 (1 / 101) 2 64).toOption.map
+  (·.cutoff) == some 11
+#guard (LeanCert.Tactic.discoverReciprocalPowerCutoff 1000 (1 / 1000000) 2 64).toOption.map
+  (·.cutoff) == some 31623
+#guard discoveredCutoffIsSound 3 (1 / 1000) 2 7
+#guard completedDiscoveryIsMinimal 1 (1 / 100) 2 64
+#guard completedDiscoveryIsMinimal 1 (1 / 101) 2 64
+#guard completedDiscoveryIsMinimal 1000 (1 / 1000000) 2 64
+
 example : ∀ n : Nat, 10 ≤ n → (1 : ℝ) / (n : ℝ) ^ 2 ≤ 1 / 100 := by
   eventual_bound
 
@@ -44,6 +70,9 @@ example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
 
 example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
   leancert (maxIterations := 7)
+
+example : ∃ N : Nat, ∀ n, n ≥ N → (2 : ℝ) / n ^ 3 ≤ 1 / 10000 := by
+  leancert
 
 example : ∀ n : Nat, 100 ≤ n → (1 : ℝ) / n ≤ 1 / 100 := by
   leancert

--- a/LeanCert/Test/ExtensionExecution.lean
+++ b/LeanCert/Test/ExtensionExecution.lean
@@ -76,6 +76,26 @@ set_option leancert.trust "kernel" in
 example : ∀ x ∈ Set.Icc (0 : ℝ) 2, shifted x - x ≤ 2 := by
   leancert (subdivisions := 1)
 
+/- Rational endpoints and bounds may materialize through `Rat.divInt`; their
+proof transport must normalize without leaking side goals. -/
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (1 / 20 : ℝ) 1, positiveBranch x ≤ 1 := by
+  leancert
+
+/- The widened registered atom loses correlation with `x`; subdivision makes
+the composed comparison precise enough. -/
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (1 / 20 : ℝ) 1, fatPositive x - x ≤ (1 / 2 : ℝ) := by
+  leancert (subdivisions := 4)
+
+/- Multiple registered atoms remain compositional under distinct core
+transcendental operations. -/
+set_option leancert.trust "kernel" in
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp (positiveBranch (x / 2 + 1 / 10)) +
+      Real.sin (positiveBranch (x + 1 / 10)) - x ≤ 4 := by
+  leancert
+
 /-- error: LeanCert recognized: univariate interval bound
 
 Attempts:
@@ -119,6 +139,18 @@ Narrow the domain or prove the required positivity/nonzero condition. Increasing
 #guard_msgs in
 example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
     Real.log (positiveBranch (x + 1) - 2) ≤ 0 := by
+  leancert
+
+/- The outer evaluator must honor the widened certified enclosure rather than
+the definition of the opaque registered atom. -/
+/-- error: LeanCert recognized: univariate interval bound
+
+Domain obstruction:
+  the checked interval evaluator rejected a partial operation
+
+Narrow the domain or prove the required positivity/nonzero condition. Increasing numerical precision does not repair an invalid domain. -/
+#guard_msgs in
+example : ∀ x ∈ Set.Icc (1 / 20 : ℝ) 1, Real.log (fatPositive x) ≤ 2 := by
   leancert
 
 end LeanCert.Test.ExtensionExecution

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@
 
 LeanCert turns numerical certificates into theorems about real-valued
 expressions. Its `leancert` tactic handles point inequalities, quantified
-bounds on boxes, root existence and uniqueness, global bounds, finite sums,
-and definite integrals. The library also exposes the checked interval,
-optimization, root-finding, and integration APIs underneath the tactic.
+bounds on boxes and natural-number tails, root existence and uniqueness,
+global bounds, finite sums, and definite integrals. Imported downstream
+functions can participate through checked enclosure rules without being added
+to LeanCert's internal expression language. The library also exposes the
+checked interval, optimization, root-finding, and integration APIs underneath
+the tactic.
 
-## Four proofs
+## Five proofs
 
 ```lean
 import LeanCert.Tactic
@@ -35,6 +38,10 @@ example : ∃! x, x ∈ Set.Icc (1 : ℝ) 2 ∧ x ^ 2 - 2 = 0 := by
 
 -- Polynomial integrals are normalized and checked exactly over ℚ.
 example : (∫ x in (0 : ℝ)..1, x ^ 2) = 1 / 3 := by
+  leancert
+
+-- LeanCert discovers and certifies a cutoff for this infinite tail.
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
   leancert
 ```
 
@@ -155,6 +162,8 @@ The main verified numerical path includes:
 - Root existence, exclusion, and Newton-style uniqueness certificates
 - Exact rational polynomial integration and certified partition integration
 - Checked downstream unary enclosure rules consumed compositionally by `leancert`
+- Fixed and automatically discovered reciprocal-power bounds over infinite
+  natural-number tails
 - Domain-specific Chebyshev, analytic-number-theory, q-product, table, and
   neural-network certificate infrastructure
 
@@ -184,6 +193,9 @@ does not imply that the theorem is false.
   Existing core operations may surround proof-carrying registered subterms;
   rejected or inconclusive candidates are retried on rational bisections.
   Unsupported custom operations are not yet covered.
+- Eventual-bound automation currently targets nonnegative rational multiples
+  of reciprocal powers over `Nat`; general logarithmic, exponential, and
+  AD-derived tail rules are not yet supported.
 
 Native verification is faster but additionally trusts Lean's compiler/runtime;
 kernel-only verification may be substantially more expensive. See the

--- a/docs/direct/eventual-bounds.md
+++ b/docs/direct/eventual-bounds.md
@@ -1,0 +1,113 @@
+# Eventual Bounds and Cutoff Discovery
+
+LeanCert can certify a supported inequality over an infinite natural-number
+tail and, for existential goals, discover a usable cutoff automatically.
+
+```lean
+import LeanCert.Tactic
+
+-- The cutoff is part of the theorem statement.
+example : ∀ n : Nat, 100 ≤ n → (1 : ℝ) / n ≤ 1 / 100 := by
+  eventual_bound
+
+-- Supply a stable cutoff explicitly.
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 3 / 100 := by
+  eventual_bound using 10
+
+-- Or let the semantic front door discover and certify one.
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  leancert
+```
+
+## Supported theorem family
+
+The current certificate language recognizes upper bounds of the form
+
+\[
+  \frac{q}{n^k} \le c
+\]
+
+over `Nat`, where `q` and `c` are rational constants, `q` is nonnegative, and
+`k` and the cutoff are positive natural numbers. Both `N ≤ n` and `n ≥ N`
+tail hypotheses are accepted.
+
+This scope is intentionally narrow. General logarithmic or exponential tails,
+real-valued tail domains, compositional domination rules, and AD/inversion tail
+proofs are not implemented by this tactic yet.
+
+## Why one cutoff proves the infinite tail
+
+The trusted validity boundary consists of:
+
+- `checkReciprocalPowerUpper`, an exact-rational Boolean checker; and
+- `verify_reciprocal_power_upper`, the Golden Theorem interpreting an accepted
+  check as a theorem for every `n` beyond the cutoff.
+
+The checker establishes the endpoint inequality. The Golden Theorem uses the
+symbolic monotonicity of nonnegative reciprocal powers to transport that bound
+across the entire infinite tail. No sampled floating-point values are part of
+the proof.
+
+## Automatic discovery is untrusted
+
+For an existential goal without `using N`, LeanCert searches for a candidate:
+
+1. exponential search finds a verified upper bracket;
+2. bounded binary refinement narrows the bracket; and
+3. the selected cutoff is replayed through the exact checker before proof
+   construction.
+
+The search algorithm is deliberately outside the trusted mathematical
+boundary. A bug in search can make automation fail or return a nonminimal
+cutoff, but it cannot prove a false tail statement.
+
+Use `maxIterations` to bound the number of candidate checks:
+
+```lean
+import LeanCert.Tactic
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  leancert (maxIterations := 64)
+```
+
+If the budget expires after a valid upper bracket has been found, LeanCert may
+return that independently verified upper cutoff while reporting that
+minimality refinement was incomplete. If no valid bracket was found, the
+attempt is inconclusive and leaves the original goal unchanged.
+
+## Inspecting and stabilizing discovery
+
+Use `leancert?` or `eventual_bound?` to see the cutoff, number of checked
+candidates, final bracket, refinement status, checker, and verifier:
+
+```lean
+import LeanCert.Tactic
+
+example : ∃ N : Nat, ∀ n ≥ N, (3 : ℝ) / n ^ 2 ≤ 1 / 1000 := by
+  leancert?
+```
+
+The report suggests an explicit proof such as:
+
+```text
+by
+  eventual_bound using 55
+```
+
+That explicit form avoids rerunning discovery and is useful when maintaining a
+stable downstream proof.
+
+## Failure meanings
+
+- **Rejected explicit cutoff:** the endpoint inequality is false at the
+  supplied `N`; choose a larger cutoff or revise the claim.
+- **Search exhausted:** increase `maxIterations` or supply a cutoff with
+  `using N`.
+- **Unsupported tail:** rewrite the goal into the supported reciprocal-power
+  family or prove a more general tail theorem separately.
+- **Invalid parameters:** negative coefficients, zero exponents, and
+  impossible nonnegative-tail bounds are rejected before proof construction.
+
+For finite-interval inequalities instead, use [`leancert`](leancert.md) or
+[`certify_bound`](bounds.md). For main-term/error-term asymptotic certificates,
+see [Asymptotic Envelopes](../proof-templates/asymptotic-envelopes.md).

--- a/docs/direct/leancert.md
+++ b/docs/direct/leancert.md
@@ -68,6 +68,8 @@ The router currently recognizes:
 - exact rational-polynomial integral equalities;
 - supported definite-integral inequalities through one retained partition
   search followed by a fixed-candidate certificate;
+- fixed-cutoff and existential eventual upper bounds for supported
+  reciprocal-power tails over `Nat`;
 - closed LeanCert Boolean checker propositions;
 - conjunctions whose children are themselves recognized.
 
@@ -188,6 +190,7 @@ algorithm:
 - `certify_bound` and `interval_bound_subdiv` for interval bounds;
 - `multivariate_bound` and `opt_bound` for box bounds and optimization;
 - `interval_roots`, `interval_unique_root`, and `root_bound` for roots;
+- `eventual_bound` for fixed or discovered reciprocal-power tail bounds;
 - `interval_minimize`, `interval_maximize`, `interval_argmin`, and
   `interval_argmax` for extrema;
 - `finsum_bound` for finite sums;

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ LeanCert is organized around proof intent:
 | A global minimum or maximum problem | [Direct Automation → Optimization and Discovery](direct/optimization-discovery.md) |
 | A certified partial derivative or gradient enclosure | [Direct Automation → Checked Automatic Differentiation](direct/checked-ad.md) |
 | A definite integral bound | [Direct Automation → Integration](direct/integration.md) |
+| A bound that should hold for every sufficiently large natural number | [Direct Automation → Eventual Bounds](direct/eventual-bounds.md) |
+| A project-specific unary function with its own checked enclosure | [Reference → Downstream Enclosure Extensions](reference/extensions.md) |
 | Generated finite rows to verify | [Proof Templates → Table Certificates](proof-templates/table-certificates.md) |
 | A summatory function with a main term and error term | [Proof Templates → Asymptotic Envelopes](proof-templates/asymptotic-envelopes.md) |
 | A real-variable approximation with an error radius | [Proof Templates → Pointwise Envelopes](proof-templates/pointwise-envelopes.md) |

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -792,7 +792,8 @@ These reduce the goal to a rational inequality that must be proved manually.
 Simplifies vector indexing expressions with explicit `Fin.mk` constructors using a custom `dsimproc` that extracts the natural number from `Fin.mk n proof` and walks the `vecCons` chain directly.
 
 ```lean
-import Mathlib
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
 import LeanCert.Tactic.VecSimp
 
 -- Basic indexing: reduces ![a, b, c] ⟨i, proof⟩ to the i-th element
@@ -859,7 +860,8 @@ rewrite or certificate attempt restores the original goal and local state.
 Expands finite sums over Finsets into explicit additions.
 
 ```lean
-import Mathlib
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
 import LeanCert.Tactic.FinSumExpand
 
 -- Interval finsets (Icc = closed-closed)

--- a/docs/tactics/choosing-tactics.md
+++ b/docs/tactics/choosing-tactics.md
@@ -57,6 +57,10 @@ What do you want to prove?
 ├─► Integral bound
 │   └─► leancert
 │
+├─► "∀ n ≥ N, q / n^k ≤ c" or "∃ N, ∀ n ≥ N, q / n^k ≤ c"
+│   └─► leancert
+│       └─► Need an explicit cutoff? ──► eventual_bound using N
+│
 ├─► Simplify vector/matrix indexing (![a,b,c] ⟨1,h⟩ → b)
 │   └─► vec_simp
 │
@@ -84,6 +88,7 @@ What do you want to prove?
 | Simplify vector indexing | `vec_simp` | `![a,b,c] ⟨1, h⟩ = b` |
 | Expand finite sums | `finsum_expand` | `∑ k ∈ Icc 1 3, f k = f 1 + f 2 + f 3` |
 | Integral equality or inequality | `leancert` | `(∫ x in a..b, f x) ≤ c` |
+| Eventual reciprocal-power bound | `leancert` | `∃ N, ∀ n ≥ N, 3 / n^2 ≤ 1/1000` |
 
 ## Trust Levels
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
     - Roots and No-Root Proofs: direct/roots.md
     - Optimization and Discovery: direct/optimization-discovery.md
     - Integration: direct/integration.md
+    - Eventual Bounds and Cutoff Discovery: direct/eventual-bounds.md
     - Checked Automatic Differentiation: direct/checked-ad.md
     - Troubleshooting: direct/troubleshooting.md
     - Advanced Guides:


### PR DESCRIPTION
This is a post-H2 polish pass focused on hardening rational proof transport, expanding stress coverage, and making the recently landed extensibility and eventual-bound workflows easier to discover.

The stress matrix exposed two related normalization gaps: rational endpoints and comparison bounds materialized through `Rat.divInt` could leave proof obligations during semantic preparation or extension-result transport. This PR closes both gaps and adds permanent regressions around the affected paths.

## Summary

- normalize `Rat.divInt` casts during semantic goal preparation
- normalize rational comparison bounds during registered-extension proof construction
- add H2 discovery regressions covering:
  - exact and off-by-one cutoffs
  - a deep cutoff at `N = 31623`
  - minimality after completed refinement
  - sound fallback when the refinement budget is exhausted
  - alternate `n ≥ N` tail syntax
- add extension regressions covering:
  - rational interval endpoints
  - correlation loss repaired by subdivision
  - domain propagation through proof-carrying atoms
  - multiple registered atoms beneath transcendental operations
- add a dedicated guide for fixed and automatically discovered eventual bounds
- surface eventual bounds and downstream enclosure extensions in the README, documentation landing page, navigation, and tactic chooser
- repair two stale documentation snippets that depended on the unbuilt `Mathlib` umbrella import

The documentation also makes the current boundary explicit: H1/H2 presently supports nonnegative rational multiples of reciprocal powers over `Nat`, using an exact checker and symbolic monotonicity. General logarithmic, exponential, and AD-derived tail rules remain future work.
