### PR TITLE
feat: automate Krawczyk candidate generation

### DIFF
--- a/LeanCert/Benchmark/Suites/Krawczyk.lean
+++ b/LeanCert/Benchmark/Suites/Krawczyk.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
 import LeanCert.Benchmark.Harness
+import LeanCert.Engine.RootFinding.KrawczykCandidate
 import LeanCert.Examples.Krawczyk
 
 /-!
@@ -67,6 +68,24 @@ private def expCheckedRun : IO Outcome := do
     return { status := "success", backendUsed := some "rational" }
   return { status := "certificate_rejected", backendUsed := some "rational" }
 
+private def automaticCandidateRun : IO Outcome := do
+  let report := generateAutomaticKrawczyk system box
+  if report.succeeded then
+    return { status := "success", backendUsed := some "rational" }
+  return { status := "candidate_search_failed", backendUsed := some "rational" }
+
+private def shiftedExpSystem : Fin 1 → LeanCert.Core.Expr :=
+  ![.add (.exp (.var 0)) (.const (-1 / 8))]
+
+private def shiftedExpBox : Fin 1 → LeanCert.Core.IntervalRat :=
+  ![⟨-57 / 20, -33 / 20, by norm_num⟩]
+
+private def refinementCandidateRun : IO Outcome := do
+  let report := generateAutomaticKrawczyk shiftedExpSystem shiftedExpBox
+  if report.succeeded && report.refinements == 1 then
+    return { status := "success", backendUsed := some "rational" }
+  return { status := "candidate_refinement_failed", backendUsed := some "rational" }
+
 private def baseParameters : List (String × String) := [
   ("system", "coupled_quadratic_2x2"),
   ("box", "[9/10,11/10]^2"),
@@ -125,6 +144,34 @@ def cases : List Case := [
     input := expInput
     innerIterations := 25
     run := expCheckedRun
+  },
+  {
+    name := "krawczyk.coupled_quadratic_2x2.automatic_candidate"
+    family := "nonlinear_system_roots"
+    tier := "end_to_end"
+    layer := .internal
+    backendRequested := "rational"
+    suites := ["smoke", "krawczyk", "all"]
+    parameters := baseParameters ++ [("candidate", "automatic_midpoint_jacobian")]
+    input
+    innerIterations := 25
+    run := automaticCandidateRun
+  },
+  {
+    name := "krawczyk.shifted_exp_1x1.refined_candidate"
+    family := "nonlinear_system_roots"
+    tier := "end_to_end"
+    layer := .internal
+    backendRequested := "rational"
+    suites := ["krawczyk", "all"]
+    parameters := [
+      ("system", "exp_x_minus_one_eighth"),
+      ("box", "[-57/20,-33/20]"),
+      ("candidate", "one_interval_newton_refinement")
+    ]
+    input := expInput
+    innerIterations := 10
+    run := refinementCandidateRun
   }
 ]
 

