### PR TITLE
fix: report false numerical claims without internal failures

### DIFF
--- a/LeanCert.lean
+++ b/LeanCert.lean
@@ -90,6 +90,10 @@ import LeanCert.Meta.ProveSupported
 import LeanCert.Meta.ToExpr
 
 -- Tactics
+-- Keep the documented stable tactic umbrella in the default `LeanCert` build.
+-- Importing its individual implementation modules here is not equivalent:
+-- downstream `import LeanCert.Tactic` requires `LeanCert/Tactic.olean` itself.
+import LeanCert.Tactic
 import LeanCert.Tactic.Interval
 import LeanCert.Tactic.Discovery
 -- Counter-example hunting

--- a/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
+++ b/LeanCert/Tactic/LeanCert/Diagnostic/Render.lean
@@ -118,12 +118,18 @@ def routerFailure (verbosity : DiagnosticVerbosity) : RouterFailure → String
             Run `leancert?` on the same goal for the attempted strategies and \
             detailed next steps."
       | .explain =>
+          let refutationAdvice :=
+            if intent == .intervalBound then
+              "\n• Use `interval_refute` to search for a certified counterexample."
+            else if intent == .pointInequality then
+              "\n• Reverse the comparison and run `leancert` to certify the opposite bound."
+            else ""
           s!"LeanCert recognized: {intentLabel intent}\n\nAttempts:\n\
             {attemptLedger attempts}\n\nBudget: spent {spent} of {budget}\n\nNext steps:\n\
             • Check whether the requested statement is true.\n\
             • Increase `(taylorDepth := ...)`, `(subdivisions := ...)`, or \
-              `(maxIterations := ...)` when the corresponding attempt was inconclusive.\n\
-            • Use `interval_refute` to search for a certified counterexample."
+              `(maxIterations := ...)` when the corresponding attempt was inconclusive.\
+            {refutationAdvice}"
   | .certifiedRefutation intent? evidence =>
       let recognized := intent?.map (fun intent =>
         s!"LeanCert recognized: {intentLabel intent}\n\n") |>.getD ""

--- a/LeanCert/Tactic/LeanCert/Integral.lean
+++ b/LeanCert/Tactic/LeanCert/Integral.lean
@@ -61,6 +61,7 @@ structure IntegralOutcome where
 /-- Typed failures from exact and partition-based integral solvers. -/
 inductive IntegralFailure where
   | unsupported (detail : String)
+  | falseEquality (actual claimed : ℚ)
   | domainObstruction (detail : String)
   | exhausted (start maximum : Nat) (lastPartitions : Option Nat)
       (lastEnclosure : Option IntervalRat) (attempts : Nat)
@@ -143,6 +144,11 @@ private def exactIntegralAttemptTyped (parsed : ParsedIntegralGoal) :
   let some poly := QPoly.ofExpr astValue
     | return .error <| .unsupported "integrand is not a rational polynomial"
   let value := poly.integralRat a b
+  if parsed.comparison == .eq then
+    let some claimed ← LeanCert.Meta.Numeral.toRat? parsed.bound
+      | return .error <| .unsupported "equality target is not rational"
+    if value != claimed then
+      return .error <| .falseEquality value claimed
   try
     let checkType ← mkAppM ``Eq #[
       ← mkAppM ``QPoly.checkExactIntegral #[reified.ast, toExpr a, toExpr b, toExpr value],
@@ -412,6 +418,9 @@ syntax (name := integralExactTac) "integral_exact" : tactic
 unsafe def elabIntegralExact : Tactic := fun _ => do
   match ← integralExactCoreTyped with
   | .ok _ => pure ()
+  | .error (.falseEquality actual claimed) =>
+      throwError "integral_exact: The statement is false. Computed integral: \
+        {actual}; claimed: {claimed}."
   | .error failure => throwError "integral_exact: {repr failure}"
 
 end LeanCert.Tactic

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -519,6 +519,11 @@ private def integralFailureToAttempt (solver : Name) :
     IntegralFailure → AttemptFailure
   | .unsupported detail =>
       .unsupported { expression := "interval integral", detail := some detail }
