### PR TITLE
docs: add Python SDK guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,32 @@ lake env lean Main.lean
 For a reproducible development or release, pin `rev` to a commit or tag rather
 than `main`.
 
+## Prefer Python?
+
+The self-contained Python SDK bundles the matching LeanCert Bridge on supported
+platforms, so checking a claim does not require a local Lean installation:
+
+```bash
+pip install leancert
+leancert doctor
+```
+
+```python
+import leancert as lc
+from leancert import ast
+
+x = ast.var("x")
+result = lc.prove(x**2 <= 1, where={x: (0, 1)})
+
+if isinstance(result, lc.Verified):
+    print(result.claim_id)
+```
+
+Python handles exact modeling and untrusted candidate search; advertised
+LeanCert checkers authorize successful outcomes. Replayable results can be
+exported as pinned Lean projects for an independent kernel rebuild. Begin with
+the [Python SDK documentation](https://docs.leancert.io/python/).
+
 ## What is actually verified?
 
 LeanCert separates finding a certificate, checking it, and interpreting it.

--- a/docs/architecture/backend-selection.md
+++ b/docs/architecture/backend-selection.md
@@ -99,8 +99,12 @@ def preciseDyadic : EvalOptions := {
 #eval evalInterval (.exp (.var 0)) [unit] preciseDyadic
 ```
 
-The historical `eval_interval_dyadic` and `eval_interval_affine` JSON methods
-were removed; use `eval_interval` with the `backend` selector. Global
+The current Core public JSON facade removed the historical
+`eval_interval_dyadic` and `eval_interval_affine` methods; use `eval_interval`
+with the `backend` selector. The published Python SDK 1.0 compatibility client
+still uses native Dyadic/Affine operation names when negotiating its released
+Bridge contract. Those names are a Python/Bridge compatibility surface, not
+additional Lean public APIs. Global
 optimization uses `LeanCert.GlobalOptOptions`, which composes the same
 `EvalOptions` with independent `SearchOptions`:
 

--- a/docs/architecture/python-bridge.md
+++ b/docs/architecture/python-bridge.md
@@ -1,0 +1,48 @@
+# Python Bridge Contract
+
+The Python SDK communicates with `lean_bridge` over a versioned newline-delimited
+JSON protocol. It is a typed capability contract, not generic JSON-RPC.
+
+## Handshake
+
+Before checked operations, `get_info` identifies:
+
+- protocol, Bridge, Lean, and LeanCert versions;
+- framing and protocol name;
+- source revision, source digest, environment digest, and build profile;
+- supported operations and expression nodes;
+- request, result, and certificate schemas;
+- available numerical backends; and
+- verification routes.
+
+The SDK refuses to send unadvertised operations and validates that responses
+use the authority negotiated for that operation.
+
+## Checked capability families
+
+| Capability | Stable Python outcome | Replay payload |
+|---|---|---|
+| `check_bound` | `Verified` and typed non-successes | `bound-check/2` |
+| `verify_adaptive` | Checked adaptive leaf evidence | `adaptive-bound-check/1` |
+| `check_unique_system_root` | `VerifiedSystemRoot` / `CandidateRejected` | `krawczyk-check/1` |
+| `check_eventual_bound` | `VerifiedEventualBound` and typed non-successes | `eventual-bound-check/1` |
+
+Adaptive evidence is intentionally distinct from the fixed payload families
+currently supported by standalone project export.
+
+## Validation is not re-proving
+
+Python validates exact rationals, requested direction, claim/payload agreement,
+certificate schema, checker identity, and verification route. These checks
+prevent Python from misrepresenting a Bridge result; they do not prove the
+mathematical theorem a second time.
+
+## Failure boundary
+
+Malformed envelopes, mismatched response IDs, contradictory results, and
+unknown schemas are protocol failures. Mathematical non-success is represented
+by typed operation outcomes such as `Inconclusive`, `Unsupported`, or
+`CandidateRejected`.
+
+For the Lean-side checker and Golden-Theorem story, continue to the
+[trust model](trust-model.md).

--- a/docs/choosing-interface.md
+++ b/docs/choosing-interface.md
@@ -1,0 +1,42 @@
+# Choose Python or Lean
+
+LeanCert exposes the same checked numerical foundations through two workflows.
+Choose the interface that matches where your theorem starts.
+
+| Choose Python when... | Choose Lean when... |
+|---|---|
+| Your model, data, or search procedure already lives in Python | Your proposition is already a Lean theorem |
+| You want a self-contained `pip install` experience | You want tactics inside an existing Lean development |
+| NumPy or PyTorch supplies untrusted candidate data | You want direct access to LeanCert certificate APIs |
+| You want typed `Verified`/`Rejected`/`Inconclusive` outcomes | You want a theorem immediately available to downstream Lean code |
+| You want to export a fixed certificate for later audit | You want to construct or compose certificates manually |
+
+The choice is not a choice of mathematical authority. In the Python workflow,
+candidate discovery remains untrusted and the bundled Bridge invokes LeanCert's
+checked operations. Replayable result families can then be exported as pinned
+Lean projects and rebuilt with the Lean kernel.
+
+## Begin with Python
+
+```bash
+pip install leancert
+leancert doctor
+```
+
+Continue to the [Python quickstart](python/quickstart.md).
+
+## Begin with Lean
+
+Add LeanCert to a Lake project and continue to the
+[Lean quickstart](quickstart.md).
+
+## Use both
+
+A common workflow is:
+
+1. Describe an exact claim in Python.
+2. Let Python search for candidate numerical data.
+3. Accept success only after a LeanCert checker validates that data.
+4. Export the retained certificate.
+5. Rebuild the exported theorem independently and import the mathematical idea
+   into a larger Lean development.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,20 @@
 # LeanCert
 
-LeanCert is a Lean 4 library for certified numerical computation and
-proof-producing certificate workflows.
+LeanCert is a certified numerical-computation system with two first-class
+interfaces: a Lean 4 library for proving theorems directly and a Python SDK
+for constructing exact claims, orchestrating numerical search, and producing
+checked evidence.
 
-For theorem proving, begin with [`leancert`](direct/leancert.md). For
-programmatic use, see the [supported public API](reference/public-api.md).
-For a compact evaluation path, build the [curated showcase](showcase.md) and
-read the [trust model](architecture/trust-model.md).
+| I want to... | Start here |
+|---|---|
+| Prove numerical theorems in Lean | [Lean quickstart](quickstart.md) |
+| Check exact claims from Python | [Python quickstart](python/quickstart.md) |
+| Understand what is trusted | [Trust model](architecture/trust-model.md) |
+| Rebuild Python-produced evidence independently | [Export and verification](python/evidence/export.md) |
+
+Both interfaces reach LeanCert's checked numerical engines. Python may search
+for candidate bounds, cutoffs, or Krawczyk data, but search never authorizes a
+successful result: an advertised checker must accept the exact payload.
 
 Downstream packages can register checked enclosure rules for their own unary
 real functions without modifying LeanCert's internal expression datatype.
@@ -55,6 +63,28 @@ example : ∀ x ∈ Set.Icc (0 : ℝ) 1, Real.sin x ≤ 1 := by
   leancert
 ```
 
+## Quick Python Example
+
+Install the self-contained SDK wheel and prove a bound without installing Lean:
+
+```bash
+pip install leancert
+```
+
+```python
+import leancert as lc
+from leancert import ast
+
+x = ast.var("x")
+result = lc.prove(x**2 <= 1, where={x: (0, 1)})
+
+if isinstance(result, lc.Verified):
+    print(result.claim_id)
+```
+
+The wheel bundles the matching LeanCert Bridge. A verified result retains its
+semantic claim identity, checked certificate, and exact build provenance.
+
 ## Install
 
 Add LeanCert as a Lake dependency:
@@ -79,17 +109,25 @@ lake update
 
 | Section | Description |
 |---|---|
-| [Getting Started](choosing-proof-shape.md) | Choose the right proof path before selecting modules |
+| [Getting Started](choosing-interface.md) | Choose Python or Lean, then prove a first claim |
+| [Python SDK](python/index.md) | Exact claims, typed outcomes, evidence export, and numerical workflows |
 | [Direct Automation](direct/leancert.md) | Start with `leancert`; use dedicated tactics as advanced controls |
 | [Proof Templates](proof-templates/overview.md) | Reusable certificate strategies and proof patterns |
 | [Domain Libraries](domains/overview.md) | Domain-specific certificate packages |
 | [Architecture and Trust](architecture/golden-theorems.md) | Why checkers imply theorems, and what is trusted |
 | [Reference](reference/imports.md) | Imports, tactics, and certificate API references |
 
-## Split Repositories
+## LeanCert Repositories
 
-This repo is Lean-only.
-The Python package and bridge release pipeline were moved out of this repo.
+The documentation covers one product family delivered through three
+repositories:
 
-- Python SDK: `https://github.com/alerad/leancert-python`
-- Bridge binaries: `https://github.com/alerad/leancert-bridge`
+- **Core:** [`alerad/leancert`](https://github.com/alerad/leancert) contains
+  the Lean definitions, checkers, and soundness theorems.
+- **Python SDK:** [`alerad/leancert-python`](https://github.com/alerad/leancert-python)
+  contains the semantic Python API, orchestration, result types, and exporters.
+- **Bridge:** [`alerad/leancert-bridge`](https://github.com/alerad/leancert-bridge)
+  packages the versioned checked interface used by SDK wheels.
+
+Repository separation controls releases and licensing; it does not divide the
+user documentation into disconnected products.

--- a/docs/python/adaptive/index.md
+++ b/docs/python/adaptive/index.md
@@ -1,0 +1,77 @@
+# Adaptive Verification
+
+!!! info "Capability status"
+    **Stability:** Experimental · **Authority:** Checked Bridge per accepted
+    leaf · **Split selection:** Untrusted heuristic ·
+    **Standalone unified replay:** No
+
+Adaptive verification decomposes a difficult box into smaller boxes, checks
+each leaf, and records the search tree. The Python scheduler can assign real
+Bridge processes to separate workers, so independent leaves can be checked
+concurrently.
+
+## A bound that benefits from decomposition
+
+The maximum of `x sin(x)` on `[0, 10]` lies just below `8`, but a coarse
+enclosure has to reason across several oscillations. The adaptive driver can
+split around useful algebraic regions and check the smaller leaves:
+
+```python
+from fractions import Fraction
+
+import leancert as lc
+
+# Adaptive verification currently uses the programmatic expression API.
+x = lc.var("x")
+expression = x * lc.sin(x)
+
+config = lc.AdaptiveConfig(
+    strategy=lc.SplitStrategy.ALGEBRAIC,
+    max_splits=64,
+    max_depth=12,
+    parallel=True,
+    max_workers=4,
+)
+
+with lc.Solver() as solver:
+    result = solver.verify_bound_adaptive(
+        expression,
+        {"x": (0, 10)},
+        upper=Fraction(8),
+        adaptive_config=config,
+    )
+
+print(result.verified)
+print(result.summary())
+print(result.tree_visualization(max_depth=3))
+```
+
+On the v1.0 release this closes through multiple checked leaves rather than a
+single sampled estimate.
+
+## Split strategies
+
+| Strategy | Selection rule |
+|---|---|
+| `BISECT` | Split the first axis at its midpoint |
+| `LARGEST_FIRST` | Split the widest axis |
+| `WORST_POINT` | Use optimizer diagnosis to choose an axis/point |
+| `GRADIENT_GUIDED` | Estimate midpoint gradients with batched finite differences |
+| `ALGEBRAIC` | Score heuristic critical-point, curvature, monotonicity, and dependency candidates |
+
+Checked interval automatic differentiation exists in the numerical toolkit,
+but the current gradient-guided splitter uses Python finite differences. Split
+choices affect search efficiency, not proof authority.
+
+## Parallel workers
+
+With the normal `LeanClient`, executor threads lazily receive distinct Bridge
+processes. A custom or fake client may deliberately retain shared behavior.
+
+## Read `verified` carefully
+
+An accepted leaf is backed by the advertised bound checker or checked adaptive
+optimizer. The aggregate `AdaptiveResult.certificate` is currently a legacy
+checked-leaf record, and `lean_proof` is a generated proof sketch. Neither is a
+standalone replayable v1 export. Use the stable semantic bound route when an
+independently rebuildable artifact is required.

--- a/docs/python/capabilities.md
+++ b/docs/python/capabilities.md
@@ -1,0 +1,45 @@
+# Python Capability Status
+
+LeanCert Python contains stable checked interfaces, lower-level numerical
+tools, compatibility APIs, and experimental orchestration. This matrix states
+which layer is allowed to authorize a success.
+
+| Surface | Stability | Authority | Standalone replay | Preferred use |
+|---|---|---|---:|---|
+| `prove()` exact bounds | Stable | Checked Bridge | Yes | Default bound API |
+| Unique nonlinear-system roots | Stable | Checked Bridge | Yes | Default system-root API |
+| Eventual reciprocal-power bounds | Stable | Checked Bridge | Yes | Default supported tail API |
+| Typed non-success outcomes | Stable | Checked Bridge/SDK validation | N/A | Always inspect the type |
+| Semantic AST and claim digests | Stable v1 schema | Deterministic SDK semantics | Included in exports | Modeling and identity |
+| `eval_interval`, `find_bounds` | Legacy/programmatic | Checked numerical operation | No | Exploration and advanced control |
+| Scalar roots and integration | Legacy/programmatic | Checked numerical operation | No | Advanced numerical workflows |
+| Checked derivative enclosures | Programmatic | Checked numerical operation | No | Sensitivity and Lipschitz analysis |
+| Adaptive leaf verification | Experimental | Checked Bridge per leaf | No unified replay | Difficult bound search |
+| Adaptive split selection | Experimental | Search heuristic | No | Candidate domain decomposition |
+| NN forward enclosures | Programmatic | Checked numerical operation | No | ReLU-network bounds |
+| PyTorch/Transformer conversion | Experimental | Untrusted conversion/code generation | Depends on downstream build | Candidate model export |
+| Quantifier synthesis | Experimental/mixed | Varies by operation | Usually no | Witness discovery |
+| Monte Carlo and bug triage | Diagnostic | None | No | Finding examples, never proof |
+| Legacy proof-sketch rendering | Legacy | None until separately compiled | No | Human inspection only |
+
+## Authority vocabulary
+
+**Kernel-replayable** means an exported fixed certificate can be rebuilt as a
+pinned Lean project and checked with `#assert_trust kernel`.
+
+**Checked Bridge** means the negotiated LeanCert checker accepted the exact
+request payload. It does not mean Python search became trusted.
+
+**Checked numerical operation** means the Bridge returned a rigorous numerical
+result, but the Python result family does not currently export the complete
+standalone replay project promised by the v1 semantic API.
+
+**Search heuristic** and **diagnostic** outputs may propose candidates or find
+concrete violations. They cannot authorize `Verified`.
+
+## Compatibility APIs
+
+The pre-1.0 `lc.var`, `Solver`, and numerical result classes remain useful.
+New proof-oriented code should begin with `leancert.ast` and `leancert.prove`.
+The two expression systems are intentionally not accepted interchangeably;
+explicit adapters preserve the migration boundary.

--- a/docs/python/evidence/export.md
+++ b/docs/python/evidence/export.md
@@ -1,0 +1,75 @@
+# Export and Independently Verify Evidence
+
+!!! info "Capability status"
+    **Stability:** Stable · **Exportable families:** checked bounds, unique
+    system roots, and eventual bounds · **Trust class:** Kernel
+
+A replayable Python result retains the complete fixed checker input. Exporting
+turns it into a small pinned Lean project:
+
+```python
+import leancert as lc
+from leancert import ast
+
+x = ast.var("x")
+result = lc.prove(x**2 <= 1, where={x: (0, 1)})
+
+if isinstance(result, lc.Verified):
+    export = result.export_lean_project("verified-bound", verify=True)
+    print(type(export).__name__)
+```
+
+The directory contains:
+
+```text
+verified-bound/
+├── LeanCertExport.lean
+├── artifact.json
+├── certificate.json
+├── claim.json
+├── provenance.json
+├── lakefile.toml
+├── lean-toolchain
+└── README.md
+```
+
+## Verify later or elsewhere
+
+```bash
+leancert verify verified-bound
+leancert verify exported-proofs/ --require-trust kernel
+leancert verify exported-proofs/ --format json
+```
+
+Verification checks the integrity envelope and semantic claim digest before it
+invokes Lake. It runs the exported project's explicit target and does not rerun
+numerical search.
+
+## Reproducible is not automatically air-gapped
+
+The project pins its Lean toolchain and LeanCert source revision. A machine
+still needs those dependencies, either from the network, an existing cache, or
+a separately prepared vendor/archive process. Copying only the export directory
+to a pristine offline machine is not sufficient by itself.
+
+## Atomic and typed failures
+
+Project creation occurs through a temporary sibling directory. Build rejection,
+missing tooling, and resource limits leave no partial project at the requested
+destination and return distinct result types.
+
+The verification CLI uses stable exit codes:
+
+| Code | Meaning |
+|---:|---|
+| `0` | Every discovered artifact rebuilt successfully |
+| `1` | Lean rejected at least one theorem |
+| `2` | An artifact or command argument was malformed |
+| `3` | Required verification infrastructure was unavailable |
+| `4` | A rebuild exceeded its resource limit |
+
+## What is not exportable
+
+Legacy numerical `Certificate` objects, adaptive checked-leaf records, and
+generated proof sketches are not silently treated as replayable v1 artifacts.
+The result type explicitly reports when export is unsupported.

--- a/docs/python/evidence/trust.md
+++ b/docs/python/evidence/trust.md
@@ -1,0 +1,66 @@
+# Python Trust Boundary
+
+Python is responsible for modeling, orchestration, candidate search, and
+presentation. It is not allowed to declare its own heuristic candidate a
+proof.
+
+```text
+exact Python claim
+        │
+        ▼
+normalization + semantic digest
+        │
+        ▼
+untrusted candidate search ──► candidate bound / cutoff / Krawczyk data
+                                      │
+                                      ▼
+                           negotiated LeanCert checker
+                                      │
+                         accepted fixed certificate
+                                      │
+                  ┌───────────────────┴───────────────────┐
+                  ▼                                       ▼
+       typed Python outcome                    exported Lean project
+                                                          │
+                                                          ▼
+                                             independent kernel rebuild
+```
+
+## What `Verified` means
+
+A v1 `Verified` result means:
+
+- the request was a closed, normalized exact claim;
+- the Bridge advertised the operation and schema used;
+- the response matched the negotiated backend, certificate schema, and
+  verification route;
+- the certificate payload agreed with the original request; and
+- the named checked operation accepted it.
+
+It does not mean every Python module, search heuristic, NumPy operation, or
+compiler optimization has joined the trusted computing base.
+
+## Compiled checking and kernel replay are separate events
+
+The bundled Bridge reports a `compiled_checker` verification route. Exporting
+and rebuilding a fixed certificate is a second event: the generated project
+kernel-reduces the retained checker input, applies the soundness theorem, and
+uses `#assert_trust kernel` on the resulting theorem.
+
+Do not relabel the original Bridge result as a kernel-replay result. Record both
+events when an audit requires both.
+
+## Provenance
+
+Verified outcomes retain:
+
+- Python claim digest and normalized claim;
+- Bridge API and protocol versions;
+- Lean and LeanCert versions;
+- source revision and source digest;
+- build-environment digest and profile;
+- resolved Lean toolchain and LeanCert dependency revision; and
+- the negotiated capability identity.
+
+Run `leancert doctor --json` to inspect the installed runtime independently of
+a particular proof.

--- a/docs/python/experimental.md
+++ b/docs/python/experimental.md
@@ -1,0 +1,52 @@
+# Experimental Search and Synthesis
+
+These APIs are valuable research tools, but they mix checked numerical
+subroutines with untrusted candidate generation and generated proof text. Use
+the [capability matrix](capabilities.md) to avoid treating every successful
+search result as a replayable theorem.
+
+## Quantifier and witness synthesis
+
+The SDK can search for:
+
+- a bound witnessing an `exists-forall` pattern;
+- minimum, maximum, and scalar-root candidates;
+- thresholds for selected epsilon values;
+- epsilon/delta candidates using derivative enclosures; and
+- sign certificates over boxes.
+
+Some final numerical subclaims are checked by Bridge operations. Generated
+Lean strings are not automatically authoritative unless separately compiled
+against the intended theorem. In particular, finding thresholds for a finite
+list of epsilon values is not a proof of a universally quantified statement
+over every positive epsilon.
+
+## Counterexample discovery
+
+Adaptive bound checking can ask a global optimizer for a candidate point,
+refine it locally, and then submit a point box to the checked bound operation.
+Only a rigorously enclosed violation becomes `Rejected`. A plausible point
+that does not check remains candidate information.
+
+## Bug-triage utilities
+
+`IntervalExplosionDetector`, `CounterexampleVerifier`, `CommentAnalyzer`, and
+`BugValidator` can help rank reports, evaluate concrete points, sample a
+domain, and recognize Solidity comments suggesting intentional protections.
+
+These are diagnostics:
+
+- Monte Carlo success never establishes a universal property;
+- failure to reproduce a violation never proves a report false;
+- comment text never overrides mathematical evidence; and
+- the midpoint currently used by one validator may miss a nearby violation.
+
+Keep diagnostic verdicts separate from LeanCert's typed proof outcomes in user
+interfaces and stored reports.
+
+## Proof sketches
+
+Legacy `Certificate.render_proof_sketch()`, adaptive `lean_proof`, and witness
+`to_lean_tactic()` methods produce human-readable starting points. They are not
+the same artifact as `Verified.export_lean_project()` and should not be
+advertised as independently checked until a Lean build accepts them.

--- a/docs/python/experimental.md
+++ b/docs/python/experimental.md
@@ -21,6 +21,9 @@ against the intended theorem. In particular, finding thresholds for a finite
 list of epsilon values is not a proof of a universally quantified statement
 over every positive epsilon.
 
+See [Quantifier and Witness Synthesis](experimental/quantifiers.md) for the
+callable API and its authority boundary.
+
 ## Counterexample discovery
 
 Adaptive bound checking can ask a global optimizer for a candidate point,
@@ -43,6 +46,9 @@ These are diagnostics:
 
 Keep diagnostic verdicts separate from LeanCert's typed proof outcomes in user
 interfaces and stored reports.
+
+See [Bug-Report Triage](experimental/bug-validation.md) for examples that keep
+these heuristics in their proper diagnostic role.
 
 ## Proof sketches
 

--- a/docs/python/experimental/bug-validation.md
+++ b/docs/python/experimental/bug-validation.md
@@ -1,0 +1,44 @@
+# Bug-Report Triage
+
+LeanCert includes utilities for ranking suspected numerical bugs: interval
+explosion detection, concrete-point evaluation, Monte Carlo sampling, and
+comment-pattern analysis.
+
+!!! danger "Diagnostic only"
+    **Stability:** Experimental · **Authority:** Heuristic · **Proof value:**
+    None unless a separate checked operation returns mathematical evidence
+
+```python
+import leancert as lc
+
+source = """
+function quote(uint amount) internal pure returns (uint) {
+    // Floor division is intentional for slippage protection.
+    return amount / 100;
+}
+"""
+
+intentional, pattern, comment = (
+    lc.CommentAnalyzer().is_intentional_protection(source)
+)
+print(intentional, pattern, comment)
+```
+
+This can route a report to a human reviewer, but comment prose cannot prove
+that code is safe or that an observed violation is intentional.
+
+For combined triage, construct a `BugReport` with the alleged expression,
+domain, claimed violation, optional bound result, and optional source text,
+then call `BugValidator.validate()`.
+
+Interpret conservatively:
+
+- Monte Carlo success never establishes a universal claim;
+- a midpoint sample can miss a nearby counterexample;
+- failure to reproduce is not proof of absence;
+- a `FALSE_POSITIVE` diagnostic verdict is not a Lean theorem; and
+- only a rigorously enclosed violating point justifies mathematical rejection.
+
+This page is intentionally outside the primary proving tutorial. It serves
+auditors and research tooling without blurring heuristic triage with the
+checked Bridge boundary.

--- a/docs/python/experimental/quantifiers.md
+++ b/docs/python/experimental/quantifiers.md
@@ -1,0 +1,40 @@
+# Quantifier and Witness Synthesis
+
+The experimental synthesizer reduces structured goals to optimization, bound,
+root, or derivative operations and proposes witnesses.
+
+!!! warning "Authority boundary"
+    **Stability:** Experimental · **Authority:** Mixed search and checked
+    numerical subclaims · **Standalone replay:** No for generated `lean_proof`
+
+```python
+import leancert as lc
+
+x = lc.var("x")
+with lc.Solver() as solver:
+    result = lc.synthesize_bound(
+        solver,
+        x * x,
+        {"x": (-1, 1)},
+        abs_bound=True,
+    )
+
+if result.success:
+    witness = result.witnesses[0]
+    print(witness.variable, witness.value, witness.rigorous_bounds)
+```
+
+Convenience functions include `synthesize_bound`, `synthesize_minimum`,
+`synthesize_maximum`, `prove_sign`, and `prove_limit`. `QuantifierResult`
+exposes `pattern`, `success`, `witnesses`, `message`, an optional legacy
+certificate, and optional generated `lean_proof` text.
+
+The name `prove_limit` is historical: its workflow searches and checks selected
+numeric obligations, and generated proof text is not automatically compiled.
+A finite set of epsilon checks is not a theorem quantified over every positive
+epsilon. Treat the result as synthesis output until a concrete theorem is
+independently accepted by Lean.
+
+The direct `Solver.synthesize_min_witness`, `synthesize_max_witness`, and
+`synthesize_root_witness` methods expose lower-level candidate results. Keep
+candidate coordinates separate from rigorous value enclosures in reports.

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -1,0 +1,67 @@
+# Python SDK
+
+The LeanCert Python SDK turns exact mathematical claims into typed, checked
+outcomes. It combines Python's modeling and search ecosystem with LeanCert's
+small, explicit certificate checkers.
+
+```python
+import leancert as lc
+from leancert import ast
+
+x = ast.var("x")
+result = lc.prove(ast.sin(x) <= 1, where={x: (0, 1)})
+
+match result:
+    case lc.Verified():
+        print("checked", result.claim_id)
+    case lc.Inconclusive(reason=reason):
+        print("not proved", reason)
+    case _:
+        print(type(result).__name__)
+```
+
+## Three layers, deliberately separated
+
+1. **Semantic claims** use immutable, exact `leancert.ast` objects and the
+   stable `leancert.prove()` front door.
+2. **Checked numerical tools** expose interval evaluation, optimization,
+   scalar roots, integration, automatic differentiation, and neural-network
+   propagation through the programmatic `Solver` API.
+3. **Search and diagnostics** include adaptive splitting, candidate
+   generation, sampling, and proof sketches. These tools help find evidence;
+   they do not silently promote heuristic success into proof.
+
+Start with the first layer. Move to the numerical toolkit only when you need
+control below `prove()`.
+
+## What is stable in v1
+
+- Exact one- and two-sided bounds over closed rational boxes
+- Unique nonlinear-system roots checked with exact rational Krawczyk data
+- Eventual reciprocal-power bounds over natural-number tails
+- Typed non-success outcomes
+- Stable semantic claim digests
+- Complete Bridge build provenance
+- Standalone Lean-project export for the three replayable result families
+- Independent artifact verification with stable CLI exit codes
+
+See the [capability status matrix](capabilities.md) before relying on adaptive,
+quantifier-synthesis, neural-network, or legacy APIs.
+
+## Installation
+
+```bash
+pip install leancert
+leancert doctor
+```
+
+Supported wheels include the matching Bridge binary, so ordinary SDK use does
+not require a local Lean installation. Rebuilding exported projects does
+require Lake and access to the pinned Lean dependencies.
+
+## Next steps
+
+- [Prove a first claim](quickstart.md)
+- [Model exact mathematics](modeling.md)
+- [Understand typed outcomes](proving/outcomes.md)
+- [Export independently rebuildable evidence](evidence/export.md)

--- a/docs/python/ml/export.md
+++ b/docs/python/ml/export.md
@@ -1,0 +1,33 @@
+# Exporting Network Definitions to Lean
+
+Network classes can emit Lean source definitions after rationalizing Python or
+PyTorch parameters.
+
+!!! info "Capability status"
+    **Stability:** Model-dependent · **Authority:** Untrusted source generation
+    until compiled and connected to a theorem · **Standalone replay:** Not by
+    `export_lean()` alone
+
+```python
+from pathlib import Path
+
+lean_source = network.export_lean("ControllerNet")
+Path("ControllerNet.lean").write_text(lean_source, encoding="utf-8")
+```
+
+`TwoLayerReLUNetwork`, `SequentialNetwork`, and selected Transformer structures
+provide `export_lean()` methods. `float_to_rational()` and conversion helpers
+approximate floating parameters with bounded-denominator rationals.
+
+Record the source model digest and framework version, layer ordering,
+rationalization policy, generated-source digest, and LeanCert/Bridge revisions
+used for later checks.
+
+Generated definitions are inputs to Lean development, not proof that the
+rational model matches the original floating runtime or that a property holds.
+Compile the source, state the intended theorem, and use checked operations or
+Lean proofs for authority.
+
+This differs from `Verified.export_lean_project()`: that method packages a
+specific semantic claim and fixed replay certificate for independent kernel
+verification.

--- a/docs/python/ml/index.md
+++ b/docs/python/ml/index.md
@@ -41,6 +41,20 @@ print(enclosures)
 against those output enclosures. It returns a Boolean rather than the v1
 semantic `ProofResult` hierarchy.
 
+```python
+within_limits = lc.verify_nn_bounds(
+    network,
+    {"x0": (-1, 1), "x1": (-1, 1)},
+    output_lower=0,
+    output_upper=8,
+    precision=-80,
+)
+```
+
+The Boolean means the returned checked enclosure fits inside the requested
+limits. Retain the enclosures when an audit needs the actual evidence rather
+than a convenience decision.
+
 ## PyTorch conversion
 
 Install the optional dependency:
@@ -67,6 +81,10 @@ without attention. The exporter can emit Lean definitions and optionally use
 Affine LayerNorm infrastructure, but this is not a claim that arbitrary
 end-to-end PyTorch Transformers are automatically verified by
 `forward_interval`.
+
+For generated Lean definitions, rationalization policy, and the distinction
+between source export and checked proof artifacts, see
+[Lean Source Export](export.md).
 
 ## Backends
 

--- a/docs/python/ml/index.md
+++ b/docs/python/ml/index.md
@@ -1,0 +1,75 @@
+# Machine-Learning Verification
+
+LeanCert Python can rationalize model parameters, export selected PyTorch
+structures, and compute checked forward interval enclosures for sequential
+ReLU networks.
+
+!!! info "Capability status"
+    **ReLU forward enclosures:** Programmatic checked operation ·
+    **PyTorch conversion:** Untrusted preprocessing ·
+    **Transformer support:** Experimental Lean source export
+
+## A small ReLU network
+
+```python
+import numpy as np
+
+import leancert as lc
+from leancert.nn import Layer, TwoLayerReLUNetwork
+
+hidden = Layer.from_numpy(
+    weights=np.array([[2.0, -2.0], [-2.0, 2.0]]),
+    bias=np.array([0.0, 0.0]),
+    activation="relu",
+)
+output = Layer.from_numpy(
+    weights=np.array([[1.0, 1.0]]),
+    bias=np.array([0.0]),
+    activation="none",
+)
+network = TwoLayerReLUNetwork(hidden, output, input_names=["x0", "x1"])
+
+enclosures = lc.forward_interval(
+    network,
+    {"x0": (-1, 1), "x1": (-1, 1)},
+    precision=-80,
+)
+print(enclosures)
+```
+
+`verify_nn_bounds` is a convenience wrapper that checks requested limits
+against those output enclosures. It returns a Boolean rather than the v1
+semantic `ProofResult` hierarchy.
+
+## PyTorch conversion
+
+Install the optional dependency:
+
+```bash
+pip install 'leancert[pytorch]'
+```
+
+The SDK can extract:
+
+- two-layer linear/ReLU/linear models;
+- sequential multi-layer perceptrons; and
+- selected Transformer encoder feed-forward and LayerNorm structures.
+
+Floating parameters are rationalized with a configurable denominator limit.
+Conversion is candidate preparation, not a proof that the rationalized model
+is semantically identical to every behavior of the original runtime model.
+Record the source-model identity and rationalization policy in serious audits.
+
+## Transformer scope
+
+`TransformerBlock` currently models a simplified encoder feed-forward portion
+without attention. The exporter can emit Lean definitions and optionally use
+Affine LayerNorm infrastructure, but this is not a claim that arbitrary
+end-to-end PyTorch Transformers are automatically verified by
+`forward_interval`.
+
+## Backends
+
+The Python `forward_interval` convenience API currently targets the Bridge's
+Dyadic sequential-network endpoint. Rational and Affine expression backends do
+not imply selectable end-to-end NN propagation through this function.

--- a/docs/python/modeling.md
+++ b/docs/python/modeling.md
@@ -1,0 +1,90 @@
+# Exact Mathematical Modeling
+
+`leancert.ast` is an immutable, bridge-independent meaning layer. Constructing
+an AST does not run a solver and never sets a `verified` flag.
+
+!!! info "Capability status"
+    **Stability:** Stable schema v1 · **Authority:** Deterministic semantic
+    model · **Proof status:** No AST object is a proof by itself
+
+## Exact values
+
+Semantic claims accept exact integers, `Fraction`, `Decimal`, and decimal
+strings through `ast.rational`:
+
+```python
+from decimal import Decimal
+from fractions import Fraction
+from leancert import ast
+
+a = ast.rational("0.1")
+b = ast.rational(Decimal("0.2"))
+c = ast.rational(Fraction(3, 10))
+
+assert ast.semantically_equal(a + b, c)
+```
+
+Python floats are rejected because the SDK cannot infer which decimal value a
+binary approximation was intended to mean:
+
+```python
+from leancert import ast
+
+ast.rational(0.1)  # raises InexactFloatError
+```
+
+## Symbols have identity
+
+```python
+x = ast.var("x")
+n = ast.var("n", sort=ast.NATURAL)
+```
+
+Variables are identified by a namespace/name `SymbolId`; their display name is
+metadata. This prevents accidental capture when claims are normalized or
+serialized.
+
+## Domains close claims
+
+```python
+from leancert import ast
+
+x = ast.var("x")
+open_claim = ast.sin(x) <= 1
+closed_claim = ast.close_claim(open_claim, where={x: (0, 1)})
+```
+
+`close_claim` requires exact coverage of every free variable. The canonical
+encoding uses binder depths, so alpha-renaming a bound variable does not change
+the claim's meaning.
+
+## Canonical bytes and semantic digests
+
+```python
+payload = ast.encode_canonical(closed_claim)
+digest = ast.semantic_digest(closed_claim)
+round_trip = ast.decode_canonical_strict(payload)
+
+assert ast.alpha_equivalent(closed_claim, round_trip)
+```
+
+A semantic digest commits to the AST schema version, normalization version,
+canonical semantic bytes, and resolved external declaration identities.
+Annotations and source spans do not affect it.
+
+## Built-in and external functions
+
+The semantic AST includes arithmetic, transcendental and special functions,
+vectors, integrals, derivatives, root claims, and eventual claims. Presence in
+the AST means the expression has a stable meaning; it does **not** guarantee
+that the currently negotiated Bridge exposes a checker for every claim shape.
+
+External functions require package, revision, semantic, and declaration
+identity before they can receive an authoritative semantic digest.
+
+## Legacy expressions
+
+`lc.var("x")` constructs the pre-1.0 programmatic expression type. Use
+`ast.legacy_expression`, `ast.legacy_interval`, `ast.legacy_box`, or
+`ast.legacy_bound_claim` when migrating intentionally. Conversion is not
+verification.

--- a/docs/python/modeling.md
+++ b/docs/python/modeling.md
@@ -58,6 +58,12 @@ closed_claim = ast.close_claim(open_claim, where={x: (0, 1)})
 encoding uses binder depths, so alpha-renaming a bound variable does not change
 the claim's meaning.
 
+Use `ast.interval(lo, hi)` and `ast.box(...)` when a first-class semantic
+domain is clearer than tuple shorthand. The older `leancert.Interval` and
+`leancert.Box` types belong to the programmatic `Solver` compatibility API;
+they are not interchangeable with semantic AST domains without an explicit
+legacy conversion.
+
 ## Canonical bytes and semantic digests
 
 ```python
@@ -88,3 +94,7 @@ identity before they can receive an authoritative semantic digest.
 `ast.legacy_expression`, `ast.legacy_interval`, `ast.legacy_box`, or
 `ast.legacy_bound_claim` when migrating intentionally. Conversion is not
 verification.
+
+For programmatically generated legacy expressions, see
+[Simplification](modeling/simplification.md). For advanced semantic-AST
+inspection and rewrites, see [AST Utilities](reference/ast-utilities.md).

--- a/docs/python/modeling/simplification.md
+++ b/docs/python/modeling/simplification.md
@@ -1,0 +1,39 @@
+# Simplifying Programmatic Expressions
+
+`leancert.simplify()` and `leancert.expand()` operate on the legacy
+programmatic `Expr` type. They can expose cancellation before interval
+evaluation and thereby reduce dependency over-approximation.
+
+!!! info "Capability status"
+    **Stability:** Compatibility API · **Authority:** Untrusted symbolic
+    preprocessing · **Standalone replay:** No
+
+```python
+import leancert as lc
+
+x = lc.var("x")
+raw = x * 100 + 5 - x * 100
+reduced = lc.simplify(raw)
+
+print(raw)
+print(reduced)  # 5
+```
+
+`simplify()` folds constants, removes identities, propagates zero, collects
+polynomial terms, and recursively simplifies supported transcendental
+arguments. `expand()` distributes polynomial products before collection.
+
+This is a search-quality optimization, not evidence. Submit the resulting
+expression to a checked operation for an authoritative enclosure or proof
+outcome.
+
+!!! warning "Partial expressions"
+    Algebraic identities can require domain assumptions. In particular, the
+    compatibility simplifier currently rewrites `x / x` to `1`; that identity
+    is valid only where `x != 0`. Do not use simplification to bypass domain
+    checks, and prefer the semantic AST plus checked proving path for new
+    safety-critical claims.
+
+The semantic `leancert.ast` layer has separate normalization and canonical
+encoding. `lc.simplify()` does not accept semantic AST nodes and does not alter
+a semantic claim digest.

--- a/docs/python/proving/bounds.md
+++ b/docs/python/proving/bounds.md
@@ -1,0 +1,68 @@
+# Exact Bounds Without Floating-Point Ambiguity
+
+!!! info "Capability status"
+    **Stability:** Stable · **Authority:** Checked Bridge ·
+    **Standalone replay:** Yes
+
+Python's `0.1 + 0.2` example is harmless in ordinary numerical work but an
+ambiguous foundation for a formal claim. LeanCert therefore rejects floats at
+the semantic boundary and requires the intended exact number.
+
+## The exact claim
+
+```python
+import leancert as lc
+from leancert import ast
+
+x = ast.var("x")
+three_halves = ast.rational("1.5")
+
+result = lc.prove(
+    ast.sin(x) ** 2 <= 1,
+    where={x: (-three_halves, three_halves)},
+)
+
+if isinstance(result, lc.Verified):
+    print("checked:", result.claim_id)
+```
+
+The decimal spelling `"1.5"` denotes exactly `3/2`. The result covers every
+real number in `[-3/2, 3/2]`; no input grid is sampled.
+
+## The deliberate failure mode
+
+```python
+lc.prove(
+    ast.sin(x) <= 0.5,
+    where={x: (0, 1)},
+)
+```
+
+This raises `InexactFloatError` before a Bridge request is sent. Write
+`ast.rational("0.5")` or `Fraction(1, 2)` to state the intended proposition.
+
+## Two-sided bounds
+
+```python
+from fractions import Fraction
+
+result = lc.prove(
+    ast.all_of(x >= -1, x <= 1),
+    where={x: (Fraction(-1), Fraction(1))},
+)
+```
+
+Each direction is checked exactly once and retained as separate evidence.
+
+## Export the receipt
+
+```python
+if isinstance(result, lc.Verified):
+    exported = result.export_lean_project("verified-bound", verify=True)
+    print(type(exported).__name__)
+```
+
+The exported project contains the normalized claim, fixed checker payload,
+certificate, provenance, Lean source, toolchain pin, and integrity manifest.
+It can be rebuilt without rerunning Python search. An offline rebuild requires
+the pinned Lean toolchain and dependencies to have been cached or vendored.

--- a/docs/python/proving/eventual-bounds.md
+++ b/docs/python/proving/eventual-bounds.md
@@ -1,0 +1,66 @@
+# Proving a Bound All the Way to Infinity
+
+!!! info "Capability status"
+    **Stability:** Stable for nonnegative rational reciprocal-power tails ·
+    **Authority:** Checked Bridge · **Standalone replay:** Yes
+
+A finite numerical grid cannot establish a proposition for every sufficiently
+large natural number. LeanCert's eventual-bound route searches for a cutoff
+and checks one exact certificate for the complete infinite tail.
+
+```python
+from fractions import Fraction
+
+import leancert as lc
+from leancert import ast
+
+n = ast.var("n", sort=ast.NATURAL)
+claim = ast.eventually(
+    Fraction(5) / n**2 <= Fraction(1, 100),
+    variable=n,
+)
+
+result = lc.prove(claim)
+
+if isinstance(result, lc.VerifiedEventualBound):
+    print(f"proved for every n >= {result.cutoff}")
+```
+
+For this claim the checked cutoff is `23`: every natural `n >= 23` satisfies
+`5 / n² <= 1/100`.
+
+## Discovery is not the proof
+
+Python may use exponential search followed by refinement to discover the
+smallest accepted cutoff within its search budget. The exported evidence
+retains the final cutoff, coefficient, exponent, and bound—not the search
+procedure.
+
+Supply an explicit cutoff or control the search budget when needed:
+
+```python
+result = lc.prove(
+    ast.eventually(
+        Fraction(5) / n**2 <= Fraction(1, 100),
+        variable=n,
+        cutoff=23,
+    ),
+    config=lc.ProveConfig(eventual=lc.EventualConfig(max_checks=100)),
+)
+```
+
+## Supported shape
+
+The stable route covers nonnegative rational multiples of reciprocal natural
+powers against an exact rational upper bound. A valid but unsupported general
+asymptotic expression returns `UnsupportedEventualBound`; it is not sampled and
+reported as proof.
+
+## Export
+
+```python
+if isinstance(result, lc.VerifiedEventualBound):
+    result.export_lean_project("verified-tail", verify=True)
+```
+
+The exported theorem covers the entire natural-number tail.

--- a/docs/python/proving/index.md
+++ b/docs/python/proving/index.md
@@ -1,0 +1,48 @@
+# Checked Proving with `prove()`
+
+`leancert.prove()` is the stable front door for semantic claims. It:
+
+1. closes free variables with exact domains;
+2. normalizes the claim;
+3. computes a stable semantic identity;
+4. negotiates an advertised Bridge capability;
+5. validates the typed response and its authority; and
+6. returns a result whose class expresses the outcome.
+
+```python
+import leancert as lc
+from leancert import ast
+
+x = ast.var("x")
+result = lc.prove(ast.sin(x) <= 1, where={x: (0, 1)})
+```
+
+## Stable checked families
+
+- [Exact one- and two-sided bounds](bounds.md)
+- [Unique nonlinear-system roots](system-roots.md)
+- [Eventual reciprocal-power bounds](eventual-bounds.md)
+
+Valid semantic claims outside these routes return a typed `Unsupported`
+outcome where possible. They are not silently weakened or sent to an unrelated
+discovery API.
+
+## Effort controls
+
+```python
+result = lc.prove(
+    claim,
+    where={x: (0, 1)},
+    config=lc.ProveConfig(taylor_depth=16),
+)
+```
+
+`ProveConfig` controls effort accepted by the negotiated checker schema. It is
+not a request to replace the advertised checker or verification route.
+
+## Exact claims versus approximate candidates
+
+The proposition and its domain remain exact. Some workflows, such as nonlinear
+system roots, may accept NumPy/SciPy values as **untrusted candidate data**.
+Those values are deterministically rationalized, and a poor candidate can only
+be rejected; it cannot mint a successful result.

--- a/docs/python/proving/outcomes.md
+++ b/docs/python/proving/outcomes.md
@@ -1,0 +1,46 @@
+# Typed Outcomes
+
+LeanCert does not encode every mathematical non-success as `False`. The result
+type tells you exactly what was established.
+
+| Outcome | Meaning |
+|---|---|
+| `Verified` | Every requested bound was accepted by the checked route |
+| `Rejected` | A rigorously checked point enclosure violates the requested bound |
+| `Inconclusive` | Available enclosures did not decide the claim |
+| `DomainObstruction` | The checked evaluator could not establish domain validity |
+| `Unsupported` | No negotiated checked route supports the expression or claim shape |
+| `VerifiedSystemRoot` | Exact Krawczyk evidence proves one unique system root in the box |
+| `CandidateRejected` | An untrusted Krawczyk candidate failed; the mathematical claim remains open |
+| `VerifiedEventualBound` | A fixed cutoff certificate proves the complete tail |
+| `InconclusiveEventualBound` | The checked route did not close the supplied/discovered cutoff |
+
+## Pattern-match the outcome
+
+```python
+import leancert as lc
+
+match result:
+    case lc.Verified():
+        print("proved", result.claim_id)
+    case lc.Rejected(counterexample=counterexample):
+        print("disproved at", counterexample.values)
+    case lc.Inconclusive(reason=reason):
+        print("claim remains open:", reason)
+    case lc.DomainObstruction(reason=reason):
+        print("domain issue:", reason)
+    case lc.Unsupported(reason=reason):
+        print("unsupported:", reason)
+```
+
+## Truthiness is not the primary API
+
+Some compatibility objects implement Boolean conversion. New code should use
+`isinstance` or structural matching so that an unsupported operation is never
+confused with a refuted proposition.
+
+## Candidate rejection is not refutation
+
+Search algorithms propose boxes, points, cutoffs, or preconditioners. Rejecting
+one proposal says only that this proposal did not certify the claim. A genuine
+`Rejected` bound contains a checked counterexample enclosure.

--- a/docs/python/proving/system-roots.md
+++ b/docs/python/proving/system-roots.md
@@ -1,0 +1,70 @@
+# Proving a Unique Nonlinear-System Root
+
+!!! info "Capability status"
+    **Stability:** Stable · **Authority:** Checked Bridge ·
+    **Standalone replay:** Yes · **Current maximum dimension:** 4
+
+An approximate solver can suggest a zero. LeanCert can instead certify that a
+whole box contains exactly one zero of a square nonlinear system.
+
+Consider
+
+\[
+x^2 + y - 2 = 0, \qquad x + y^2 - 2 = 0.
+\]
+
+The point `(1, 1)` is a root, but the claim below is stronger: it states that
+there is no second root hiding anywhere in the surrounding rational box.
+
+```python
+from fractions import Fraction
+
+import leancert as lc
+from leancert import ast
+
+x, y = ast.var("x"), ast.var("y")
+
+claim = ast.unique_system_root(
+    (x**2 + y - 2, x + y**2 - 2),
+    variables=(x, y),
+    within=ast.box({
+        x: (Fraction(9, 10), Fraction(11, 10)),
+        y: (Fraction(9, 10), Fraction(11, 10)),
+    }),
+)
+
+result = lc.prove(claim)
+
+if isinstance(result, lc.VerifiedSystemRoot):
+    print("unique root certified in", result.certificate.box)
+    print("rational center:", result.certificate.center)
+```
+
+## Why the search remains untrusted
+
+Python searches for a center and approximate inverse Jacobian. Users may also
+supply candidates produced by NumPy or SciPy:
+
+```python
+candidate = lc.KrawczykCandidate.from_arrays(center, inverse_jacobian)
+config = lc.ProveConfig(
+    system_root=lc.SystemRootConfig(candidate=candidate),
+)
+result = lc.prove(claim, config=config)
+```
+
+Float candidates are rationalized and treated only as proposals. Success is
+authorized by exact rational `LeanCert.Engine.krawczykCheck` evidence. A
+well-formed but inadequate candidate returns `CandidateRejected`, which is
+neither verification nor proof that no root exists.
+
+## Export
+
+```python
+if isinstance(result, lc.VerifiedSystemRoot):
+    result.export_lean_project("verified-system-root", verify=True)
+```
+
+The project reconstructs the fixed Krawczyk certificate, kernel-reduces its
+checker, applies the corresponding soundness theorem, and asserts kernel trust
+on the resulting theorem.

--- a/docs/python/proving/system-roots.md
+++ b/docs/python/proving/system-roots.md
@@ -2,7 +2,11 @@
 
 !!! info "Capability status"
     **Stability:** Stable · **Authority:** Checked Bridge ·
-    **Standalone replay:** Yes · **Current maximum dimension:** 4
+    **Standalone replay:** Yes · **Released Bridge capability ceiling:** 4
+
+`SystemRootConfig.max_dimension` defaults to `4` and can lower the caller's
+accepted search dimension. It cannot expand the capability advertised by the
+connected Bridge. Effective support is limited by both values.
 
 An approximate solver can suggest a zero. LeanCert can instead certify that a
 whole box contains exactly one zero of a square nonlinear system.

--- a/docs/python/quickstart.md
+++ b/docs/python/quickstart.md
@@ -1,0 +1,75 @@
+# Python Quickstart
+
+!!! info "Capability status"
+    **Stability:** Stable · **Authority:** Checked Bridge ·
+    **Standalone replay:** Supported for verified bounds, system roots, and
+    eventual bounds
+
+## Install and diagnose
+
+```bash
+python -m pip install leancert
+leancert doctor
+```
+
+A healthy release reports the bundled binary, Bridge Contract, replay support,
+checked adaptive capability, and release provenance.
+
+## Prove an exact claim
+
+```python
+from fractions import Fraction
+
+import leancert as lc
+from leancert import ast
+
+x = ast.var("x")
+claim = x**2 <= Fraction(9, 4)
+
+result = lc.prove(
+    claim,
+    where={x: (Fraction(-3, 2), Fraction(3, 2))},
+)
+
+if isinstance(result, lc.Verified):
+    print("verified:", result.claim_id)
+    print("Lean:", result.provenance.lean_version)
+else:
+    print(type(result).__name__, result.reason)
+```
+
+This proves one proposition for every real input in the closed interval. It is
+not a sample-based test.
+
+## Inspect the evidence
+
+For a bound result, each requested direction has its own checked evidence:
+
+```python
+if isinstance(result, lc.Verified):
+    for check in result.checks:
+        print(check.direction, check.enclosure)
+        print(check.replay_certificate.checker)
+```
+
+## Export it
+
+```python
+if isinstance(result, lc.Verified):
+    export = result.export_lean_project("verified-bound", verify=True)
+    print(type(export).__name__)
+```
+
+`verify=True` creates the pinned project and asks Lake to build its explicit
+target. Use `leancert verify verified-bound` to audit it again later. Exported
+projects do not rerun Python search.
+
+## Never collapse non-success into `False`
+
+```python
+result = lc.prove(x - x <= -1, where={x: (0, 1)})
+assert isinstance(result, lc.Inconclusive)
+```
+
+LeanCert distinguishes failure to establish a claim from a checked
+counterexample. Continue with [typed outcomes](proving/outcomes.md).

--- a/docs/python/reference/artifact-verification-api.md
+++ b/docs/python/reference/artifact-verification-api.md
@@ -1,0 +1,44 @@
+# Programmatic Artifact Verification
+
+The independent rebuild used by `leancert verify` is also a Python API.
+
+```python
+import leancert as lc
+
+projects = lc.discover_exported_projects(["./proof-artifacts"])
+report = lc.verify_exported_projects(
+    [str(path) for path in projects],
+    require_trust="kernel",
+    timeout=900,
+    fail_fast=True,
+)
+
+for artifact in report.artifacts:
+    print(artifact.path, artifact.status, artifact.claim_id)
+
+raise SystemExit(int(report.exit_code))
+```
+
+Discovery accepts project directories, parent trees, or an `artifact.json`
+path. It skips common build and virtual-environment directories and does not
+follow symlinked directories.
+
+`verify_exported_projects()` validates manifests and digests before invoking
+`lake build`. Statuses distinguish `verified`, `verification_failed`,
+`invalid_artifact`, `infrastructure_failure`, and `resource_limit`.
+`VerificationExitCode` maps these classes to stable process codes. A report is
+verified only when it contains at least one artifact and every artifact passes.
+
+## Programmatic doctor
+
+```python
+import leancert as lc
+
+report = lc.diagnose()
+for check in report.checks:
+    print(check.name, check.ok, check.detail)
+```
+
+`diagnose()` checks binary discovery, handshake/contract compatibility,
+replayable-bound support, checked-adaptive support, and release provenance.
+Health is installation evidence, not a mathematical proof result.

--- a/docs/python/reference/ast-utilities.md
+++ b/docs/python/reference/ast-utilities.md
@@ -1,0 +1,33 @@
+# AST Utilities
+
+The semantic AST includes deterministic traversal, transformation, validation,
+and capability-analysis helpers for tooling authors.
+
+```python
+from leancert import ast
+
+x = ast.var("x")
+claim = ast.close_claim(ast.sin(x) <= 1, where={x: (-1, 1)})
+
+print(ast.node_count(claim), ast.max_depth(claim))
+print(ast.free_variables(claim))
+requirements = ast.infer_requirements(claim)
+ast.validate_ast(claim)
+```
+
+Inspection helpers include `walk`, `children`, `fold`, `node_count`,
+`max_depth`, `free_variables`, `bound_variables`, `collect_functions`,
+`collect_constants`, `collect_external_functions`, and `contains_node_type`.
+They do not contact Bridge.
+
+`transform`, `map_expressions`, `substitute`, and `rename_symbol` return new
+immutable nodes. Validate and re-close transformed claims before proving them;
+a syntactic rewrite is not evidence of semantic equivalence.
+
+`infer_requirements` summarizes features a checker must support, while
+`check_capabilities` compares requirements with an advertised capability set.
+This is preflight analysis, not verification. The negotiated operation and
+returned typed outcome remain authoritative.
+
+Canonical encoding, strict decoding, normalization, alpha equivalence, and
+semantic digests are covered in [Exact Mathematical Modeling](../modeling.md).

--- a/docs/python/reference/cli.md
+++ b/docs/python/reference/cli.md
@@ -1,0 +1,43 @@
+# CLI and Diagnostics
+
+## `leancert doctor`
+
+```bash
+leancert doctor
+leancert doctor --json
+leancert doctor --bridge /absolute/path/to/lean_bridge
+```
+
+The diagnostic checks:
+
+- binary discovery;
+- Bridge Contract compatibility;
+- replayable bound support;
+- the checked adaptive route; and
+- release source/environment provenance.
+
+The command exits `0` only when every required check is healthy.
+
+## `leancert verify`
+
+```bash
+leancert verify verified-bound
+leancert verify exports/ --require-trust kernel
+leancert verify exports/ --timeout 1200 --fail-fast
+leancert verify exports/ --format json
+```
+
+Directories are searched recursively for `leancert-export/1` manifests while
+build directories are skipped. Verification checks artifact integrity before
+running the pinned Lake target.
+
+| Exit | Meaning |
+|---:|---|
+| `0` | All artifacts rebuilt |
+| `1` | Lean rejected an exported theorem |
+| `2` | Invalid artifact or command usage |
+| `3` | Missing verification infrastructure |
+| `4` | Resource limit exceeded |
+
+Machine-readable reports include artifact paths, claim identities, trust
+classes, outcomes, timing, and captured build output.

--- a/docs/python/reference/compatibility.md
+++ b/docs/python/reference/compatibility.md
@@ -1,0 +1,66 @@
+# Installation and Compatibility
+
+## Install
+
+```bash
+python -m pip install leancert
+```
+
+LeanCert Python 1.0 requires Python 3.10 or newer and depends on NumPy. PyTorch
+support is optional:
+
+```bash
+python -m pip install 'leancert[pytorch]'
+```
+
+## Bundled Bridge platforms
+
+The 1.0 release publishes wheels for:
+
+- Linux x86-64;
+- macOS arm64;
+- macOS x86-64; and
+- Windows x86-64.
+
+Supported wheels include a version-pinned `lean_bridge` binary. Installing from
+an sdist or running on an unsupported platform may require an explicitly built
+Bridge:
+
+```bash
+export LEANCERT_BRIDGE_PATH=/absolute/path/to/lean_bridge
+leancert doctor
+```
+
+## Contract negotiation
+
+The SDK checks the Bridge API major version, operation schemas, advertised
+capabilities, certificate families, backends, and verification routes before
+sending checked work. Unknown major versions and contradictory responses are
+rejected rather than guessed compatible.
+
+## Core, Bridge, and SDK versions
+
+The Python package, Bridge, and LeanCert Core have separate release numbers.
+Use `leancert doctor --json` or a result's `provenance` instead of inferring one
+component's version from another.
+
+## Legacy API migration
+
+The pre-1.0 API remains available:
+
+```python
+x = lc.var("x")
+with lc.Solver() as solver:
+    result = solver.find_bounds(x**2, {"x": (-1, 1)})
+```
+
+New proof-oriented code should use:
+
+```python
+x = ast.var("x")
+result = lc.prove(x**2 <= 1, where={x: (-1, 1)})
+```
+
+The semantic API adds exact input enforcement, claim normalization, stable
+identity, typed non-success, and replay export. Use explicit `ast.legacy_*`
+adapters when crossing the boundary.

--- a/docs/python/reference/configuration.md
+++ b/docs/python/reference/configuration.md
@@ -1,0 +1,53 @@
+# Configuration Reference
+
+LeanCert has two configuration families because semantic proving and the
+legacy numerical toolkit expose different contracts.
+
+## `ProveConfig`
+
+```python
+import leancert as lc
+
+config = lc.ProveConfig(
+    taylor_depth=14,
+    system_root=lc.SystemRootConfig(
+        max_iterations=12,
+        max_dimension=4,
+        precision_bits=28,
+    ),
+    eventual=lc.EventualConfig(max_checks=2000),
+)
+```
+
+| Field | Default | Meaning |
+|---|---:|---|
+| `taylor_depth` | `10` | non-negative checker effort for supported operations |
+| `system_root.max_iterations` | `8` | Krawczyk candidate-search refinements |
+| `system_root.max_dimension` | `4` | caller ceiling; cannot exceed Bridge capability |
+| `system_root.precision_bits` | `20` | candidate rationalization/search precision |
+| `system_root.candidate` | `None` | optional explicit `KrawczykCandidate` |
+| `eventual.max_checks` | `1000` | cutoff-search check budget |
+
+These settings control effort and candidate search. They do not let a caller
+invent a checker capability the Bridge did not advertise.
+
+## Toolkit `Config`
+
+`Config` controls legacy `Solver` operations: `taylor_depth`, `max_iters`,
+`tolerance`, `use_monotonicity`, `timeout_sec`, `backend`, backend-specific
+configuration, racing, incremental refinement, target bound, and timeout.
+
+Presets include:
+
+- `Config.low_precision()`, `medium_precision()`, `high_precision()`;
+- `Config.dyadic()`, `dyadic_fast()`, `dyadic_high_precision()`; and
+- `Config.affine()`, `affine_compact()`.
+
+`DyadicConfig` exposes `precision` and the compatibility `round_after_ops`
+field, with `ieee_double()`, `high_precision()`, and `fast()` presets.
+`AffineConfig` exposes `max_noise_symbols`, with `default()` and `compact()`.
+
+!!! warning "Exact input boundary"
+    `ProveConfig` never changes the rule that semantic values must be exact.
+    Toolkit configuration may accept floats for heuristic tolerances or search
+    inputs; that does not make those floats part of an exact semantic claim.

--- a/docs/python/reference/exceptions.md
+++ b/docs/python/reference/exceptions.md
@@ -1,0 +1,44 @@
+# Exceptions
+
+Semantic outcomes such as `Rejected` and `Inconclusive` are values, not
+exceptions. Exceptions represent malformed requests, compatibility wrapper
+behavior, protocol failures, or unavailable infrastructure.
+
+```python
+import leancert as lc
+from leancert.exceptions import ProtocolViolation
+
+try:
+    result = lc.prove(claim)
+except lc.DomainError as exc:
+    handle_bad_domain(exc)
+except ProtocolViolation as exc:
+    quarantine_bridge(exc)
+```
+
+All SDK exceptions derive from `LeanCertError`:
+
+- `CompilationError`: legacy expression compilation failed.
+- `DomainError`: a domain is invalid or incompatible.
+- `VerificationFailed`: a compatibility raising API established failure.
+- `VerificationInconclusive`: a compatibility raising API could not decide.
+- `VerificationTimeout`: the operation exceeded its time budget.
+- `BridgeError`: Bridge launch or communication failed.
+  - `ProtocolViolation`: the process contradicted the negotiated wire contract.
+  - `BridgeRemoteError`: a structured remote infrastructure error; inspect
+    `code` and `data`.
+- `ExpressionError`: expression construction or use failed.
+  - `UnsupportedExpressionError`
+  - `PartialFunctionError`
+
+Import `ProtocolViolation` and `BridgeRemoteError` from `leancert.exceptions`;
+do not depend on incidental root-package exposure.
+
+`leancert.ast` exports precise construction and decoding errors, including
+`AstValidationError`, `SortMismatch`, `DimensionMismatch`, `InexactFloatError`,
+`InvalidDomainError`, `FreeVariableError`, `AstDecodeError`, and capability or
+canonicalization errors. Catch the narrowest error your application can repair.
+
+Do not catch `LeanCertError` merely to turn every failure into “unverified.” A
+protocol violation and a mathematically inconclusive enclosure have entirely
+different operational meanings.

--- a/docs/python/reference/public-api.md
+++ b/docs/python/reference/public-api.md
@@ -1,0 +1,49 @@
+# Python Public API
+
+This inventory is organized by authority rather than presenting every package
+attribute as equally stable.
+
+## Semantic proving
+
+Use these for new proof-oriented code:
+
+- `leancert.prove`;
+- `ProveConfig`, `SystemRootConfig`, and `EventualConfig`;
+- `leancert.ast` claim, expression, domain, encoding, digest, and validation APIs;
+- typed outcomes including `Verified`, `Rejected`, `Inconclusive`,
+  `Unsupported`, `DomainObstruction`, `VerifiedSystemRoot`, and
+  `VerifiedEventualBound`; and
+- `Verified*.export_lean_project()`.
+
+## Programmatic numerical toolkit
+
+The context-managed `leancert.Solver` exposes checked numerical operations and
+legacy compatibility workflows:
+
+- `eval_interval`, `find_bounds`, `verify_bound`, `verify_bound_or_raise`;
+- `find_roots`, `find_unique_root`, `integrate`;
+- `compute_lipschitz_bound`, `diagnose_bound_failure`; and
+- adaptive verification and witness synthesis.
+
+See [Solver Toolkit](solver.md) and [Result Types](results.md).
+
+## Evidence and installation
+
+- `verify_exported_projects`, `discover_exported_projects`;
+- `diagnose`, `DoctorReport`, `DoctorCheck`; and
+- `leancert doctor` and `leancert verify`.
+
+## Modeling and ML helpers
+
+- legacy expressions such as `var`, `sin`, `cos`, `exp`, and `log`;
+- `Interval`, `Box`, `normalize_domain`, and `to_fraction`;
+- `simplify` and `expand`; and
+- network types plus `forward_interval` and `verify_nn_bounds`.
+
+Quantifier synthesis, adaptive internals, and bug-report triage are publicly
+callable but experimental. Import less-prominent helpers from their defining
+modules rather than relying on incidental root-package attributes. The
+presence of a name on `leancert` is not itself a proof-authority claim.
+
+The Lean-facing API is documented separately under
+[Supported Public API](../../reference/public-api.md).

--- a/docs/python/reference/results.md
+++ b/docs/python/reference/results.md
@@ -1,0 +1,48 @@
+# Result Types
+
+## Semantic proof outcomes
+
+Results from `prove()` have no Boolean truth value. Pattern-match the concrete
+type:
+
+```python
+import leancert as lc
+
+result = lc.prove(claim)
+if isinstance(result, lc.Verified):
+    ...
+elif isinstance(result, lc.Rejected):
+    ...
+elif isinstance(result, lc.Inconclusive):
+    ...
+```
+
+Bound outcomes retain per-check evidence and Bridge provenance. System-root
+and eventual-bound outcomes have their own typed families and replayable
+certificate payloads. See [Typed Outcomes](../proving/outcomes.md).
+
+## Toolkit numerical results
+
+| Type | Useful members |
+|---|---|
+| `BoundsResult` | exact `min_bound`/`max_bound`; float conveniences `min_lo`, `min_hi`, `max_lo`, `max_hi`; midpoint estimates `min_value`, `max_value` |
+| `RootInterval` | `interval`, `status`, `lo`, `hi`, `value`, `width` |
+| `RootsResult` | isolated root intervals and retained certificate |
+| `UniqueRootResult` | existence/uniqueness status, root interval, derivative evidence |
+| `IntegralResult` | exact enclosure, approximate value, and `error` convenience |
+| `LipschitzResult` | derivative enclosures and aggregate Lipschitz bound |
+| `WitnessPoint` | candidate coordinates, function value, and verification metadata |
+| `FailureDiagnosis` | margins, worst-point candidate, and suggested bounds |
+
+Float convenience properties are for display. Exact `Fraction` endpoints in
+the underlying `Interval` are the rigorous values.
+
+## Legacy certificates
+
+`Certificate.save()`, `Certificate.load()`, and `Certificate.hash()` support
+legacy JSON persistence. `render_proof_sketch()` is non-authoritative generated
+text. For portable kernel evidence, use `export_lean_project()` on a supported
+semantic typed outcome and independently rebuild it.
+
+`VerificationReport` contains `ArtifactVerification` entries and exposes
+`verified`, `verified_count`, `exit_code`, and `to_dict()`.

--- a/docs/python/reference/solver.md
+++ b/docs/python/reference/solver.md
@@ -1,0 +1,34 @@
+# Solver Toolkit Reference
+
+`Solver` owns a Bridge subprocess and provides the lower-level programmatic
+interface. Prefer a context manager so the subprocess is always closed.
+
+```python
+import leancert as lc
+
+x = lc.var("x")
+with lc.Solver() as solver:
+    enclosure = solver.eval_interval(x * x, {"x": (-2, 3)})
+    bounds = solver.find_bounds(x * x, {"x": (-2, 3)})
+```
+
+| Methods | Purpose | Typical result |
+|---|---|---|
+| `eval_interval`, `find_bounds` | rigorous enclosure and global bounds | `Interval`, `BoundsResult` |
+| `verify_bound` | typed checked lower/upper-bound decision | `Verified`, `Rejected`, `Inconclusive`, ... |
+| `verify_bound_or_raise` | compatibility exception wrapper | typed result or exception |
+| `find_roots`, `find_unique_root` | scalar isolation and uniqueness | `RootsResult`, `UniqueRootResult` |
+| `integrate` | verified integral enclosure | `IntegralResult` |
+| `compute_lipschitz_bound` | checked derivative enclosure | `LipschitzResult` |
+| `diagnose_bound_failure` | candidate explanation and suggested bounds | `FailureDiagnosis` |
+| `verify_bound_adaptive` | split-and-check orchestration | `AdaptiveResult` |
+| `synthesize_*_witness` | candidate witness search plus retained checks | witness result types |
+
+Method names such as `find_*` may combine untrusted search with checked leaves.
+Inspect the result type, its `verified` field where applicable, and retained
+certificate/provenance rather than inferring authority from successful return.
+Legacy `Certificate.render_proof_sketch()` is not equivalent to a rebuildable
+`Verified.export_lean_project()` artifact.
+
+Use the semantic `prove()` interface when you want a closed claim, claim
+digest, negotiated capability, and typed proof outcome as one workflow.

--- a/docs/python/toolkit.md
+++ b/docs/python/toolkit.md
@@ -1,0 +1,75 @@
+# Programmatic Numerical Toolkit
+
+The `Solver` API exposes checked numerical operations below the semantic
+`prove()` layer. It is useful for exploration, algorithm development, and
+advanced control, but most of its legacy result families do not yet provide
+the standalone replay contract of v1 semantic claims.
+
+!!! warning "Authority"
+    These are rigorous Bridge operations, not ordinary floating-point
+    estimates. Nevertheless, a legacy `Certificate` or rendered tactic string
+    is not automatically an independently rebuildable Lean theorem.
+
+## Lifecycle
+
+```python
+import leancert as lc
+
+x = lc.var("x")
+with lc.Solver() as solver:
+    enclosure = solver.eval_interval(lc.exp(x), {"x": (0, 1)})
+    bounds = solver.find_bounds(x * lc.sin(x), {"x": (0, 10)})
+```
+
+The context manager owns one Bridge process and closes it deterministically.
+
+## Operations
+
+| Operation | Purpose |
+|---|---|
+| `eval_interval` | Enclose an expression on a box |
+| `find_bounds` | Compute rigorous global min/max enclosures |
+| `find_roots` | Isolate scalar roots and distinguish confirmed/possible regions |
+| `find_unique_root` | Check interval-Newton contraction for a scalar root |
+| `integrate` | Compute rigorous one-dimensional integral bounds |
+| `compute_lipschitz_bound` | Enclose derivatives with checked forward AD |
+| `forward_interval` | Propagate intervals through sequential ReLU layers |
+
+## Arithmetic backends
+
+```python
+rational = lc.Config(backend=lc.Backend.RATIONAL)
+dyadic = lc.Config.dyadic(precision=-80)
+affine = lc.Config.affine()
+```
+
+- **Rational** uses exact fractions and can experience denominator growth.
+- **Dyadic** uses fixed-precision powers of two with outward rounding.
+- **Affine** tracks correlations between repeated variables to reduce the
+  dependency problem.
+
+The legacy solver can automatically select Affine arithmetic for expressions
+with repeated variables when `auto_affine` is enabled. Backend selection here
+does not imply that `prove()` exposes arbitrary backend choice; semantic proving
+uses the backend advertised by its checked capability.
+
+## Checked automatic differentiation
+
+```python
+with lc.Solver() as solver:
+    sensitivity = solver.compute_lipschitz_bound(
+        x**2,
+        {"x": (0, 1)},
+    )
+    print(sensitivity.gradient_bounds)
+```
+
+Derivative intervals are computed by the Bridge. When interpreting a scalar
+Lipschitz constant in several variables, document the norm convention used by
+the consuming argument.
+
+## Prefer semantic claims for durable proof APIs
+
+Use `lc.prove()` when the mathematical statement fits a stable checked claim
+family. It adds exact input discipline, normalized claim identity, typed
+non-success, complete provenance, and replayable export.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: LeanCert
-site_description: Certified numerical computation and bound verification for Lean 4.
+site_description: Certified numerical computation for Lean 4 and Python.
 site_url: https://docs.leancert.io
 repo_url: https://github.com/alerad/leancert
 repo_name: alerad/leancert
@@ -52,10 +52,33 @@ extra_javascript:
 nav:
   - Home: index.md
   - Getting Started:
-    - Quickstart: quickstart.md
+    - Choose Python or Lean: choosing-interface.md
+    - Python Quickstart: python/quickstart.md
+    - Lean Quickstart: quickstart.md
     - Choosing A Proof Shape: choosing-proof-shape.md
     - Curated Showcase: showcase.md
     - Failure Showcase: showcase-failures.md
+  - Python SDK:
+    - Overview: python/index.md
+    - Capability Status: python/capabilities.md
+    - Mathematical Modeling: python/modeling.md
+    - Checked Proving:
+      - Using prove(): python/proving/index.md
+      - Exact Bounds: python/proving/bounds.md
+      - Nonlinear System Roots: python/proving/system-roots.md
+      - Eventual Bounds: python/proving/eventual-bounds.md
+      - Typed Outcomes: python/proving/outcomes.md
+    - Evidence and Audit:
+      - Trust Boundary: python/evidence/trust.md
+      - Export and Independent Verification: python/evidence/export.md
+    - Numerical Toolkit: python/toolkit.md
+    - Adaptive Verification: python/adaptive/index.md
+    - Machine Learning: python/ml/index.md
+    - Experimental Workflows: python/experimental.md
+    - Reference:
+      - Installation and Compatibility: python/reference/compatibility.md
+      - CLI and Diagnostics: python/reference/cli.md
+    - Bridge Contract: architecture/python-bridge.md
   - Direct Automation:
     - Using leancert: direct/leancert.md
     - Bounds and Inequalities: direct/bounds.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,9 @@ nav:
   - Python SDK:
     - Overview: python/index.md
     - Capability Status: python/capabilities.md
-    - Mathematical Modeling: python/modeling.md
+    - Mathematical Modeling:
+      - Exact AST and Domains: python/modeling.md
+      - Simplification: python/modeling/simplification.md
     - Checked Proving:
       - Using prove(): python/proving/index.md
       - Exact Bounds: python/proving/bounds.md
@@ -73,9 +75,21 @@ nav:
       - Export and Independent Verification: python/evidence/export.md
     - Numerical Toolkit: python/toolkit.md
     - Adaptive Verification: python/adaptive/index.md
-    - Machine Learning: python/ml/index.md
-    - Experimental Workflows: python/experimental.md
+    - Machine Learning:
+      - Verification: python/ml/index.md
+      - Lean Source Export: python/ml/export.md
+    - Experimental Workflows:
+      - Status and Boundaries: python/experimental.md
+      - Quantifier and Witness Synthesis: python/experimental/quantifiers.md
+      - Bug-Report Triage: python/experimental/bug-validation.md
     - Reference:
+      - Python Public API: python/reference/public-api.md
+      - Solver Toolkit: python/reference/solver.md
+      - Configuration: python/reference/configuration.md
+      - Result Types: python/reference/results.md
+      - Exceptions: python/reference/exceptions.md
+      - AST Utilities: python/reference/ast-utilities.md
+      - Programmatic Artifact Verification: python/reference/artifact-verification-api.md
       - Installation and Compatibility: python/reference/compatibility.md
       - CLI and Diagnostics: python/reference/cli.md
     - Bridge Contract: architecture/python-bridge.md


### PR DESCRIPTION
## Summary

Add first-class Python SDK documentation to docs.leancert.io and present Python
and Lean as two interfaces to the same checked numerical foundations.

## Included

- add Python installation and quickstart guides
- document exact semantic modeling and float rejection
- document checked bounds, nonlinear system roots, and eventual bounds
- explain typed outcomes and candidate-versus-proof distinctions
- document evidence export, kernel rebuilding, and provenance
- add the programmatic numerical toolkit and backend guide
- document adaptive verification with an executed multi-leaf example
- describe ReLU, PyTorch, and current Transformer support accurately
- separate experimental synthesis and diagnostic utilities
- add platform, compatibility, CLI, and Bridge Contract references
- add a capability matrix describing stability, authority, and replayability
- update the homepage and README to expose the Python workflow

## Trust-model improvements

The documentation explicitly distinguishes:

- checked Bridge outcomes
- independently kernel-replayable artifacts
- checked numerical APIs without standalone replay
- untrusted candidate search
- diagnostic sampling and bug triage
- legacy proof sketches