--- a/LeanCert/Engine/RootFinding/KrawczykCandidate.lean
+++ b/LeanCert/Engine/RootFinding/KrawczykCandidate.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Engine.RootFinding.Krawczyk
+
+/-!
+# Untrusted automatic Krawczyk candidates
+
+This module constructs rational centers and preconditioners for the checked
+Krawczyk engine.  None of the search code is trusted: a successful candidate
+is useful only after `krawczykCheck` accepts it and the Krawczyk golden theorem
+turns that Boolean result into a proof.
+
+The initial center is the rational midpoint of the target box.  At every
+attempt we enclose the Jacobian on the singleton center, take entrywise
+midpoints, invert that rational matrix by pivoted Gauss--Jordan elimination,
+and test the resulting certificate on the original box.  Rejected candidates
+may be refined by an interval-Newton midpoint step; the target box itself is
+never subdivided.
+-/
+
+namespace LeanCert.Engine
+
+open LeanCert.Core
+
+/-- User-independent limits for automatic candidate construction. -/
+structure AutomaticKrawczykConfig where
+  maxIterations : Nat := 8
+  maxDimension : Nat := 4
+  /-- Candidate values are rounded to this dyadic precision after every
+  untrusted Newton step to prevent rational denominator explosion. -/
+  precisionBits : Nat := 20
+  deriving Repr, Inhabited
+
+/-- Stable failure classes returned by the untrusted generator. -/
+inductive AutomaticKrawczykFailure where
+  | invalidDimension
+  | dimensionLimit (actual limit : Nat)
+  | unsupportedAD
+  | singularPointJacobian (attempt : Nat)
+  | centerEscaped (attempt : Nat)
+  | stagnated (attempt : Nat)
+  | exhausted (attempts : Nat)
+  deriving Repr, Inhabited, DecidableEq
+
+/-- Dimension-erased output suitable for tactic evaluation and reporting. -/
+structure AutomaticKrawczykReport where
+  dimension : Nat
+  attempts : Nat := 0
+  refinements : Nat := 0
+  center : List ℚ := []
+  preconditioner : List (List ℚ) := []
+  contractionBound : ℚ := 0
+  failure : Option AutomaticKrawczykFailure := none
+  deriving Repr, Inhabited
+
+def AutomaticKrawczykReport.succeeded (report : AutomaticKrawczykReport) : Bool :=
+  report.failure.isNone
+
+private def arrayGetD [Inhabited α] (values : Array α) (index : Nat) : α :=
+  (values[index]?).getD default
+
+private def matrixArrayGet (rows : Array (Array ℚ)) (i j : Nat) : ℚ :=
+  ((rows[i]?).bind fun row => row[j]?).getD 0
+
+private def matrixArraySet (rows : Array (Array ℚ)) (i j : Nat) (value : ℚ) :
+    Array (Array ℚ) :=
+  match rows[i]? with
+  | none => rows
+  | some row => rows.set! i (row.set! j value)
+
+private def swapRows (rows : Array (Array ℚ)) (i j : Nat) : Array (Array ℚ) :=
+  if i == j then rows
+  else
+    let left := arrayGetD rows i
+    let right := arrayGetD rows j
+    (rows.set! i right).set! j left
+
+private def findPivot (rows : Array (Array ℚ)) (column start size : Nat) : Option Nat :=
+  (List.range (size - start)).findSome? fun offset =>
+    let row := start + offset
+    if matrixArrayGet rows row column != 0 then some row else none
+
+private def eliminateColumn (rows : Array (Array ℚ)) (column size : Nat) :
+    Array (Array ℚ) :=
+  (List.range size).foldl (fun current row =>
+    if row == column then current
+    else
+      let factor := matrixArrayGet current row column
+      if factor == 0 then current
+      else
+        (List.range (2 * size)).foldl (fun updated entry =>
+          matrixArraySet updated row entry
+            (matrixArrayGet current row entry -
+              factor * matrixArrayGet current column entry)) current) rows
+
+private partial def gaussJordanLoop (rows : Array (Array ℚ)) (column size : Nat) :
+    Option (Array (Array ℚ)) :=
+  if column < size then
+    match findPivot rows column column size with
+    | none => none
+    | some pivotRow =>
+        let swapped := swapRows rows column pivotRow
+        let pivot := matrixArrayGet swapped column column
+        if pivot == 0 then none
+        else
+          let normalized := (arrayGetD swapped column).map fun value => value / pivot
+          let rows := swapped.set! column normalized
+          gaussJordanLoop (eliminateColumn rows column size) (column + 1) size
+  else
+    some rows
+
+private def augmentedMatrix {n : Nat} (matrix : Matrix (Fin n) (Fin n) ℚ) :
+    Array (Array ℚ) :=
+  Array.ofFn fun i : Fin n =>
+    Array.ofFn fun j : Fin (2 * n) =>
+      if h : j.val < n then
+        matrix i ⟨j.val, h⟩
+      else if j.val - n == i.val then 1 else 0
+
+private def arrayToMatrix {n : Nat} (rows : Array (Array ℚ)) :
+    Matrix (Fin n) (Fin n) ℚ :=
+  fun i j => matrixArrayGet rows i.val (n + j.val)
+
+/-- Exact rational inversion with row pivoting.  This is candidate-generation
+machinery only; `krawczykCheck` independently requires the returned
+preconditioner to be nonsingular. -/
+def invertRatMatrix? {n : Nat} (matrix : Matrix (Fin n) (Fin n) ℚ) :
+    Option (Matrix (Fin n) (Fin n) ℚ) := do
+  if n == 0 then none
+  else
+    let reduced ← gaussJordanLoop (augmentedMatrix matrix) 0 n
+    pure (arrayToMatrix reduced)
+
+def KrawczykCert.ofLists (n : Nat) (center : List ℚ)
+    (preconditioner : List (List ℚ)) : KrawczykCert n where
+  center i := (center[i.val]?).getD 0
+  preconditioner i j := ((preconditioner[i.val]?).bind fun row => row[j.val]?).getD 0
+
+private def roundRat (precisionBits : Nat) (value : ℚ) : ℚ :=
+  let bits := min precisionBits 60
+  let scale : Nat := 2 ^ bits
+  let magnitude := value.num.natAbs
+  let rounded := (2 * magnitude * scale + value.den) / (2 * value.den)
+  let signed : Int := if value.num < 0 then -(rounded : Int) else (rounded : Int)
+  (signed : ℚ) / scale
+
+private def roundMatrix {n : Nat} (precisionBits : Nat)
+    (matrix : Matrix (Fin n) (Fin n) ℚ) : Matrix (Fin n) (Fin n) ℚ :=
+  fun i j => roundRat precisionBits (matrix i j)
+
+private def pointJacobianMidpoint {n : Nat} (F : Fin n → Expr)
+    (center : Fin n → ℚ) (cfg : EvalConfig) (precisionBits : Nat) :
+    Matrix (Fin n) (Fin n) ℚ :=
+  let pointBox : Fin n → IntervalRat := fun i => IntervalRat.singleton (center i)
+  fun i j => roundRat precisionBits (intervalJacobian F pointBox cfg i j).midpoint
+
+private def rationalMatVec {n : Nat} (matrix : Matrix (Fin n) (Fin n) ℚ)
+    (vector : Fin n → ℚ) : Fin n → ℚ :=
+  fun i => ∑ j, matrix i j * vector j
+
+private def refinedCenter {n : Nat} (F : Fin n → Expr) (center : Fin n → ℚ)
+    (preconditioner : Matrix (Fin n) (Fin n) ℚ) (cfg : EvalConfig)
+    (precisionBits : Nat) : Fin n → ℚ :=
+  let residual : Fin n → ℚ := fun i => (pointEvalIntervals F center cfg i).midpoint
+  let correction := rationalMatVec preconditioner residual
+  fun i => roundRat precisionBits (center i - correction i)
+
+private def matrixRows {n : Nat} (matrix : Matrix (Fin n) (Fin n) ℚ) :
+    List (List ℚ) :=
+  List.ofFn fun i => List.ofFn fun j => matrix i j
+
+private def contractionFor {n : Nat} (F : Fin n → Expr)
+    (X : Fin n → IntervalRat) (preconditioner : Matrix (Fin n) (Fin n) ℚ)
+    (cfg : EvalConfig) : ℚ :=
+  intervalMatrixBound (preconditionedJacobian preconditioner (intervalJacobian F X cfg))
+
+private def reportFailure {n : Nat} (failure : AutomaticKrawczykFailure)
+    (attempts refinements : Nat) (center : Fin n → ℚ)
+    (preconditioner : Option (Matrix (Fin n) (Fin n) ℚ) := none)
+    (contraction : ℚ := 0) : AutomaticKrawczykReport := {
+  dimension := n
+  attempts
+  refinements
+  center := List.ofFn center
+  preconditioner := preconditioner.map matrixRows |>.getD []
+  contractionBound := contraction
+  failure := some failure
+}
+
+private partial def automaticKrawczykLoop {n : Nat} (F : Fin n → Expr)
+    (X : Fin n → IntervalRat) (cfg : EvalConfig) (maximum precisionBits attempt : Nat)
+    (center : Fin n → ℚ) : AutomaticKrawczykReport :=
+  let attemptNumber := attempt + 1
+  let jacobian := pointJacobianMidpoint F center cfg precisionBits
+  match invertRatMatrix? jacobian with
+  | none => reportFailure (.singularPointJacobian attemptNumber)
+      attemptNumber attempt center
+  | some rawPreconditioner =>
+      let preconditioner := roundMatrix precisionBits rawPreconditioner
+      if decide (preconditioner.det = 0) then
+        reportFailure (.singularPointJacobian attemptNumber)
+          attemptNumber attempt center (some preconditioner)
+      else
+       let cert : KrawczykCert n := { center, preconditioner }
+       let contraction := contractionFor F X preconditioner cfg
+       if krawczykCheck F X cert cfg then
+        {
+          dimension := n
+          attempts := attemptNumber
+          refinements := attempt
+          center := List.ofFn center
+          preconditioner := matrixRows preconditioner
+          contractionBound := contraction
+        }
+       else if attemptNumber >= maximum then
+        reportFailure (.exhausted attemptNumber) attemptNumber attempt center
+          (some preconditioner) contraction
+       else
+        let next := refinedCenter F center preconditioner cfg precisionBits
+        if !decide (centerInside X next) then
+          reportFailure (.centerEscaped attemptNumber) attemptNumber attempt center
+            (some preconditioner) contraction
+        else if decide (next = center) then
+          reportFailure (.stagnated attemptNumber) attemptNumber attempt center
+            (some preconditioner) contraction
+        else
+          automaticKrawczykLoop F X cfg maximum precisionBits attemptNumber next
+
+/-- Generate a dimension-erased automatic candidate report.  On success its
+center and preconditioner can be reconstructed with `KrawczykCert.ofLists` and
+must then be submitted to `krawczykCheck`. -/
+def generateAutomaticKrawczyk {n : Nat} (F : Fin n → Expr)
+    (X : Fin n → IntervalRat) (cfg : EvalConfig := {})
+    (search : AutomaticKrawczykConfig := {}) : AutomaticKrawczykReport :=
+  if n == 0 then
+    { dimension := n, failure := some .invalidDimension }
+  else if n > search.maxDimension then
+    { dimension := n, failure := some (.dimensionLimit n search.maxDimension) }
+  else if search.maxIterations == 0 then
+    { dimension := n, failure := some (.exhausted 0) }
+  else if !(decide (∀ i, (F i).checkADSupported = true)) then
+    { dimension := n, failure := some .unsupportedAD }
+  else
+    let center : Fin n → ℚ := fun i => (X i).midpoint
+    automaticKrawczykLoop F X cfg search.maxIterations search.precisionBits 0 center
+
+end LeanCert.Engine

--- a/LeanCert/Tactic/Krawczyk.lean
+++ b/LeanCert/Tactic/Krawczyk.lean
@@ -5,15 +5,17 @@ Authors: LeanCert Contributors
 -/
 import LeanCert.Tactic.LeanCert.Semantic.Parse
 import LeanCert.Tactic.Verification
+import LeanCert.Engine.RootFinding.KrawczykCandidate
 import LeanCert.Validity.Krawczyk
 
 /-!
-# Manual Krawczyk certificate tactic
+# Manual and automatic Krawczyk certificate tactics
 
-`system_unique_root using cert` is the I1 front end for the existing checked
-Krawczyk engine. Candidate construction is deliberately external to this
-module; the supplied certificate is accepted only through `krawczykCheck` and
-`verify_unique_system_root`.
+`system_unique_root using cert` is the I1 manual front end for the checked
+Krawczyk engine. `system_unique_root` is the I2 automatic front end: it runs an
+untrusted midpoint-Jacobian/interval-Newton search and submits the selected
+candidate to the identical `krawczykCheck` and `verify_unique_system_root`
+boundary.
 -/
 
 open Lean Meta Elab Tactic