+  | .falseEquality actual claimed =>
+      .refuted {
+        witness := "exact rational integral evaluation"
+        detail := some s!"The computed integral is {actual}, not {claimed}."
+      }
   | .domainObstruction detail =>
       .domainObstruction { source := unknownDomainSource, reason := detail }
   | .exhausted start maximum _lastPartitions lastEnclosure attempts =>
@@ -1218,6 +1223,48 @@ private def preparedReified? (prepared : Semantic.PreparedGoal) (source : Lean.E
     | .unsupported .. | .deferred .. => pure ()
   return none
 
+/-- Prove the opposite of a closed scalar comparison with the same checked
+point-enclosure path used by the ordinary portfolio.  The proof goal is
+temporary: successful verification is retained only as diagnostic evidence,
+and the caller's complete tactic state is restored before returning. -/
+private def certifiedPointRefutation?
+    (semantic : Semantic.SemanticGoal)
+    (cfg : LeanCertConfig) : TacticM (Option Diagnostic.RefutationEvidence) := do
+  let .point spec := semantic
+    | return none
+  let mut opposites : Array Lean.Expr := #[]
+  match spec.comparison with
+  | .lt => opposites := opposites.push (← mkAppM ``LE.le #[spec.rhs, spec.lhs])
+  | .le => opposites := opposites.push (← mkAppM ``LT.lt #[spec.rhs, spec.lhs])
+  | .eq =>
+      opposites := opposites.push (← mkAppM ``LT.lt #[spec.lhs, spec.rhs])
+      opposites := opposites.push (← mkAppM ``LT.lt #[spec.rhs, spec.lhs])
+  | .ne => return none
+  let original ← saveState
+  try
+    for opposite in opposites do
+      for depth in #[cfg.taylorDepth, cfg.taylorDepth + 10] do
+        original.restore
+        let proofGoal ← mkFreshExprMVar opposite
+        setGoals [proofGoal.mvarId!]
+        match ← pointAttemptTyped depth with
+        | .ok execution =>
+            let rendered := toString (← Meta.ppExpr opposite)
+            original.restore
+            return some {
+              witness := s!"opposite comparison `{rendered}`"
+              verifier := execution.verifier
+              detail := some "LeanCert certified this opposite comparison with a checked \
+                point-enclosure proof."
+            }
+        | .error _ => pure ()
+    original.restore
+    return none
+  catch error =>
+    original.restore
+    trace[LeanCert.router] "closed-comparison refutation failed: {error.toMessageData}"
+    return none
+
 /-- Search for a checked rational witness after a unary bound portfolio fails.
 
 This is diagnostic evidence, not a proof attempt: the original goal state is
@@ -1676,6 +1723,9 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
         failures := failures.push (solver.plan.strategy, outcome)
         enforceAttemptDisposition verbosity intent outcome
 
+  if let some refutation ← certifiedPointRefutation? semantic cfg then
+    throwRouterFailure verbosity <|
+      Diagnostic.RouterFailure.certifiedRefutation (some intent) refutation
   if let some refutation ← certifiedBoundRefutation? semantic prepared cfg then
     throwRouterFailure verbosity <|
       Diagnostic.RouterFailure.certifiedRefutation (some intent) refutation

--- a/LeanCert/Test/LeanCertIntegrals.lean
+++ b/LeanCert/Test/LeanCertIntegrals.lean
@@ -37,6 +37,42 @@ example : (3 / 10 : ℝ) ≤ (∫ x in (0 : ℝ)..1, x ^ 2) ∧
     (∫ x in (0 : ℝ)..1, x ^ 2) ≤ 2 / 5 := by
   leancert
 
+/-! False rational-polynomial equalities are ordinary refutations, not proof
+transport failures.  These cover a monomial, a linear term, and a constant. -/
+
+/--
+error: integral_exact: The statement is false. Computed integral: 1/4; claimed: 1/3.
+-/
+#guard_msgs in
+example : (∫ x in (0 : ℝ)..1, x ^ 3) = 1 / 3 := by
+  integral_exact
+
+/--
+error: integral_exact: The statement is false. Computed integral: 1/2; claimed: 1/5.
+-/
+#guard_msgs in
+example : (∫ x in (0 : ℝ)..1, x) = 1 / 5 := by
+  integral_exact
+
+/--
+error: integral_exact: The statement is false. Computed integral: 1; claimed: 2.
+-/
+#guard_msgs in
+example : (∫ _x in (0 : ℝ)..1, (1 : ℝ)) = 2 := by
+  integral_exact
+
+/--
+error: LeanCert recognized: definite integral bound
+
+The statement is false.
+
+Certified counterexample: exact rational integral evaluation
+The computed integral is 1/2, not 1/5.
+-/
+#guard_msgs in
+example : (∫ x in (0 : ℝ)..1, x) = 1 / 5 := by
+  leancert?
+
 private def shiftedSquare (x : ℝ) : ℝ := (x - 1) ^ 2
 
 example : (∫ x in (0 : ℝ)..2, shiftedSquare x) = 2 / 3 := by

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -1366,26 +1366,25 @@ error: LeanCert recognized a conjunction, but child 2 of 2 failed: closed numeri
 
 LeanCert recognized: closed numerical comparison
 
-Attempts:
-  1. exact normalization
-     solver left 1 proof obligation(s):
-False
-  2. direct point enclosure (Taylor depth 10)
-     The candidate certificate was rejected by its checker.
-Try increasing `taylorDepth`, enabling subdivision, or using the corresponding dedicated tactic for finer control.
-  3. direct point enclosure (Taylor depth 20)
-     The candidate certificate was rejected by its checker.
-Try increasing `taylorDepth`, enabling subdivision, or using the corresponding dedicated tactic for finer control.
+The statement is false.
 
-Budget: spent 3 of 6
-
-Next steps:
-• Check whether the requested statement is true.
-• Increase `(taylorDepth := ...)`, `(subdivisions := ...)`, or `(maxIterations := ...)` when the corresponding attempt was inconclusive.
-• Use `interval_refute` to search for a certified counterexample.
+Certified counterexample: opposite comparison `1 ≤ 2`
+LeanCert certified this opposite comparison with a checked point-enclosure proof.
 -/
 #guard_msgs in
 example : ((1 : ℝ) < 2) ∧ ((2 : ℝ) < 1) := by
+  leancert?
+
+/--
+error: LeanCert recognized: closed numerical comparison
+
+The statement is false.
+
+Certified counterexample: opposite comparison `2 ≤ Real.exp 1`
+LeanCert certified this opposite comparison with a checked point-enclosure proof.
+-/
+#guard_msgs in
+example : Real.exp 1 < 2 := by
   leancert?
 
 -- Question mode proves the goal and reports the winning dedicated tactic.


### PR DESCRIPTION
## Summary

- classify false rational-polynomial integral equalities before proof transport and report the exact computed and claimed values
- automatically refute false closed scalar comparisons by kernel-checking the opposite point bound
- only recommend interval_refute for goal shapes it accepts
- make the default LeanCert root depend on the documented LeanCert.Tactic umbrella
- add regressions for three false integrals and Real.exp 1 < 2

## User-visible behavior

- integral_exact now reports: The statement is false. Computed integral: 1/2; claimed: 1/5.
- leancert? on Real.exp 1 < 2 now reports a checked proof of the opposite comparison 2 ≤ Real.exp 1
- lake build LeanCert now produces LeanCert/Tactic.olean, so import LeanCert.Tactic works immediately

## Validation

- lake build LeanCert.Test.LeanCertRouter LeanCert.Test.LeanCertIntegrals LeanCert.Test.ReadmeTest
- removed the generated LeanCert/Tactic.olean, ran lake build LeanCert, and confirmed the umbrella artifact was recreated
- lake build FunctionalTests: 3,822 jobs passed
- git diff --check