@@ -77,6 +79,7 @@ def inspectKrawczyk {n : Nat} (F : Fin n → LeanCert.Core.Expr)
 inductive SystemUniqueRootFailure where
   | unsupportedGoal (detail : String)
   | dimensionMismatch (expected actual : String)
+  | generationFailed (report : AutomaticKrawczykReport)
   | rejected (inspection : KrawczykInspection)
   | verificationFailure (detail : String)
   | transportFailure (detail : String)
@@ -86,6 +89,7 @@ inductive SystemUniqueRootFailure where
 /-- Runtime facts retained by a successful manual Krawczyk proof. -/
 structure SystemUniqueRootOutcome where
   inspection : KrawczykInspection
+  search : Option AutomaticKrawczykReport := none
   checker : Name := ``LeanCert.Engine.krawczykCheck
   verifier : Name := ``LeanCert.Validity.verify_unique_system_root
   verification : VerificationEvent
@@ -128,6 +132,55 @@ private unsafe def evaluateInspection (spec : SystemRootSpec)
   trace[LeanCert.solver] "Krawczyk inspection expression: {← ppExpr expression}"
   evalExpr KrawczykInspection (mkConst ``KrawczykInspection) expression
 
+private def parseSystemRootTarget (target : Lean.Expr) :
+    TacticM (Except SystemUniqueRootFailure SystemRootSpec) := do
+  match ← withMainContext do Semantic.parseGoal target with
+  | .ok (.systemRoot spec) => return .ok spec
+  | .ok _ => return .error (.unsupportedGoal
+      "expected `∃! x : Fin n → ℝ, FinBoxMem x X ∧ SystemZero F x`")
+  | .error failure => return .error (.unsupportedGoal failure.detail)
+
+private unsafe def verifySystemUniqueRootCandidate
+    (saved : Lean.Elab.Tactic.SavedState) (goal : MVarId) (target : Lean.Expr)
+    (spec : SystemRootSpec) (certificate cfg : Lean.Expr)
+    (search : Option AutomaticKrawczykReport := none) :
+    TacticM (Except SystemUniqueRootFailure SystemUniqueRootOutcome) := do
+  let inspection ← evaluateInspection spec certificate cfg
+  let checker ← mkAppM ``LeanCert.Engine.krawczykCheck
+    #[spec.system, spec.box, certificate, cfg]
+  let certificateGoalType ← mkAppM ``Eq #[checker, mkConst ``Bool.true]
+  let certificateProof ← mkFreshExprMVar certificateGoalType MetavarKind.syntheticOpaque
+  let verificationConfig ← VerificationConfig.current
+  match ← closeCertificateGoalTyped verificationConfig certificateProof.mvarId!
+      (tacticName := "system_unique_root") with
+  | .rejected =>
+      saved.restore
+      return .error (.rejected inspection)
+  | .failed failure =>
+      saved.restore
+      return .error (.verificationFailure
+        (failure.message "system_unique_root"))
+  | .accepted event =>
+      let golden ← mkAppM ``LeanCert.Validity.verify_unique_system_root
+        #[spec.system, spec.box, certificate, cfg, certificateProof]
+      let proof ←
+        if spec.reversedConjunction then
+          mkAppM ``swapSystemRootConjunction #[spec.system, spec.box, golden]
+        else
+          pure golden
+      let proof ← instantiateMVars proof
+      if proof.hasMVar then
+        saved.restore
+        return .error (.transportFailure "the final proof contains unresolved metavariables")
+      let proofType ← inferType proof
+      unless ← isDefEq proofType target do
+        let detail := s!"constructed proof of {← ppExpr proofType}, expected {← ppExpr target}"
+        saved.restore
+        return .error (.transportFailure detail)
+      goal.assign proof
+      pruneSolvedGoals
+      return .ok { inspection, search, verification := event }
+
 /-- Reporting-aware manual-certificate core. Failure restores the caller's
 complete tactic state; success assigns only a proof of the original goal. -/
 unsafe def systemUniqueRootCoreTyped (certificateSyntax : TSyntax `term)
@@ -141,18 +194,12 @@ unsafe def systemUniqueRootCoreTyped (certificateSyntax : TSyntax `term)
     -- definitional-equality check still validates the user's original goal.
     let target ← withMainContext do
       zetaReduce (← instantiateMVars (← goal.getType))
-    let semantic ← withMainContext do
-      Semantic.parseGoal target
     let spec ←
-      match semantic with
-      | .ok (.systemRoot spec) => pure spec
-      | .ok _ =>
-          saved.restore
-          return .error (.unsupportedGoal
-            "expected `∃! x : Fin n → ℝ, FinBoxMem x X ∧ SystemZero F x`")
+      match ← parseSystemRootTarget target with
+      | .ok spec => pure spec
       | .error failure =>
           saved.restore
-          return .error (.unsupportedGoal failure.detail)
+          return .error failure
     let certificateResult ← withMainContext do
       elaborateCertificate certificateSyntax spec.dimension
     let certificate ←
@@ -167,41 +214,41 @@ unsafe def systemUniqueRootCoreTyped (certificateSyntax : TSyntax `term)
     let certificate ← withMainContext do
       zetaReduce (← instantiateMVars certificate)
     let cfg ← mkAppM ``LeanCert.Engine.EvalConfig.mk #[toExpr taylorDepth]
-    let inspection ← evaluateInspection spec certificate cfg
-    let checker ← mkAppM ``LeanCert.Engine.krawczykCheck
-      #[spec.system, spec.box, certificate, cfg]
-    let certificateGoalType ← mkAppM ``Eq #[checker, mkConst ``Bool.true]
-    let certificateProof ← mkFreshExprMVar certificateGoalType MetavarKind.syntheticOpaque
-    let verificationConfig ← VerificationConfig.current
-    match ← closeCertificateGoalTyped verificationConfig certificateProof.mvarId!
-        (tacticName := "system_unique_root") with
-    | .rejected =>
-        saved.restore
-        return .error (.rejected inspection)
-    | .failed failure =>
-        saved.restore
-        return .error (.verificationFailure
-          (failure.message "system_unique_root"))
-    | .accepted event =>
-        let golden ← mkAppM ``LeanCert.Validity.verify_unique_system_root
-          #[spec.system, spec.box, certificate, cfg, certificateProof]
-        let proof ←
-          if spec.reversedConjunction then
-            mkAppM ``swapSystemRootConjunction #[spec.system, spec.box, golden]
-          else
-            pure golden
-        let proof ← instantiateMVars proof
-        if proof.hasMVar then
+    verifySystemUniqueRootCandidate saved goal target spec certificate cfg
+  catch exception =>
+    saved.restore
+    return .error (.internalFailure (← exception.toMessageData.toString))
+
+/-- Reporting-aware I2 core. Candidate generation is untrusted; the selected
+center and preconditioner are reconstructed as a typed certificate and replayed
+through exactly the same checker/golden-theorem path as I1. -/
+unsafe def systemUniqueRootAutomaticCoreTyped (maxIterations : Nat := 8)
+    (maxDimension : Nat := 4) (taylorDepth : Nat := 10) :
+    TacticM (Except SystemUniqueRootFailure SystemUniqueRootOutcome) := do
+  let saved ← saveState
+  try
+    let goal ← getMainGoal
+    let target ← withMainContext do
+      zetaReduce (← instantiateMVars (← goal.getType))
+    let spec ←
+      match ← parseSystemRootTarget target with
+      | .ok spec => pure spec
+      | .error failure =>
           saved.restore
-          return .error (.transportFailure "the final proof contains unresolved metavariables")
-        let proofType ← inferType proof
-        unless ← isDefEq proofType target do
-          let detail := s!"constructed proof of {← ppExpr proofType}, expected {← ppExpr target}"
-          saved.restore
-          return .error (.transportFailure detail)
-        goal.assign proof
-        pruneSolvedGoals
-        return .ok { inspection, verification := event }
+          return .error failure
+    let cfg ← mkAppM ``LeanCert.Engine.EvalConfig.mk #[toExpr taylorDepth]
+    let searchCfg ← mkAppM ``LeanCert.Engine.AutomaticKrawczykConfig.mk
+      #[toExpr maxIterations, toExpr maxDimension, toExpr 20]
+    let reportExpr ← mkAppM ``LeanCert.Engine.generateAutomaticKrawczyk
+      #[spec.system, spec.box, cfg, searchCfg]
+    let report ← evalExpr AutomaticKrawczykReport
+      (mkConst ``AutomaticKrawczykReport) reportExpr
+    if let some _ := report.failure then
+      saved.restore
+      return .error (.generationFailed report)
+    let certificate ← mkAppM ``LeanCert.Engine.KrawczykCert.ofLists
+      #[spec.dimension, toExpr report.center, toExpr report.preconditioner]
+    verifySystemUniqueRootCandidate saved goal target spec certificate cfg (some report)
   catch exception =>
     saved.restore
     return .error (.internalFailure (← exception.toMessageData.toString))
@@ -216,11 +263,32 @@ private def checkStageMessage : KrawczykCheckStage → String
   | .imageNotStrictlyInside =>
       "the checked Newton image is not strictly inside the target box"
 
+private def generationFailureMessage : AutomaticKrawczykFailure → String
+  | .invalidDimension => "automatic Krawczyk generation requires a positive dimension"
+  | .dimensionLimit actual limit =>
+      s!"system dimension {actual} exceeds the automatic limit {limit}; provide an explicit certificate"
+  | .unsupportedAD =>
+      "the system contains an expression outside the differentiable checked-AD fragment"
+  | .singularPointJacobian attempt =>
+      s!"the rational midpoint Jacobian was singular at attempt {attempt}"
+  | .centerEscaped attempt =>
+      s!"the interval-Newton refinement left the target box after attempt {attempt}"
+  | .stagnated attempt =>
+      s!"candidate refinement stagnated after attempt {attempt}"
+  | .exhausted attempts =>
+      s!"candidate search exhausted its configured budget after {attempts} attempt(s)"
+
 private def failureMessage : SystemUniqueRootFailure → String
   | .unsupportedGoal detail =>
       s!"system_unique_root does not recognize this goal.\n{detail}"
   | .dimensionMismatch expected actual =>
       s!"Krawczyk certificate dimension mismatch.\nExpected: {expected}\nFound: {actual}"
+  | .generationFailed report =>
+      let detail := report.failure.map generationFailureMessage |>.getD
+        "candidate generation returned no certificate"
+      s!"Automatic Krawczyk candidate generation failed: {detail}.\n\
+        Last center: {report.center}\n\
+        Last checked contraction bound: {report.contractionBound}"
   | .rejected inspection =>
       s!"Krawczyk certificate rejected: {checkStageMessage inspection.stage}.\n\
         Checked contraction bound: {inspection.contractionBound}"
@@ -265,39 +333,87 @@ Suggested proof:
   by
     system_unique_root using {certificate.raw.reprint.getD "cert"}"
 
+private unsafe def runSystemUniqueRootAutomatic (maxIterations maxDimension taylorDepth : Nat)
+    (explain : Bool) : TacticM Unit := do
+  match ← systemUniqueRootAutomaticCoreTyped maxIterations maxDimension taylorDepth with
+  | .error failure => throwError (failureMessage failure)
+  | .ok outcome =>
+      if explain then
+        let search := outcome.search.getD { dimension := outcome.inspection.dimension }
+        logInfo m!"LeanCert recognized: nonlinear system uniqueness
+
+Selected strategy:
+  automatic Krawczyk candidate generation
+
+Candidate search:
+  Dimension: {search.dimension}
+  Attempts: {search.attempts}
+  Newton refinements: {search.refinements}
+  Selected center: {search.center}
+  Generated preconditioner: {search.preconditioner}
+  Checked contraction bound: {outcome.inspection.contractionBound} < 1
+
+Certificate verification:
+  requested {requestedVerificationLabel outcome.verification.requested} → used {verificationLabel outcome.verification}
+Checker: {outcome.checker}
+Verifier: {outcome.verifier}
+
+Suggested proof:
+  by
+    system_unique_root
+
+Stable explicit certificate:
+  center := {search.center}
+  preconditioner := {search.preconditioner}"
+
 declare_syntax_cat systemUniqueRootConfigItem
 syntax "(" &"taylorDepth" " := " num ")" : systemUniqueRootConfigItem
+syntax "(" &"maxIterations" " := " num ")" : systemUniqueRootConfigItem
+syntax "(" &"maxDimension" " := " num ")" : systemUniqueRootConfigItem
 syntax "(" &"trust" " := " leancertTrustMode ")" : systemUniqueRootConfigItem
 
 syntax (name := systemUniqueRootTac) "system_unique_root" " using " term:max
   systemUniqueRootConfigItem* : tactic
 syntax (name := systemUniqueRootQuestionTac) "system_unique_root?" " using " term:max
   systemUniqueRootConfigItem* : tactic
+syntax (name := systemUniqueRootAutoTac) "system_unique_root"
+  systemUniqueRootConfigItem* : tactic
+syntax (name := systemUniqueRootAutoQuestionTac) "system_unique_root?"
+  systemUniqueRootConfigItem* : tactic
+
+private structure SystemUniqueRootConfig where
+  taylorDepth : Nat := 10
+  maxIterations : Nat := 8
+  maxDimension : Nat := 4
+  trust : Option VerificationMode := none
 
 private def parseSystemUniqueRootConfig (items : Array Syntax) :
-    TacticM (Nat × Option VerificationMode) := do
-  let mut depth := 10
-  let mut trust : Option VerificationMode := none
+    TacticM SystemUniqueRootConfig := do
+  let mut cfg : SystemUniqueRootConfig := {}
   for item in items do
     match item with
     | `(systemUniqueRootConfigItem| (taylorDepth := $n:num)) =>
-        depth := n.getNat
+        cfg := { cfg with taylorDepth := n.getNat }
+    | `(systemUniqueRootConfigItem| (maxIterations := $n:num)) =>
+        cfg := { cfg with maxIterations := n.getNat }
+    | `(systemUniqueRootConfigItem| (maxDimension := $n:num)) =>
+        cfg := { cfg with maxDimension := n.getNat }
     | `(systemUniqueRootConfigItem| (trust := $m:leancertTrustMode)) =>
         let raw := m.raw.reprint.getD ""
         let some mode := VerificationMode.ofString? raw
           | throwErrorAt m "invalid trust mode '{raw}'; expected kernel, native, or auto"
-        trust := some mode
+        cfg := { cfg with trust := some mode }
     | _ => throwUnsupportedSyntax
-  return (depth, trust)
+  return cfg
 
 @[tactic systemUniqueRootTac]
 unsafe def elabSystemUniqueRoot : Tactic := fun stx => do
   match stx with
   | `(tactic| system_unique_root using $certificate:term
       $items:systemUniqueRootConfigItem*) => do
-      let (depth, trust) ← parseSystemUniqueRootConfig items
-      withTrustMode trust do
-        runSystemUniqueRoot certificate depth false
+      let cfg ← parseSystemUniqueRootConfig items
+      withTrustMode cfg.trust do
+        runSystemUniqueRoot certificate cfg.taylorDepth false
   | _ => throwUnsupportedSyntax
 
 @[tactic systemUniqueRootQuestionTac]
@@ -305,9 +421,27 @@ unsafe def elabSystemUniqueRootQuestion : Tactic := fun stx => do
   match stx with
   | `(tactic| system_unique_root? using $certificate:term
       $items:systemUniqueRootConfigItem*) => do
-      let (depth, trust) ← parseSystemUniqueRootConfig items
-      withTrustMode trust do
-        runSystemUniqueRoot certificate depth true
+      let cfg ← parseSystemUniqueRootConfig items
+      withTrustMode cfg.trust do
+        runSystemUniqueRoot certificate cfg.taylorDepth true
+  | _ => throwUnsupportedSyntax
+
+@[tactic systemUniqueRootAutoTac]
+unsafe def elabSystemUniqueRootAuto : Tactic := fun stx => do
+  match stx with
+  | `(tactic| system_unique_root $items:systemUniqueRootConfigItem*) => do
+      let cfg ← parseSystemUniqueRootConfig items
+      withTrustMode cfg.trust do
+        runSystemUniqueRootAutomatic cfg.maxIterations cfg.maxDimension cfg.taylorDepth false
+  | _ => throwUnsupportedSyntax
+
+@[tactic systemUniqueRootAutoQuestionTac]
+unsafe def elabSystemUniqueRootAutoQuestion : Tactic := fun stx => do
+  match stx with
+  | `(tactic| system_unique_root? $items:systemUniqueRootConfigItem*) => do
+      let cfg ← parseSystemUniqueRootConfig items
+      withTrustMode cfg.trust do
+        runSystemUniqueRootAutomatic cfg.maxIterations cfg.maxDimension cfg.taylorDepth true
   | _ => throwUnsupportedSyntax
 
 end LeanCert.Tactic

--- a/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
+++ b/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
@@ -107,9 +107,10 @@ def routerFailure (verbosity : DiagnosticVerbosity) : RouterFailure → String
         Increasing numerical precision does not repair an invalid domain."
   | .portfolioExhausted intent attempts spent budget =>
       if intent == .systemRoot then
-        s!"LeanCert recognized: {intentLabel intent}\n\nA manual `KrawczykCert` is required \
-          for this I1 theorem family.\n\nTry:\n  system_unique_root using cert\n\n\
-          Automatic center and preconditioner generation is reserved for I2."
+        s!"LeanCert recognized: {intentLabel intent}\n\nAutomatic Krawczyk candidate \
+          generation did not certify the original box.\n\nAttempts:\n{attemptLedger attempts}\n\n\
+          Next steps:\n  - narrow the target box;\n  - increase `(maxIterations := ...)`; or\n  \
+          - provide `system_unique_root using cert` from an external numerical solver."
       else match verbosity with
       | .compact =>
           s!"LeanCert recognized a {intentLabel intent}, but no strategy proved it \
@@ -299,6 +300,16 @@ Stable explicit proof:
   by
     eventual_bound using {statistics.cutoff}"
 
+private def renderKrawczyk (statistics : Option KrawczykStatistics) : String :=
+  match statistics with
+  | none => ""
+  | some statistics =>
+      s!"\n\nKrawczyk candidate search:\n  Dimension: {statistics.dimension}\n  \
+        Attempts: {statistics.attempts}\n  Newton refinements: {statistics.refinements}\n  \
+        Selected center: {statistics.center}\n  Generated preconditioner: \
+        {statistics.preconditioner}\n  Checked contraction bound: \
+        {statistics.contractionBound} < 1\n\nStable dedicated proof:\n  by\n    system_unique_root"
+
 private def renderCertificates
     (certificates : Array CertificateObservation) : String :=
   if certificates.isEmpty then ""
@@ -347,13 +358,14 @@ def successReport (report : SolverReport) : String :=
   let finiteSum := renderFiniteSum report.execution.finiteSum
   let integralPartitions := renderIntegralPartitions report.execution.integralPartitions
   let eventualBound := renderEventualBound report.execution.eventualBound
+  let krawczyk := renderKrawczyk report.execution.krawczyk
   let certificates := renderCertificates report.execution.certificates
   let advanced :=
     plan.dedicatedProof.map (fun proof =>
       s!"\n\nAdvanced control:\n  {renderProof proof}") |>.getD ""
   s!"LeanCert recognized: {intentLabel plan.intent}\n\n\
     Selected strategy:\n  {plan.strategy}{detail}{executionNotes}{backend}{verification}\
-    {checker}{verifier}{optimization}{subdivision}{finiteSum}{integralPartitions}{eventualBound}{certificates}\n\n\
+    {checker}{verifier}{optimization}{subdivision}{finiteSum}{integralPartitions}{eventualBound}{krawczyk}{certificates}\n\n\
     Suggested proof:\n  {renderProof plan.primaryProof}\
     {advanced}{renderChildren report.execution.children}"
 

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -14,6 +14,7 @@ import LeanCert.Tactic.Extension.Execute
 import LeanCert.Tactic.Discovery
 import LeanCert.Tactic.FinSumExpand
 import LeanCert.Tactic.EventualBound
+import LeanCert.Tactic.Krawczyk
 import LeanCert.Engine.Search.CounterExample
 
 /-!
@@ -743,6 +744,80 @@ private def eventualBoundAttemptTyped (maxChecks : Nat) :
         notes := if outcome.discovered then #[] else #[s!"Explicit cutoff: N = {outcome.cutoff}"]
       }
 
+private def automaticKrawczykFailure
+    (failure : SystemUniqueRootFailure) : AttemptFailure :=
+  match failure with
+  | .unsupportedGoal _ => .notApplicable
+  | .dimensionMismatch expected actual => .internalError
+      `LeanCert.Tactic.systemUniqueRootAutomaticCoreTyped
+      s!"automatic certificate dimension mismatch: expected {expected}, found {actual}"
+  | .generationFailed report =>
+      match report.failure with
+      | some .unsupportedAD => .unsupported {
+          expression := "nonlinear system"
+          detail := some "The system lies outside LeanCert's checked-AD fragment."
+        }
+      | some (.dimensionLimit actual limit) => .inconclusive {
+          requested := some s!"automatic dimension at most {limit}"
+          detail := s!"System dimension {actual} exceeds the automatic Krawczyk limit. \
+            Supply an explicit certificate with `system_unique_root using cert`."
+        }
+      | some (.singularPointJacobian attempt) => .inconclusive {
+          detail := s!"The midpoint Jacobian was singular at candidate attempt {attempt}."
+        }
+      | some (.centerEscaped attempt) => .inconclusive {
+          detail := s!"The interval-Newton center left the target box after attempt {attempt}."
+        }
+      | some (.stagnated attempt) => .inconclusive {
+          enclosure := none
+          detail := s!"Automatic Krawczyk refinement stagnated after attempt {attempt}; \
+            the original box may be too wide."
+        }
+      | some (.exhausted attempts) => .inconclusive {
+          requested := some s!"at most {attempts} candidate attempts"
+          detail := "Automatic Krawczyk candidate search exhausted its configured budget."
+        }
+      | some .invalidDimension => .unsupported {
+          expression := "Fin 0 system"
+          detail := some "Automatic Krawczyk generation requires a positive dimension."
+        }
+      | none => .internalError `LeanCert.Tactic.systemUniqueRootAutomaticCoreTyped
+          "candidate generation failed without a classified cause"
+  | .rejected inspection => .rejected {
+      checker := some ``LeanCert.Engine.krawczykCheck
+      detail := s!"Generated Krawczyk certificate was rejected at stage \
+        {repr inspection.stage}; contraction bound {inspection.contractionBound}."
+    }
+  | .verificationFailure detail => .internalError
+      `LeanCert.Tactic.systemUniqueRootAutomaticCoreTyped detail
+  | .transportFailure detail => .internalError
+      `LeanCert.Tactic.systemUniqueRootAutomaticCoreTyped detail
+  | .internalFailure detail => .internalError
+      `LeanCert.Tactic.systemUniqueRootAutomaticCoreTyped detail
+
+private unsafe def systemRootAttemptTyped (maxIterations taylorDepth : Nat) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← systemUniqueRootAutomaticCoreTyped maxIterations 4 taylorDepth with
+  | .error failure => return .error (automaticKrawczykFailure failure)
+  | .ok outcome =>
+      let some search := outcome.search
+        | return .error <| .internalError `LeanCert.Tactic.systemUniqueRootAutomaticCoreTyped
+            "automatic proof succeeded without retained search statistics"
+      return .ok {
+        backend := some .exactRational
+        verificationUsage := Solver.VerificationUsage.ofEvents outcome.verification.toUsage
+        checker := some outcome.checker
+        verifier := some outcome.verifier
+        krawczyk := some {
+          dimension := search.dimension
+          attempts := search.attempts
+          refinements := search.refinements
+          center := search.center
+          preconditioner := search.preconditioner
+          contractionBound := outcome.inspection.contractionBound
+        }
+      }
+
 /-- The deterministic strategy portfolio for a recognized goal intent. -/
 private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
     (mode : VerificationMode) : Array SolverSpec :=
@@ -751,15 +826,12 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
   let d3 := d + 20
   match intent with
   | .systemRoot => #[
-      { report := report intent "manual Krawczyk contraction certificate"
-          cfg mode .notApplicable
-          (some { tactic := "system_unique_root using", positionalArgs := #["cert"] })
+      { report := report intent "automatic Krawczyk candidate generation"
+          cfg mode (.fixed .exactRational)
+          (some { tactic := "system_unique_root" })
           (strategyId := .systemRoot),
-        solve := pure <| .error <| .inconclusive {
-          detail := "This I1 theorem family requires an explicit `KrawczykCert`. \
-            Use `system_unique_root using cert`; automatic candidate generation \
-            is reserved for I2."
-        } }]
+        solve := systemRootAttemptTyped
+          (if cfg.maxIterations == 1000 then 8 else cfg.maxIterations) cfg.taylorDepth }]
   | .eventualBound => #[
       { report := report intent "reciprocal-power tail certificate"
           cfg mode (.fixed .exactRational)

--- a/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
+++ b/LeanCert/Tactic/LeanCert/Solver/Protocol.lean
@@ -171,6 +171,16 @@ structure EventualBoundStatistics where
   refinementComplete : Bool
   deriving Inhabited, Repr
 
+/-- Structured facts retained from automatic Krawczyk candidate generation. -/
+structure KrawczykStatistics where
+  dimension : Nat
+  attempts : Nat
+  refinements : Nat
+  center : List ℚ
+  preconditioner : List (List ℚ)
+  contractionBound : ℚ
+  deriving Inhabited, Repr
+
 /-- Stable algorithm identity for reporting and failure classification.
 User-facing `strategy` text may be polished without changing control flow. -/
 inductive StrategyId where
@@ -230,6 +240,7 @@ structure SolverExecution where
   finiteSum : Option FiniteSumStatistics := none
   integralPartitions : Option IntegralPartitionStatistics := none
   eventualBound : Option EventualBoundStatistics := none
+  krawczyk : Option KrawczykStatistics := none
   /-- Constituent checker proofs retained by composite artifacts. The singular
   `checker`/`verifier` fields describe ordinary one-certificate solvers. -/
   certificates : Array CertificateObservation := #[]

--- a/LeanCert/Test/KrawczykTactic.lean
+++ b/LeanCert/Test/KrawczykTactic.lean
@@ -6,7 +6,7 @@ Authors: LeanCert Contributors
 import LeanCert.Examples.Krawczyk
 import LeanCert.Tactic
 
-/-! Generalized I1 regressions for the manual Krawczyk tactic front end. -/
+/-! Generalized I1/I2 regressions for manual and automatic Krawczyk front ends. -/
 
 namespace LeanCert.Test.KrawczykTactic
 
@@ -110,6 +110,51 @@ mathematical contract. -/
 example : ∃! p, SystemZero system p ∧ FinBoxMem p box := by
   system_unique_root using certificate
 
+/- I2 constructs midpoint-Jacobian candidates and replays them through the
+same checked theorem boundary as the manual tactic. -/
+example : ∃! p, FinBoxMem p translatedBox ∧ SystemZero translatedSystem p := by
+  system_unique_root (trust := kernel)
+
+example : ∃! p, FinBoxMem p mixedBox ∧ SystemZero mixedSystem p := by
+  system_unique_root (trust := native)
+
+example : ∃! p, FinBoxMem p cyclicBox ∧ SystemZero cyclicSystem p := by
+  system_unique_root (trust := auto)
+
+example : ∃! p, FinBoxMem p identityBox ∧ SystemZero identitySystem p := by
+  system_unique_root
+
+example : ∃! p, FinBoxMem p expBox ∧ SystemZero expSystem p := by
+  system_unique_root? (trust := kernel)
+
+#guard (generateAutomaticKrawczyk translatedSystem translatedBox).succeeded
+#guard (generateAutomaticKrawczyk mixedSystem mixedBox).succeeded
+#guard (generateAutomaticKrawczyk cyclicSystem cyclicBox).succeeded
+#guard (generateAutomaticKrawczyk identitySystem identityBox).succeeded
+
+/- An asymmetric exponential box makes the midpoint candidate fail while one
+bounded interval-Newton refinement produces a valid certificate. -/
+def shiftedExpSystem : Fin 1 → Expr :=
+  ![Expr.add (Expr.exp (Expr.var 0)) (Expr.const (-1 / 8))]
+
+def shiftedExpBox : Fin 1 → IntervalRat :=
+  ![⟨-57 / 20, -33 / 20, by norm_num⟩]
+
+def shiftedExpReport : AutomaticKrawczykReport :=
+  generateAutomaticKrawczyk shiftedExpSystem shiftedExpBox
+
+#guard shiftedExpReport.succeeded
+#guard shiftedExpReport.attempts == 2
+#guard shiftedExpReport.refinements == 1
+
+example : ∃! p, FinBoxMem p shiftedExpBox ∧ SystemZero shiftedExpSystem p := by
+  system_unique_root (maxIterations := 4) (trust := kernel)
+
+/- Exact pivoting is independent of the nonlinear search. -/
+#guard invertRatMatrix? (!![2, 1; 1, 2] : Matrix (Fin 2) (Fin 2) ℚ) ==
+  some !![2 / 3, -1 / 3; -1 / 3, 2 / 3]
+#guard invertRatMatrix? (!![1, 2; 2, 4] : Matrix (Fin 2) (Fin 2) ℚ) == none
+
 def singularCert : KrawczykCert 2 where
   center := ![1, 1]
   preconditioner := 0
@@ -157,12 +202,44 @@ example : ∃! p, FinBoxMem p box ∧ SystemZero system p := by
   | system_unique_root using singularCert
   | exact unique_root
 
-/- Plain semantic routing recognizes the family but does not pretend I1 can
-generate a candidate. -/
-example : True := by
-  fail_if_success
-    have : ∃! p, FinBoxMem p identityBox ∧ SystemZero identitySystem p := by
-      leancert?
-  trivial
+/- The semantic front door uses the automatic generator and retains its
+search statistics for `leancert?`. -/
+example : ∃! p, FinBoxMem p box ∧ SystemZero system p := by
+  leancert
+
+example : ∃! p, FinBoxMem p identityBox ∧ SystemZero identitySystem p := by
+  leancert? (trust := kernel)
+
+def dimensionFiveSystem : Fin 5 → Expr := fun i => Expr.var i
+def dimensionFiveBox : Fin 5 → IntervalRat := fun _ => ⟨-1 / 10, 1 / 10, by norm_num⟩
+
+#guard (generateAutomaticKrawczyk dimensionFiveSystem dimensionFiveBox).failure ==
+  some (.dimensionLimit 5 4)
+#guard (generateAutomaticKrawczyk unsupportedSystem box).failure == some .unsupportedAD
+#guard (generateAutomaticKrawczyk system box
+  (search := { maxIterations := 0 })).failure == some (.exhausted 0)
+
+def noRootSystem : Fin 1 → Expr :=
+  ![Expr.add (Expr.mul (Expr.var 0) (Expr.var 0)) (Expr.const 1)]
+
+def symmetricUnitBox : Fin 1 → IntervalRat :=
+  ![⟨-1, 1, by norm_num⟩]
+
+#guard (generateAutomaticKrawczyk noRootSystem symmetricUnitBox).failure ==
+  some (.singularPointJacobian 1)
+#guard (generateAutomaticKrawczyk system wideBox).failure.isSome
+
+/-- error: Automatic Krawczyk candidate generation failed: candidate search exhausted its configured budget after 0 attempt(s).
+Last center: []
+Last checked contraction bound: 0 -/
+#guard_msgs in
+example : ∃! p, FinBoxMem p box ∧ SystemZero system p := by
+  system_unique_root (maxIterations := 0)
+
+/- Automatic failure is transactional too. -/
+example : ∃! p, FinBoxMem p box ∧ SystemZero system p := by
+  first
+  | system_unique_root (maxIterations := 0)
+  | exact unique_root
 
 end LeanCert.Test.KrawczykTactic

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ The main verified numerical path includes:
 - Algebraic operations and supported transcendental functions including
   `exp`, `log`, `sin`, `cos`, `sqrt`, `atan`, `atanh`, and `erf`
 - Checked automatic differentiation and global bound certificates
-- Root existence, exclusion, Newton-style uniqueness, and manual Krawczyk
-  system-root certificates
+- Root existence, exclusion, Newton-style uniqueness, and automatic or manual
+  Krawczyk system-root certificates
 - Exact rational polynomial integration and certified partition integration
 - Checked downstream unary enclosure rules consumed compositionally by `leancert`
 - Fixed and automatically discovered reciprocal-power bounds over infinite

--- a/docs/architecture/root-finding.md
+++ b/docs/architecture/root-finding.md
@@ -61,7 +61,7 @@ Three golden theorems expose the same successful check in the common goal
 shapes: `verify_system_root_exists`, `verify_system_root_unique`, and
 `verify_unique_system_root`.
 
-The manual I1 front end exposes the last shape directly:
+The automatic I2 front end exposes the last shape directly:
 
 ```lean
 import LeanCert.Examples.Krawczyk
@@ -71,12 +71,14 @@ open LeanCert.Core LeanCert.Engine LeanCert.Validity
 open LeanCert.Examples.Krawczyk
 
 example : ∃! x, FinBoxMem x box ∧ SystemZero system x := by
-  system_unique_root using certificate (trust := auto)
+  system_unique_root (trust := auto)
 ```
 
-The center and preconditioner remain untrusted candidate data. The tactic
-checks dimensions, runs the same monolithic checker, and reaches the theorem
-only through the configured certificate-verification route.
+The generated center and preconditioner remain untrusted candidate data. The
+search uses a box midpoint, singleton checked-AD Jacobian, pivoted rational
+Gauss--Jordan inversion, and bounded interval-Newton refinement. It then runs
+the same monolithic checker as `system_unique_root using certificate` and
+reaches the theorem only through the configured verification route.
 
 ### Current limits
 
@@ -84,9 +86,12 @@ only through the configured certificate-verification route.
 - Boxes, centers, and preconditioners use exact rational data.
 - The norm-form enclosure is intentionally conservative; a rejected
   certificate is inconclusive.
-- LeanCert checks but does not currently generate the approximate center or
-  inverse-Jacobian preconditioner. Those remain untrusted frontend/CAS data and
-  are supplied to `system_unique_root using cert`.
+- Automatic generation defaults to dimensions at most four; explicit
+  certificates remain dimension-generic.
+- Candidate refinement uses fixed dyadic precision to prevent denominator
+  explosion in untrusted search data.
+- Automatic search does not subdivide the target box. A certificate on one
+  sub-box would not prove uniqueness over the original box.
 - The theorem is over real boxes. Complex systems must first be represented as
   coupled real and imaginary coordinates.
 
@@ -305,5 +310,6 @@ This is used internally for:
 | `Engine/RootFinding/Contraction.lean` | Newton contraction verification |
 | `Engine/RootFinding/MVTBounds.lean` | Mean value theorem utilities |
 | `Engine/RootFinding/Krawczyk.lean` | Nonlinear-system checker and soundness bridge |
+| `Engine/RootFinding/KrawczykCandidate.lean` | Untrusted rational candidate generation and refinement |
 | `Validity/Krawczyk.lean` | Stable golden theorem |
 | `Tactic/Discovery.lean` | `interval_roots`, `interval_unique_root` tactics |

--- a/docs/direct/leancert.md
+++ b/docs/direct/leancert.md
@@ -70,8 +70,8 @@ The router currently recognizes:
   search followed by a fixed-candidate certificate;
 - fixed-cutoff and existential eventual upper bounds for supported
   reciprocal-power tails over `Nat`;
-- nonlinear-system unique-root goals in Krawczyk form (recognized by the
-  router; I1 asks for `system_unique_root using cert`);
+- nonlinear-system unique-root goals in Krawczyk form, with automatic rational
+  candidate generation and checked replay through the I1 verifier;
 - closed LeanCert Boolean checker propositions;
 - conjunctions whose children are themselves recognized.
 

--- a/docs/direct/roots.md
+++ b/docs/direct/roots.md
@@ -5,10 +5,11 @@ For ordinary root existence, uniqueness, and no-root goals, start with
 controls or programmatic certificate APIs.
 
 For square multivariate systems in LeanCert's differentiable AD fragment, use
-`system_unique_root using cert`. The certificate supplies an untrusted rational
-center and approximate inverse Jacobian; LeanCert accepts it only after the
-existing `krawczykCheck` succeeds and the `verify_unique_system_root` Golden
-Theorem produces the requested proof. See the
+`system_unique_root`. It generates an untrusted rational center and approximate
+inverse Jacobian, then accepts it only after the existing `krawczykCheck`
+succeeds and the `verify_unique_system_root` Golden Theorem produces the
+requested proof. Use `system_unique_root using cert` to pin an explicit
+candidate. See the
 [system architecture and examples](../architecture/root-finding.md#nonlinear-systems-krawczyk).
 
 Typical goals:
@@ -32,9 +33,10 @@ interval_roots
 interval_unique_root
 root_bound
 system_unique_root using cert
+system_unique_root
 ```
 
-## Nonlinear systems with a manual Krawczyk certificate
+## Nonlinear systems with Krawczyk certificates
 
 The exact recognized goal is:
 
@@ -42,8 +44,7 @@ The exact recognized goal is:
 ∃! x : Fin n → ℝ, FinBoxMem x X ∧ SystemZero F x
 ```
 
-The conjunction may also be written in the opposite order. The certificate's
-dimension is checked while elaborating the tactic invocation.
+The conjunction may also be written in the opposite order.
 
 ```lean
 import LeanCert.Examples.Krawczyk
@@ -53,14 +54,33 @@ open LeanCert.Core LeanCert.Engine LeanCert.Validity
 open LeanCert.Examples.Krawczyk
 
 example : ∃! x, FinBoxMem x box ∧ SystemZero system x := by
-  system_unique_root using certificate (trust := kernel)
+  system_unique_root (trust := kernel)
 ```
 
-Use `system_unique_root?` for the dimension, center, checked contraction bound,
-checker, verifier, and effective verification route:
+Automatic search starts at the box midpoint, constructs a preconditioner from
+a singleton checked-AD Jacobian, and performs bounded interval-Newton center
+refinements when needed. Candidate values are dyadically rounded to control
+denominator growth, then checked exactly.
+
+Use `system_unique_root?` for attempts, refinements, generated center and
+preconditioner, checked contraction bound, checker, verifier, and effective
+verification route:
 
 ```text
-system_unique_root? using certificate (taylorDepth := 12) (trust := auto)
+system_unique_root? (maxIterations := 8) (taylorDepth := 12) (trust := auto)
+```
+
+The manual I1 path remains available:
+
+```lean
+import LeanCert.Examples.Krawczyk
+import LeanCert.Tactic
+
+open LeanCert.Core LeanCert.Engine
+open LeanCert.Examples.Krawczyk
+
+example : ∃! x, FinBoxMem x box ∧ SystemZero system x := by
+  system_unique_root using certificate (trust := kernel)
 ```
 
 A rejected certificate is inconclusive, not evidence that the system lacks a
@@ -69,11 +89,14 @@ outside the box, a singular preconditioner, a contraction bound not strictly
 below one, and failure of the strict self-map check. Every failure restores the
 original tactic state.
 
-I1 deliberately does not generate candidates. Centers and preconditioners may
-come from a separate numerical program, but no external computation enters the
-trusted proof: the checked Boolean certificate and Golden Theorem are the
-verification boundary. Automatic candidate construction is separate future
-frontend work.
+Automatic I2 candidates and manual I1 certificates pass through the same
+Boolean checker and Golden Theorem. Centers and preconditioners may still come
+from a separate numerical program; no external or search computation enters
+the trusted proof.
+
+Automatic generation defaults to dimensions at most four. Manual certificates
+remain dimension-generic. Automatic box subdivision is intentionally excluded:
+certifying one sub-box would not prove uniqueness over the original box.
 
 The scalar dedicated tactics use typed, transactional certificate boundaries.
 A checker result of `false` is an ordinary rejected candidate; malformed

--- a/docs/reference/imports.md
+++ b/docs/reference/imports.md
@@ -64,7 +64,7 @@ import LeanCert.Engine.Chebyshev.Theta
 import LeanCert.Validity.Krawczyk
 ```
 
-For the manual certificate tactic, import the tactic umbrella:
+For automatic or manual system-root tactics, import the tactic umbrella:
 
 ```lean
 import LeanCert.Tactic

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -15,7 +15,7 @@ proof strategy.
 | `multivariate_bound` | optional positional iteration count, followed by optional `(trust := ...)` |
 | `opt_bound` | optional positional iteration count, followed by optional `mono` and `(trust := ...)` |
 | `root_bound`, `interval_roots`, `interval_unique_root` | optional positional Taylor depth, followed by optional `(trust := ...)` |
-| `system_unique_root`, `system_unique_root?` | `using cert`, followed by optional `(taylorDepth := n)` and `(trust := native\|kernel\|auto)` in either order |
+| `system_unique_root`, `system_unique_root?` | optional `using cert`; automatic mode also accepts `(maxIterations := n)` and `(maxDimension := n)`, plus `(taylorDepth := n)` and `(trust := native\|kernel\|auto)` |
 | `interval_minimize`, `interval_maximize` | optional positional Taylor depth, followed by optional `(trust := ...)` |
 | `interval_minimize_mv`, `interval_maximize_mv` | optional positional Taylor depth, followed by optional `(trust := ...)` |
 | `interval_argmin`, `interval_argmax` | optional positional Taylor depth, followed by optional `(trust := ...)` |
@@ -384,8 +384,8 @@ failures. Every failure is transactional.
 
 ### `system_unique_root` and `system_unique_root?`
 
-Certifies a unique zero of a square nonlinear system using a user-supplied,
-dimension-indexed `KrawczykCert n`:
+Certifies a unique zero of a square nonlinear system. Automatic mode generates
+a rational `KrawczykCert n`; manual mode accepts a user-supplied certificate:
 
 ```lean
 import LeanCert.Examples.Krawczyk
@@ -395,15 +395,21 @@ open LeanCert.Core LeanCert.Engine LeanCert.Validity
 open LeanCert.Examples.Krawczyk
 
 example : ∃! x, FinBoxMem x box ∧ SystemZero system x := by
-  system_unique_root using certificate (taylorDepth := 10) (trust := auto)
+  system_unique_root (maxIterations := 8) (taylorDepth := 10) (trust := auto)
 ```
 
 The tactic accepts the conjunction in either order. `system_unique_root?`
-proves the same goal and reports the supplied center, checked contraction
-bound, `krawczykCheck`, `verify_unique_system_root`, and observed verification
-route. Candidate rejection and dimension mismatch are typed, transactional
-failures. Candidate generation and box subdivision are not part of this manual
-I1 tactic.
+proves the same goal and reports attempts, Newton refinements, generated center
+and preconditioner, checked contraction bound, `krawczykCheck`,
+`verify_unique_system_root`, and the observed verification route. Candidate
+generation is untrusted and the selected candidate is replayed through the I1
+checker. Candidate rejection, singular midpoint Jacobians, budget exhaustion,
+unsupported AD, and dimension limits are typed, transactional failures.
+
+Use `system_unique_root using certificate` to bypass search while retaining the
+same trusted verification boundary. Automatic box subdivision is intentionally
+excluded because a certificate on one sub-box does not prove uniqueness over
+the original target box.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,23 +52,23 @@ and `eventual_bound?`/`leancert?` provenance.
 
 ## Nonlinear-system roots
 
-**Current state:** `system_unique_root using cert` checks an explicit,
-dimension-indexed Krawczyk center and preconditioner for square systems in the
-checked-AD fragment. The semantic router recognizes the canonical `∃!` system
-goal, while the dedicated tactic provides typed dimension and rejection
-diagnostics, transactional failure, all verification modes, and transparent
-`system_unique_root?` provenance. Candidate data is untrusted; proof acceptance
-still passes through `krawczykCheck` and `verify_unique_system_root`.
+**Current state:** `system_unique_root` generates rational Krawczyk centers and
+preconditioners for square systems in the checked-AD fragment. It uses
+singleton point-Jacobian enclosures, pivoted Gauss--Jordan inversion, bounded
+interval-Newton refinement, and fixed-precision candidate rounding. The
+semantic router invokes it directly for the canonical `∃!` system goal.
+`system_unique_root using cert` remains the manual path. Both pass through
+`krawczykCheck` and `verify_unique_system_root`; search data is never trusted.
 
-**Possible next milestone:** generate centers and rational preconditioners in
-an untrusted frontend, then replay every candidate through the same manual I1
-boundary. Adaptive box refinement should be justified by concrete systems and
-must preserve the distinction between local uniqueness and uniqueness in the
-original box.
+**Possible next milestone:** expose the checked system-root operation through
+the bridge and let external numerical frontends supply stronger candidates.
+Adaptive box refinement remains separate: it requires existence in one box and
+root exclusion over the complement to preserve uniqueness in the original box.
 
-**Evidence:** successful translated, coupled transcendental, cyclic 3D, and
-generic 4D systems; mutation tests for every checker stage; dimension mismatch,
-conjunction-order, local-certificate, trust-route, and rollback regressions.
+**Evidence:** automatic translated, coupled transcendental, cyclic 3D, generic
+4D, and refinement-requiring exponential systems; exact and singular matrix
+inversion tests; mutation tests for every checker stage; dimension-limit,
+budget, unsupported-AD, conjunction-order, trust-route, and rollback tests.
 
 ## Stronger quantified ML theorems
 


### PR DESCRIPTION
## Summary

Adds I2 automatic Krawczyk candidate generation for nonlinear system uniqueness goals.

Users can now prove supported goals directly with:

    example : ∃! x, FinBoxMem x box ∧ SystemZero system x := by
      system_unique_root

The main `leancert` router also recognizes these goals and invokes the automatic Krawczyk strategy.

## Candidate generation

The new untrusted frontend:

- starts from the exact rational midpoint of the target box
- evaluates the checked-AD Jacobian at the candidate center
- constructs a rational preconditioner using pivoted Gauss–Jordan inversion
- rounds candidate values to a fixed dyadic precision to control denominator growth
- retries rejected candidates using bounded interval-Newton center refinement
- reports singular Jacobians, unsupported AD expressions, escaped centers, stagnation, dimension limits, and exhausted search budgets

Candidate generation remains outside the trusted boundary. Every generated certificate is replayed through the same `krawczykCheck` and `verify_unique_system_root` path introduced by I1.

## Tactic and router UX

Adds automatic forms:

    system_unique_root
    system_unique_root?
    system_unique_root (maxIterations := 12)
    system_unique_root (maxDimension := 4)
    system_unique_root (taylorDepth := 12) (trust := kernel)

The existing manual form remains available:

    system_unique_root using certificate

`system_unique_root?` and `leancert?` report:

- system dimension
- number of candidate attempts
- interval-Newton refinements
- selected center
- generated preconditioner
- checked contraction bound
- checker, verifier, and effective trust route

## Safety and scope

- Automatic generation defaults to dimensions at most four.
- Manual certificates remain dimension-generic.
- Search and matrix inversion are untrusted.
- Proof acceptance still requires the checked Boolean certificate and Golden Theorem.
- The target box is never subdivided: proving uniqueness on a sub-box would not establish uniqueness over the original box.
