### PR TITLE
Coordinate adaptive numerical refinement

### DIFF
--- a/LeanCert/Benchmark/Harness.lean
+++ b/LeanCert/Benchmark/Harness.lean
@@ -46,7 +46,7 @@ structure Config where
 def usage : String := "LeanCert benchmark harness\n\n\
 Usage: lake exe leancert-bench [options]\n\n\
 Options:\n\
-  --suite smoke|evaluation|ad|algebra|dyadic-subdivision|heavy|scaling|full|end-to-end|all\n\
+  --suite smoke|evaluation|ad|algebra|dyadic-subdivision|numerical-refinement|heavy|scaling|full|end-to-end|all\n\
                               Select benchmark suite (default: smoke)\n\
   --case TEXT                Run cases whose names contain TEXT\n\
   --samples N                Timed samples per case (default: 10)\n\

--- a/LeanCert/Benchmark/Main.lean
+++ b/LeanCert/Benchmark/Main.lean
@@ -9,6 +9,7 @@ import LeanCert.Benchmark.Suites.Krawczyk
 import LeanCert.Benchmark.Suites.DomainAwareAD
 import LeanCert.Benchmark.Suites.AlgebraicBezout
 import LeanCert.Benchmark.Suites.DyadicSubdivision
+import LeanCert.Benchmark.Suites.NumericalRefinement
 
 namespace LeanCert.Benchmark
 
@@ -19,7 +20,7 @@ def main (args : List String) : IO UInt32 := do
       return if message = usage then 0 else 1
   | .ok cfg => runBenchmarks cfg (Evaluation.cases ++ Integration.cases ++
       Krawczyk.cases ++ DomainAwareAD.cases ++ AlgebraicBezout.cases ++
-      DyadicSubdivision.cases)
+      DyadicSubdivision.cases ++ NumericalRefinement.cases)
 
 end LeanCert.Benchmark
 

--- a/LeanCert/Benchmark/Suites/NumericalRefinement.lean
+++ b/LeanCert/Benchmark/Suites/NumericalRefinement.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert.Benchmark.Harness
+import LeanCert.API.Bounds
+import LeanCert.Tactic.NumericalRefinement
+
+/-!
+# Coordinated numerical-refinement benchmarks
+
+These compiled checker benchmarks distinguish a cheap first-stage success from
+a tight bound which requires the complete precision/Taylor schedule. They
+measure candidate checking only, not tactic elaboration or kernel proof replay.
+-/
+
+namespace LeanCert.Benchmark.NumericalRefinement
+
+open LeanCert LeanCert.Core LeanCert.Tactic
+
+private def unit : IntervalRat := ⟨0, 1, by norm_num⟩
+private def exponential : Expr := .exp (.var 0)
+private def looseUpper : ℚ := 3
+private def tightUpper : ℚ :=
+  2718281828459045235360287472 / 1000000000000000000000000000
+
+private def checkedAt (bound : ℚ) (precision : Int) (taylorDepth : Nat) : Bool :=
+  LeanCert.API.Bounds.checkUpperBound exponential unit bound {
+    dyadicExponent := precision
+    taylorDepth
+  }
+
+private def runFixed (bound : ℚ) (precision : Int) (taylorDepth : Nat)
+    (expected : Bool) : IO Outcome := do
+  let actual := checkedAt bound precision taylorDepth
+  if actual = expected then
+    return {
+      status := if actual then "success" else "rejected"
+      backendUsed := some "dyadic"
+    }
+  return {
+    status := "unexpected_result"
+    backendUsed := some "dyadic"
+    error := some s!"expected {expected}, got {actual}"
+  }
+
+private def firstSuccessfulStage (bound : ℚ) :
+    List NumericalRefinementStage → Option NumericalRefinementStage
+  | [] => none
+  | stage :: rest =>
+      if checkedAt bound stage.dyadicPrecision stage.taylorDepth then
+        some stage
+      else
+        firstSuccessfulStage bound rest
+
+private def runAdaptive (bound : ℚ) : IO Outcome := do
+  let policy := NumericalRefinementPolicy.adaptive 10 0
+  match firstSuccessfulStage bound policy.stages with
+  | none =>
+      return {
+        status := "schedule_exhausted"
+        backendUsed := some "dyadic"
+        error := some "no numerical-refinement stage certified the bound"
+      }
+  | some stage =>
+      return {
+        status := "success"
+        backendUsed := some s!"dyadic-stage-{stage.index}"
+      }
+
+private def refinementCase (name : String) (parameters : List (String × String))
+    (expectedStatus : String := "success") (run : IO Outcome) : Case := {
+  name := s!"numerical_refinement.{name}"
+  family := "numerical_refinement"
+  tier := "micro"
+  layer := .checkedAPI
+  backendRequested := "dyadic"
+  suites := ["numerical-refinement", "all"]
+  parameters
+  input := { astNodes := 2, astDepth := 2, variableCount := 1 }
+  innerIterations := 10
+  expectedStatus
+  run
+}
+
+def cases : List Case := [
+  refinementCase "loose.fixed_-80_taylor_30"
+    [("schedule", "fixed"), ("precision", "-80"), ("taylor_depth", "30")]
+    (run := runFixed looseUpper (-80) 30 true),
+  refinementCase "loose.adaptive_first_stage"
+    [("schedule", "adaptive"), ("expected_stage", "0")]
+    (run := runAdaptive looseUpper),
+  refinementCase "tight.fixed_-80_rejected"
+    [("schedule", "fixed"), ("precision", "-80"), ("taylor_depth", "30")]
+    (expectedStatus := "rejected") (run := runFixed tightUpper (-80) 30 false),
+  refinementCase "tight.fixed_-117_taylor_30"
+    [("schedule", "fixed"), ("precision", "-117"), ("taylor_depth", "30")]
+    (run := runFixed tightUpper (-117) 30 true),
+  refinementCase "tight.adaptive_final_stage"
+    [("schedule", "adaptive"), ("expected_stage", "2")]
+    (run := runAdaptive tightUpper)
+]
+
+end LeanCert.Benchmark.NumericalRefinement

--- a/LeanCert/Tactic/IntervalAuto.lean
+++ b/LeanCert/Tactic/IntervalAuto.lean
@@ -75,24 +75,6 @@ elab "interval_auto" depth:(num)? t:(leancertTrustItem)? : tactic => do
       intervalDecideWithConnectives (depth.map (·.getNat))
     else
       trace[interval_decide] "interval_auto: detected quantified goal, using certify_bound"
-      match depth with
-      | some n => intervalBoundCore n.getNat
-      | none =>
-        let depths := [10, 15, 20, 25, 30]
-        let goalState ← saveState
-        let mut lastError : Option Exception := none
-        for d in depths do
-          try
-            restoreState goalState
-            trace[interval_decide] "Trying Taylor depth {d}..."
-            intervalBoundCore d
-            trace[interval_decide] "Success with Taylor depth {d}"
-            return
-          catch e =>
-            lastError := some e
-            continue
-        match lastError with
-        | some e => throw e
-        | none => throwError "interval_auto: All precision levels failed"
+      certifyBoundWithDepth (depth.map (·.getNat))
 
 end LeanCert.Tactic.Auto

--- a/LeanCert/Tactic/IntervalAuto/Bound.lean
+++ b/LeanCert/Tactic/IntervalAuto/Bound.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
 import LeanCert.Tactic.IntervalAuto.Basic
+import LeanCert.Tactic.NumericalRefinement
 import LeanCert.Tactic.Verification
 import LeanCert.Validity.Bounds
 import LeanCert.Validity.DyadicBounds
@@ -253,7 +254,7 @@ private def closeBoundTransport (goal : MVarId) (proof : Lean.Expr)
 def tryDyadicBoundImpl (goal : MVarId) (reified : LeanCert.Meta.ReifyReport)
     (boundRat : Lean.Expr)
     (intervalInfo : IntervalInfo) (taylorDepth : Nat)
-    (isStrict isLower : Bool) :
+    (isStrict isLower : Bool) (precision : Int := -80) :
     TacticM (Except IntervalBoundFailure (Option DyadicBoundOutcome)) := do
   let saved ← saveState
   let ast := reified.expr
@@ -263,7 +264,7 @@ def tryDyadicBoundImpl (goal : MVarId) (reified : LeanCert.Meta.ReifyReport)
       | false, true  => (``LeanCert.Validity.verify_lower_bound_dyadic_checked, ``LeanCert.Validity.checkLowerBoundDyadicChecked)
       | true,  false => (``LeanCert.Validity.verify_strict_upper_bound_dyadic_checked, ``LeanCert.Validity.checkStrictUpperBoundDyadicChecked)
       | true,  true  => (``LeanCert.Validity.verify_strict_lower_bound_dyadic_checked, ``LeanCert.Validity.checkStrictLowerBoundDyadicChecked)
-    let prec : Int := -80
+    let prec := precision
     let precExpr := toExpr prec
     let depthExpr := toExpr taylorDepth
     let precLeZeroProof ← mkDecideProof (← mkAppM ``LE.le #[precExpr, toExpr (0 : Int)])
@@ -1146,13 +1147,11 @@ def intervalBoundRationalCoreTyped (taylorDepth : Nat) :
   | .forallGt _ intervalInfo func bound =>
       rationalBoundAttemptTyped goal intervalInfo func bound taylorDepth true true
 
-/-- Typed direct-bound entry point.
-
-The Dyadic branch is isolated internally. Rational proof construction runs
-once on success. Only after a Rational failure do we evaluate its checker
-directly to distinguish an ordinary inconclusive enclosure from a valid
-certificate whose proof transport failed. -/
-def intervalBoundCoreTyped (taylorDepth : Nat) :
+/-- Direct typed bound attempt at an explicit Dyadic precision and Taylor
+depth. The Rational fallback runs only after that Dyadic attempt is
+inconclusive. Rational proof construction runs once on success. -/
+def intervalBoundCoreTypedAt (precision : Int) (taylorDepth : Nat)
+    (rationalFallback : Bool := true) :
     TacticM (Except IntervalBoundFailure IntervalBoundOutcome) := do
   let original ← saveState
   intervalNormCore
@@ -1194,7 +1193,7 @@ def intervalBoundCoreTyped (taylorDepth : Nat) :
           return .error <| .unsupported (toString func)
             "Dyadic preparation produced no expression"
       tryDyadicBoundImpl normalizedGoal reified boundRat intervalInfo taylorDepth
-        isStrict isLower
+        isStrict isLower precision
   let dyadicResult ←
     match boundGoal with
     | .forallLe _ intervalInfo func bound =>
@@ -1218,67 +1217,94 @@ def intervalBoundCoreTyped (taylorDepth : Nat) :
         precision := some outcome.precision
         taylorDepth := outcome.taylorDepth
       }
-  | .ok none => pure ()
+  | .ok none =>
+      original.restore
+      if rationalFallback then
+        intervalBoundRationalCoreTyped taylorDepth
+      else
+        return .error <| .inconclusive
+          s!"The Dyadic checker was inconclusive at precision {precision} and \
+            Taylor depth {taylorDepth}."
+
+/-- Compatibility entry point retaining the historical fixed `-80` Dyadic
+attempt before Rational fallback. New adaptive callers should use
+`intervalBoundAdaptiveCoreTyped`. -/
+def intervalBoundCoreTyped (taylorDepth : Nat) :
+    TacticM (Except IntervalBoundFailure IntervalBoundOutcome) :=
+  intervalBoundCoreTypedAt (-80) taylorDepth
+
+/-- Try coordinated Dyadic stages in increasing refinement order, then run the
+Rational fallback once at the final Taylor depth. Each attempt is isolated in
+the original tactic state. -/
+def intervalBoundAdaptiveCoreTyped (policy : NumericalRefinementPolicy) :
+    TacticM (Except IntervalBoundFailure IntervalBoundOutcome) := do
+  let original ← saveState
+  let stages := policy.stages
+  let mut lastFailure : Option IntervalBoundFailure := none
+  for stage in stages do
+    original.restore
+    match ← intervalBoundCoreTypedAt stage.dyadicPrecision stage.taylorDepth false with
+    | .ok outcome => return .ok outcome
+    | .error failure@(.inconclusive ..) =>
+        lastFailure := some failure
+    | .error failure =>
+        original.restore
+        return .error failure
   original.restore
-  intervalBoundRationalCoreTyped taylorDepth
+  match stages.getLast? with
+  | some stage => intervalBoundRationalCoreTyped stage.taylorDepth
+  | none => return .error <| lastFailure.getD <|
+      .inconclusive "the numerical refinement policy contains no stages"
 
 /-! ## Tactic Syntax -/
 
-/-- Core of `certify_bound`: fixed depth when given, else adaptive depth search. -/
+private def IntervalBoundFailure.message : IntervalBoundFailure → MessageData
+  | .unsupported expression detail =>
+      m!"certify_bound: unsupported expression {expression}:\n{detail}"
+  | .inconclusive detail => m!"certify_bound: {detail}"
+  | .transportFailure detail =>
+      m!"certify_bound: proof transport failed:\n{detail}"
+  | .internalFailure detail =>
+      m!"certify_bound: certificate verification failed:\n{detail}"
+
+/-- Core of `certify_bound`. Without an explicit Taylor depth, Dyadic
+precision and Taylor depth increase together. With an explicit depth, only
+Dyadic precision is refined. Rational fallback runs once after the final
+Dyadic stage. -/
 def certifyBoundWithDepth (depth : Option Nat) : TacticM Unit := do
-  match depth with
-  | some n =>
-    -- Fixed depth specified by user
-    intervalBoundCore n
-  | none =>
-    -- Adaptive: try increasing depths until success
-    let depths := [10, 15, 20, 25, 30]
-    let _goal ← getMainGoal
-    let goalState ← saveState
-    let mut lastError : Option Exception := none
-    for d in depths do
-      try
-        restoreState goalState
-        trace[interval_decide] "Trying Taylor depth {d}..."
-        intervalBoundCore d
-        trace[interval_decide] "Success with Taylor depth {d}"
-        return  -- Success!
-      catch e =>
-        lastError := some e
-        continue
-    -- All depths failed - run diagnostics and report enriched error
-    match lastError with
-    | some e =>
-      -- Restore state and try to parse goal for diagnostics
+  let policy := match depth with
+    | some n => NumericalRefinementPolicy.fixedTaylor n 0
+    | none => NumericalRefinementPolicy.adaptive 10 0
+  let goalState ← saveState
+  match ← intervalBoundAdaptiveCoreTyped policy with
+  | .ok _ => pure ()
+  | .error failure =>
       restoreState goalState
       let diagMsg ← try
-        -- Apply same preprocessing as intervalBoundCore for consistent parsing
         try
-          evalTactic (← `(tactic| intro _x _hx; simp only [ge_iff_le, gt_iff_lt]; revert _x _hx))
+          evalTactic (← `(tactic|
+            intro _x _hx; simp only [ge_iff_le, gt_iff_lt]; revert _x _hx))
         catch _ =>
           try evalTactic (← `(tactic| simp only [ge_iff_le, gt_iff_lt]))
           catch _ => pure ()
         try
-          evalTactic (← `(tactic| simp only [pow_zero, pow_one, one_mul, mul_one] at *))
+          evalTactic (← `(tactic|
+            simp only [pow_zero, pow_one, one_mul, mul_one] at *))
         catch _ => pure ()
-
         let goal ← getMainGoal
         let goalType ← goal.getType
-        let boundGoalOpt ← parseBoundGoal goalType
-        runShadowDiagnostic boundGoalOpt goalType
+        runShadowDiagnostic (← parseBoundGoal goalType) goalType
       catch _ =>
         pure m!"(Could not run diagnostics)"
-
-      throwError m!"{e.toMessageData}\n\n{diagMsg}"
-    | none => throwError "certify_bound: All precision levels failed"
+      throwError m!"{failure.message}\n\n{diagMsg}"
 
 /-- The certify_bound tactic.
 
     Automatically proves bounds on expressions using interval arithmetic.
 
     Usage:
-    - `certify_bound` - uses adaptive precision (tries depths 10, 15, 20, 25, 30)
-    - `certify_bound 20` - uses fixed Taylor depth of 20
+    - `certify_bound` - coordinates increasing Dyadic precision and Taylor depth
+    - `certify_bound 20` - fixes Taylor depth at 20 while refining Dyadic precision
     - `certify_bound (trust := kernel)` - kernel-only certificate verification
       (likewise `native`, `auto`; defaults to the `leancert.trust` option)
 

--- a/LeanCert/Tactic/IntervalAuto/PointIneq.lean
+++ b/LeanCert/Tactic/IntervalAuto/PointIneq.lean
@@ -48,7 +48,8 @@ inductive PointInequalityFailure where
 
 /-- Try to prove a closed expression bound directly using certificate verification. -/
 def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
-    (taylorDepth : Nat) :
+    (taylorDepth : Nat) (precision : Int := -80)
+    (rationalFallback : Bool := true) :
     TacticM (Except PointInequalityFailure PointInequalityOutcome) := do
   trace[interval_decide] "typed point bound: starting with goal {goalType}"
   goal.withContext do
@@ -310,7 +311,7 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
     let dyadicSaved ← saveState
     let tryDyadic : TacticM (Except PointInequalityFailure
         (Option PointInequalityOutcome)) := do
-      let prec : Int := -80
+      let prec := precision
       let precExpr := toExpr prec
       let depthExpr := toExpr taylorDepth
       let precLeZeroTy ← mkAppM ``LE.le #[precExpr, toExpr (0 : Int)]
@@ -376,7 +377,11 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
     let dyadicResult ← tryDyadic
     match dyadicResult with
     | .ok (some outcome) => return .ok outcome
-    | .ok none => pure ()
+    | .ok none =>
+        if !rationalFallback then
+          return .error <| .inconclusive
+            s!"The Dyadic point checker was inconclusive at precision \
+              {precision} and Taylor depth {taylorDepth}."
     | .error failure => return .error failure
 
     let supportProof ←
@@ -454,9 +459,31 @@ def proveClosedExpressionBoundTyped (goal : MVarId) (goalType : Lean.Expr)
     return .error <| .transportFailure
       "certified Rational proof did not close the original point inequality"
 
-private def proveClosedExpressionBoundOrThrow (goal : MVarId) (goalType : Lean.Expr)
-    (taylorDepth : Nat) : TacticM Unit := do
-  match ← proveClosedExpressionBoundTyped goal goalType taylorDepth with
+/-- Coordinate Dyadic precision and Taylor depth for a closed point
+inequality. The Rational fallback runs only in the final stage. -/
+def proveClosedExpressionBoundAdaptiveTyped (goal : MVarId)
+    (goalType : Lean.Expr) (policy : NumericalRefinementPolicy) :
+    TacticM (Except PointInequalityFailure PointInequalityOutcome) := do
+  let original ← saveState
+  let mut lastFailure : Option PointInequalityFailure := none
+  for stage in policy.stages do
+    original.restore
+    let isFinal := stage.index + 1 == policy.stageCount
+    match ← proveClosedExpressionBoundTyped goal goalType stage.taylorDepth
+        stage.dyadicPrecision isFinal with
+    | .ok outcome => return .ok outcome
+    | .error failure@(.inconclusive ..) => lastFailure := some failure
+    | .error failure@(.rejected ..) => lastFailure := some failure
+    | .error failure =>
+        original.restore
+        return .error failure
+  original.restore
+  return .error <| lastFailure.getD <|
+    .inconclusive "the numerical refinement policy contains no stages"
+
+private def proveClosedExpressionBoundAdaptiveOrThrow (goal : MVarId)
+    (goalType : Lean.Expr) (policy : NumericalRefinementPolicy) : TacticM Unit := do
+  match ← proveClosedExpressionBoundAdaptiveTyped goal goalType policy with
   | .ok _ => pure ()
   | .error (.unsupported expression detail) =>
       throwError "interval_decide: unsupported expression {expression}:\n{detail}"
@@ -469,8 +496,9 @@ private def proveClosedExpressionBoundOrThrow (goal : MVarId) (goalType : Lean.E
   | .error (.internalFailure detail) =>
       throwError "interval_decide: certificate verification failed:\n{detail}"
 
-/-- The interval_decide tactic implementation. -/
-def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
+/-- Point-inequality implementation under one coordinated refinement policy. -/
+def intervalDecideCoreWithPolicy (policy : NumericalRefinementPolicy) : TacticM Unit := do
+  let taylorDepth := policy.initialTaylorDepth
   intervalNormCore
   let goal ← getMainGoal
   let goalType ← goal.getType
@@ -514,7 +542,7 @@ def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
     if !hasFreeVars then
       trace[interval_decide] "No free variables, trying closed expression path"
       try
-        proveClosedExpressionBoundOrThrow goal goalType taylorDepth
+        proveClosedExpressionBoundAdaptiveOrThrow goal goalType policy
         return
       catch e =>
         trace[interval_decide] "Closed expression path on original goal failed: {e.toMessageData}"
@@ -533,7 +561,7 @@ def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
       catch _ => pure ()
 
       try
-        proveClosedExpressionBoundOrThrow currentGoal currentGoalType taylorDepth
+        proveClosedExpressionBoundAdaptiveOrThrow currentGoal currentGoalType policy
         return
       catch _ => pure ()
 
@@ -589,6 +617,12 @@ def intervalDecideCore (taylorDepth : Nat) : TacticM Unit := do
               exact h {cStr} ⟨le_refl {cStr}, le_refl {cStr}⟩\n\
               ```\n\
               Replace `f x` with your expression (using `x` instead of `{cStr}`)."
+
+/-- Compatibility entry point with fixed Taylor depth and adaptive Dyadic
+precision. -/
+def intervalDecideCore (taylorDepth : Nat) : TacticM Unit :=
+  intervalDecideCoreWithPolicy
+    (NumericalRefinementPolicy.fixedTaylor taylorDepth 0)
 
 /-! ### Depth estimation helpers -/
 
@@ -898,56 +932,30 @@ private def intervalDecideSingle (depth : Option Nat) : TacticM Unit := do
   match depth with
   | some n =>
     let goalState ← saveState
-    let goalType ← getMainTarget
-    -- If we can estimate a much smaller depth, try it first to save time.
-    let est ← estimateTranscendentalDepth goalType
-    let est' := Nat.min est n
-    let depths : List Nat :=
-      if est' + 5 < n then [est', n] else [n]
-    let mut lastError : Option Exception := none
-    for d in depths do
-      try
-        restoreState goalState
-        intervalDecideCore d
-        return
-      catch e =>
-        lastError := some e
-        continue
-    restoreState goalState
-    let splitSuccess ← trySumSplitting n
-    if splitSuccess then return
-    match lastError with
-    | some e => throw e
-    | none => throwError "interval_decide: failed at all depth levels"
+    try
+      intervalDecideCore n
+      return
+    catch e =>
+      restoreState goalState
+      let splitSuccess ← trySumSplitting n
+      if splitSuccess then return
+      throw e
   | none =>
     let goalType ← getMainTarget
     let est ← estimateTranscendentalDepth goalType
-    let depths :=
-      if est > 10 then
-        [est, est + 10, est + 20]
-      else
-        [10, 15, 20, 25, 30]
-    trace[interval_decide] "Estimated depth: {est}, trying depths: {depths}"
+    let initialDepth := if est > 10 then est else 10
+    let policy := NumericalRefinementPolicy.adaptive initialDepth 0
+    trace[interval_decide] "Estimated depth: {est}, refinement stages: {repr policy.stages}"
     let goalState ← saveState
-    let mut lastError : Option Exception := none
-    for d in depths do
-      try
-        restoreState goalState
-        trace[interval_decide] "Trying Taylor depth {d}..."
-        intervalDecideCore d
-        trace[interval_decide] "Success with Taylor depth {d}"
-        return
-      catch e =>
-        lastError := some e
-        continue
-    -- All depths failed — try sum splitting as a last resort
-    let est2 := if est > 10 then est else 30
-    restoreState goalState
-    let splitSuccess ← trySumSplitting est2
-    if splitSuccess then return
-    match lastError with
-    | some e => throw e
-    | none => throwError "interval_decide: failed at all depth levels"
+    try
+      intervalDecideCoreWithPolicy policy
+      return
+    catch e =>
+      restoreState goalState
+      let finalDepth := initialDepth + 2 * policy.taylorDepthStep
+      let splitSuccess ← trySumSplitting finalDepth
+      if splitSuccess then return
+      throw e
 
 /-- Recursively handle conjunctions and disjunctions, then apply intervalDecideSingle -/
 partial def intervalDecideWithConnectives (depth : Option Nat) : TacticM Unit := do

--- a/LeanCert/Tactic/LeanCert/Router.lean
+++ b/LeanCert/Tactic/LeanCert/Router.lean
@@ -133,12 +133,29 @@ private def subdivisionFailure :
   | .internalFailure detail =>
       .internalError `LeanCert.Tactic.Auto.intervalBoundSubdivCoreTyped detail
 
-private unsafe def subdivisionAttemptTyped (cfg : LeanCertConfig) :
+private unsafe def adaptiveSubdivisionAttemptTyped (cfg : LeanCertConfig) :
     TacticM (Except AttemptFailure SolverExecution) := do
-  match ← Auto.intervalBoundSubdivCoreTyped
-      (some cfg.taylorDepth) cfg.subdivisions with
-  | .ok outcome => return .ok (subdivisionExecution outcome)
-  | .error failure => return .error (subdivisionFailure failure)
+  let original ← saveState
+  let stages := (NumericalRefinementPolicy.adaptive cfg.taylorDepth
+    cfg.subdivisions).stages
+  let mut lastFailure : Option Auto.SubdivisionFailure := none
+  for stage in stages do
+    if stage.subdivisionDepth == 0 then continue
+    original.restore
+    match ← Auto.intervalBoundSubdivCoreTyped
+        (some stage.taylorDepth) stage.subdivisionDepth with
+    | .ok outcome => return .ok (subdivisionExecution outcome)
+    | .error failure@(.exhausted ..) => lastFailure := some failure
+    | .error failure@(.rejected ..) => lastFailure := some failure
+    | .error failure =>
+        original.restore
+        return .error (subdivisionFailure failure)
+  original.restore
+  match lastFailure with
+  | some failure => return .error (subdivisionFailure failure)
+  | none => return .error <| .inconclusive {
+      detail := "The numerical refinement policy scheduled no positive subdivision depth."
+    }
 
 private def pointExecution (outcome : Auto.PointInequalityOutcome) :
     SolverExecution := Id.run do
@@ -172,6 +189,24 @@ private def pointAttemptTyped (depth : Nat) :
       return .error <| .rejected {
         detail := "The candidate certificate was rejected by its checker."
       }
+  | .error (.inconclusive detail) =>
+      return .error <| .inconclusive { detail }
+  | .error (.transportFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.interval_decide detail
+  | .error (.internalFailure detail) =>
+      return .error <| .internalError `LeanCert.Tactic.Auto.interval_decide detail
+
+private def adaptivePointAttemptTyped (policy : NumericalRefinementPolicy) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  Auto.intervalNormCore
+  let goal ← getMainGoal
+  let goalType ← goal.getType
+  match ← Auto.proveClosedExpressionBoundAdaptiveTyped goal goalType policy with
+  | .ok outcome => return .ok (pointExecution outcome)
+  | .error (.unsupported expression detail) =>
+      return .error <| .unsupported { expression, detail := some detail }
+  | .error (.rejected detail) =>
+      return .error <| .rejected { detail }
   | .error (.inconclusive detail) =>
       return .error <| .inconclusive { detail }
   | .error (.transportFailure detail) =>
@@ -221,38 +256,55 @@ private def registeredEnclosureExecution
       #[s!"proof-carrying composition: {outcome.compositionSteps} surrounding core layer(s)"]
 }
 
-private unsafe def registeredEnclosureAttemptTyped (prepared : Semantic.PreparedGoal)
-    (depth maxDepth : Nat) : TacticM (Except AttemptFailure SolverExecution) := do
-  match ← Extension.registeredEnclosureBoundSubdivCoreTyped
-      prepared (-53) depth maxDepth with
-  | .ok outcome => return .ok (registeredEnclosureExecution outcome)
-  | .error .notApplicable => return .error .notApplicable
-  | .error (.unsupported expression detail) =>
-      return .error <| .unsupported { expression, detail := some detail }
-  | .error (.domainObstruction operation detail) =>
-      return .error <| .domainObstruction {
+private def registeredEnclosureFailure :
+    Extension.RegisteredEnclosureFailure → AttemptFailure
+  | .notApplicable => .notApplicable
+  | .unsupported expression detail =>
+      .unsupported { expression, detail := some detail }
+  | .domainObstruction operation detail =>
+      .domainObstruction {
         source := { original := mkConst ``True, kind := .intervalRat }
         operation := some operation
         reason := detail
       }
-  | .error (.inconclusive detail enclosure) =>
-      return .error <| .inconclusive { detail, enclosure }
-  | .error (.rejected checker enclosure detail) =>
-      return .error <| .rejected { checker, enclosure, detail }
-  | .error (.exhausted maxDepth boxes deepest leaves enclosure detail) =>
-      return .error <| .inconclusive {
+  | .inconclusive detail enclosure => .inconclusive { detail, enclosure }
+  | .rejected checker enclosure detail => .rejected { checker, enclosure, detail }
+  | .exhausted maxDepth boxes deepest leaves enclosure detail =>
+      .inconclusive {
         enclosure
         detail := s!"Registered enclosure subdivision reached its configured depth \
           {maxDepth} after examining {boxes} boxes (deepest depth {deepest}; \
           {leaves} certified leaves). Last failure: {detail}"
       }
-  | .error (.verificationFailure detail) =>
-      return .error <| .internalError
+  | .verificationFailure detail =>
+      .internalError
         `LeanCert.Tactic.Extension.registeredEnclosureBoundSubdivCoreTyped detail
 
-private unsafe def directBoundAttemptTyped (depth : Nat) :
+private unsafe def adaptiveRegisteredEnclosureAttemptTyped
+    (prepared : Semantic.PreparedGoal) (policy : NumericalRefinementPolicy) :
     TacticM (Except AttemptFailure SolverExecution) := do
-  match ← Auto.intervalBoundCoreTyped depth with
+  let original ← saveState
+  let mut lastFailure : Option AttemptFailure := none
+  for stage in policy.stages do
+    original.restore
+    match ← Extension.registeredEnclosureBoundSubdivCoreTyped prepared
+        stage.dyadicPrecision stage.taylorDepth stage.subdivisionDepth with
+    | .ok outcome => return .ok (registeredEnclosureExecution outcome)
+    | .error failure =>
+        let mapped := registeredEnclosureFailure failure
+        match mapped with
+        | retry@(.inconclusive ..) => lastFailure := some retry
+        | retry@(.rejected ..) => lastFailure := some retry
+        | terminal =>
+            original.restore
+            return .error terminal
+  original.restore
+  return .error <| lastFailure.getD .notApplicable
+
+private unsafe def adaptiveDirectBoundAttemptTyped
+    (policy : NumericalRefinementPolicy) :
+    TacticM (Except AttemptFailure SolverExecution) := do
+  match ← Auto.intervalBoundAdaptiveCoreTyped policy with
   | .ok outcome => return .ok (directBoundExecution outcome)
   | .error (.unsupported expression detail) =>
       return .error <| .unsupported {
@@ -852,34 +904,30 @@ private unsafe def portfolio (intent : GoalIntent) (cfg : LeanCertConfig)
           (some (suggestion "norm_num")) (strategyId := .exactNormalization),
         solve := exactTacticAttemptTyped
           (do evalTactic (← `(tactic| norm_num))) },
-      { report := report intent s!"direct point enclosure (Taylor depth {d})" cfg mode
+      { report := report intent "adaptive point enclosure" cfg mode
           (.policy "checked interval tactic portfolio")
-          (some (suggestion "interval_auto" #[toString d]))
+          none
+          (some "Dyadic precision and Taylor depth increase together; the \
+            Rational fallback runs once after the final stage")
           (strategyId := .pointEnclosure),
-        solve := pointAttemptTyped d },
-      { report := report intent s!"direct point enclosure (Taylor depth {d2})" cfg mode
-          (.policy "checked interval tactic portfolio")
-          (some (suggestion "interval_auto" #[toString d2]))
-          (strategyId := .pointEnclosure),
-        solve := pointAttemptTyped d2 }]
+        solve := adaptivePointAttemptTyped
+          (NumericalRefinementPolicy.adaptive d 0) }]
   | .intervalBound => #[
-      { report := report intent s!"direct interval enclosure (Taylor depth {d})" cfg mode
+      { report := report intent "adaptive direct interval enclosure" cfg mode
           (.policy "Dyadic-first, then checked Rational fallback")
-          (some (suggestion "certify_bound" #[toString d]))
+          (some (suggestion "certify_bound"))
+          (some "Dyadic precision and Taylor depth increase together; the \
+            Rational fallback runs once after the final stage")
           (strategyId := .intervalEnclosure),
-        solve := directBoundAttemptTyped d },
-      { report := report intent s!"direct interval enclosure (Taylor depth {d2})" cfg mode
-          (.policy "Dyadic-first, then checked Rational fallback")
-          (some (suggestion "certify_bound" #[toString d2]))
-          (strategyId := .intervalEnclosure),
-        solve := directBoundAttemptTyped d2 },
+        solve := adaptiveDirectBoundAttemptTyped
+          (NumericalRefinementPolicy.adaptive d cfg.subdivisions) },
       { report := report intent "recursive interval subdivision" cfg mode
           (.fixed .rationalInterval)
-          (some (suggestion "interval_bound_subdiv"
-            #[toString d, toString cfg.subdivisions]))
-          (some s!"Taylor depth {d}; maximum recursive depth {cfg.subdivisions}")
+          none
+          (some s!"Taylor depth and spatial depth refine together up to maximum \
+            recursive depth {cfg.subdivisions}")
           .subdivision,
-        solve := subdivisionAttemptTyped cfg },
+        solve := adaptiveSubdivisionAttemptTyped cfg },
       { report := report intent
           (if cfg.useMonotonicity then s!"opt_bound {cfg.maxIterations} mono"
            else s!"opt_bound {cfg.maxIterations}") cfg mode
@@ -1520,7 +1568,8 @@ unsafe def runLeanCert (cfg : LeanCertConfig)
         .registeredEnclosure
       let extensionSpec : SolverSpec := {
         report := extensionPlan
-        solve := registeredEnclosureAttemptTyped prepared cfg.taylorDepth cfg.subdivisions
+        solve := adaptiveRegisteredEnclosureAttemptTyped prepared
+          (NumericalRefinementPolicy.adaptive cfg.taylorDepth cfg.subdivisions)
       }
       match ← trySolver extensionSpec with
       | .proved artifact => return ← commitArtifact artifact

--- a/LeanCert/Tactic/NumericalRefinement.lean
+++ b/LeanCert/Tactic/NumericalRefinement.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+
+/-!
+# Coordinated numerical refinement
+
+This module contains the untrusted scheduling policy shared by tactic-side
+candidate search. A stage coordinates three independent sources of enclosure
+error: Dyadic rounding, Taylor approximation, and spatial subdivision.
+
+The schedule never proves a theorem. A selected stage must still close the
+ordinary Boolean checker and apply its existing Golden Theorem.
+-/
+
+namespace LeanCert.Tactic
+
+/-- One finite numerical-refinement attempt. `index` is zero-based. -/
+structure NumericalRefinementStage where
+  index : Nat
+  dyadicPrecision : Int
+  taylorDepth : Nat
+  subdivisionDepth : Nat
+  deriving DecidableEq, Repr, Inhabited
+
+/-- Deterministic policy for coordinated candidate refinement. -/
+structure NumericalRefinementPolicy where
+  initialDyadicPrecision : Int := -53
+  dyadicPrecisionStep : Nat := 32
+  initialTaylorDepth : Nat := 10
+  taylorDepthStep : Nat := 10
+  maxSubdivisionDepth : Nat := 4
+  stageCount : Nat := 3
+  deriving DecidableEq, Repr, Inhabited
+
+namespace NumericalRefinementPolicy
+
+/-- Spatial depth at a stage, linearly ramped from zero to the configured
+maximum. A singleton schedule receives the full configured depth. -/
+def subdivisionDepthAt (policy : NumericalRefinementPolicy) (index : Nat) : Nat :=
+  if policy.stageCount ≤ 1 then
+    policy.maxSubdivisionDepth
+  else
+    policy.maxSubdivisionDepth * index / (policy.stageCount - 1)
+
+/-- Materialize one stage of the policy. -/
+def stageAt (policy : NumericalRefinementPolicy) (index : Nat) :
+    NumericalRefinementStage := {
+  index
+  dyadicPrecision := policy.initialDyadicPrecision -
+    Int.ofNat (index * policy.dyadicPrecisionStep)
+  taylorDepth := policy.initialTaylorDepth + index * policy.taylorDepthStep
+  subdivisionDepth := policy.subdivisionDepthAt index
+}
+
+/-- All configured stages in increasing refinement order. -/
+def stages (policy : NumericalRefinementPolicy) : List NumericalRefinementStage :=
+  (List.range policy.stageCount).map policy.stageAt
+
+/-- Default three-stage policy used by the semantic tactic router. -/
+def adaptive (initialTaylorDepth maxSubdivisionDepth : Nat) :
+    NumericalRefinementPolicy := {
+  initialTaylorDepth
+  maxSubdivisionDepth
+}
+
+/-- Refine Dyadic rounding and spatial depth while holding a user-specified
+Taylor depth fixed. -/
+def fixedTaylor (taylorDepth maxSubdivisionDepth : Nat) :
+    NumericalRefinementPolicy := {
+  initialTaylorDepth := taylorDepth
+  taylorDepthStep := 0
+  maxSubdivisionDepth
+}
+
+end NumericalRefinementPolicy
+
+end LeanCert.Tactic

--- a/LeanCert/Test/LeanCertRouter.lean
+++ b/LeanCert/Test/LeanCertRouter.lean
@@ -916,9 +916,10 @@ example : (1 : ℝ) < 2 := by
 info: LeanCert recognized: closed numerical comparison
 
 Selected strategy:
-  direct point enclosure (Taylor depth 10)
+  adaptive point enclosure
+  Dyadic precision and Taylor depth increase together; the Rational fallback runs once after the final stage
   Taylor depth: 10
-  precision: -80
+  precision: -53
 
 Numerical computation:
   Dyadic interval evaluation
@@ -931,10 +932,6 @@ Verifier: LeanCert.Validity.verify_strict_upper_bound_dyadic_checked
 Suggested proof:
   by
     leancert
-
-Advanced control:
-  by
-    interval_auto 10
 -/
 #guard_msgs in
 example : Real.log 2 < 7 / 10 := by
@@ -944,9 +941,10 @@ example : Real.log 2 < 7 / 10 := by
 info: LeanCert recognized: univariate interval bound
 
 Selected strategy:
-  direct interval enclosure (Taylor depth 10)
+  adaptive direct interval enclosure
+  Dyadic precision and Taylor depth increase together; the Rational fallback runs once after the final stage
   Taylor depth: 10
-  precision: -80
+  precision: -53
 
 Numerical computation:
   Dyadic interval evaluation
@@ -962,7 +960,7 @@ Suggested proof:
 
 Advanced control:
   by
-    certify_bound 10
+    certify_bound
 -/
 #guard_msgs in
 example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
@@ -1015,7 +1013,7 @@ info: LeanCert recognized: univariate interval bound
 
 Selected strategy:
   recursive interval subdivision
-  Taylor depth 10; maximum recursive depth 8
+  Taylor depth and spatial depth refine together up to maximum recursive depth 8
 
 Numerical computation:
   Rational interval evaluation
@@ -1026,7 +1024,7 @@ Checker: LeanCert.Validity.checkUpperBound
 Verifier: LeanCert.Validity.verify_upper_bound_Icc_core
 
 Subdivision:
-  Taylor depth: 10
+  Taylor depth: 30
   Configured maximum depth: 8
   Deepest depth used: 5
   Boxes examined: 27
@@ -1036,10 +1034,6 @@ Subdivision:
 Suggested proof:
   by
     leancert (subdivisions := 8) (trust := kernel)
-
-Advanced control:
-  by
-    interval_bound_subdiv 10 8 (trust := kernel)
 -/
 #guard_msgs in
 example : ∀ x ∈ Set.Icc (0 : ℝ) 1, x * (1 - x) ≤ (27 / 100 : ℚ) := by

--- a/LeanCert/Test/NumericalRefinement.lean
+++ b/LeanCert/Test/NumericalRefinement.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 LeanCert Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanCert Contributors
+-/
+import LeanCert
+import LeanCert.API.Bounds
+
+/-! # Coordinated numerical-refinement regressions -/
+
+namespace LeanCert.Test.NumericalRefinement
+
+open LeanCert LeanCert.Core LeanCert.API.Bounds LeanCert.Tactic
+
+private def unit : IntervalRat := ⟨0, 1, by norm_num⟩
+private def exponential : Expr := .exp (.var 0)
+private def veryTightUpper : ℚ :=
+  2718281828459045235360287472 / 1000000000000000000000000000
+
+example : (NumericalRefinementPolicy.adaptive 10 4).stages = [
+    ⟨0, -53, 10, 0⟩,
+    ⟨1, -85, 20, 2⟩,
+    ⟨2, -117, 30, 4⟩
+  ] := by native_decide
+
+example : (NumericalRefinementPolicy.fixedTaylor 20 6).stages = [
+    ⟨0, -53, 20, 0⟩,
+    ⟨1, -85, 20, 3⟩,
+    ⟨2, -117, 20, 6⟩
+  ] := by native_decide
+
+-- The historical fixed `-80` precision cannot certify this bound even with
+-- enough Taylor terms; coordinated refinement reaches a successful stage.
+example : LeanCert.API.Bounds.checkUpperBound exponential unit veryTightUpper
+    { dyadicExponent := -80, taylorDepth := 30 } = false := by native_decide
+
+example : LeanCert.API.Bounds.checkUpperBound exponential unit veryTightUpper
+    { dyadicExponent := -117, taylorDepth := 30 } = true := by native_decide
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp x ≤
+      (2718281828459045235360287472 /
+        1000000000000000000000000000 : ℚ) := by
+  certify_bound
+
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp x ≤
+      (2718281828459045235360287472 /
+        1000000000000000000000000000 : ℚ) := by
+  leancert
+
+-- The unified dedicated entry point shares the same schedule rather than
+-- nesting its historical Taylor loop around the precision loop.
+example : ∀ x ∈ Set.Icc (0 : ℝ) 1,
+    Real.exp x ≤
+      (2718281828459045235360287472 /
+        1000000000000000000000000000 : ℚ) := by
+  interval_auto
+
+example : Real.exp 1 ≤
+    (2718281828459045235360287472 /
+      1000000000000000000000000000 : ℚ) := by
+  leancert
+
+example : Real.exp 1 ≤
+    (2718281828459045235360287472 /
+      1000000000000000000000000000 : ℚ) := by
+  interval_auto
+
+end LeanCert.Test.NumericalRefinement

--- a/docs/architecture/benchmarks.md
+++ b/docs/architecture/benchmarks.md
@@ -58,6 +58,11 @@ The larger suites are split by purpose:
   Materialized-cell cases validate leaf count and total semantic width. The
   frontier case includes path construction and structural validation but
   deliberately excludes numerical leaf evaluation and proof construction;
+- `numerical-refinement` compares fixed checked-Dyadic configurations with the
+  coordinated precision/Taylor schedule. It includes both a cheap first-stage
+  success and a tight final-stage success, plus the historical fixed `-80`
+  rejection. These cases measure compiled candidate checking, not tactic
+  elaboration or kernel proof replay;
 - `all` includes every suite, including the seconds-scale integration cases.
 
 ## Commands
@@ -94,6 +99,10 @@ lake exe leancert-bench --suite algebra --samples 15 --warmups 3
 # Establish the closed-tree baseline for addressed dyadic subdivision
 lake exe leancert-bench \
   --suite dyadic-subdivision --samples 15 --warmups 3
+
+# Compare fixed and adaptive checked-Dyadic bound attempts
+lake exe leancert-bench \
+  --suite numerical-refinement --samples 15 --warmups 3
 
 # Run absolutely everything
 lake exe leancert-bench --suite all

--- a/docs/direct/bounds.md
+++ b/docs/direct/bounds.md
@@ -34,6 +34,12 @@ you intentionally want the dedicated single-variable interval engine, including
 explicit Taylor-depth selection.
 `certify_bound` is a numerical portfolio rather than a promise of one fixed
 backend. Subdivision and global optimization are strategies, not backends.
+Without a positional Taylor depth it uses the same coordinated three-stage
+schedule as `leancert`: Dyadic precision increases from `-53` through `-85` to
+`-117`, while Taylor depth increases by 10 at each stage. A positional depth,
+for example `certify_bound 20`, keeps Taylor depth fixed and still adapts
+Dyadic precision. The final Rational fallback runs only after the Dyadic
+stages are exhausted.
 
 `interval_bound_subdiv depth maxDepth` splits candidate boxes and certifies
 every retained leaf. `leancert?` reports its configured and deepest depths,

--- a/docs/direct/leancert.md
+++ b/docs/direct/leancert.md
@@ -101,6 +101,20 @@ example : ∀ x ∈ Set.Icc (0 : ℝ) 1, x * (1 - x) ≤ (27 / 100 : ℚ) := by
 | `maxIterations` | `1000` | Iteration limit for global-optimization strategies |
 | `trust` | scoped option | Certificate-verification policy: `kernel`, `native`, or `auto` |
 
+Numerical interval strategies use a deterministic three-stage refinement
+schedule. Starting from the configured `taylorDepth`, the ordinary adaptive
+route tries Taylor depths `d`, `d + 10`, and `d + 20` together with Dyadic
+precisions `-53`, `-85`, and `-117`. Strategies that subdivide also ramp their
+spatial limit from zero to the configured `subdivisions` maximum. An explicit
+Taylor depth passed to a dedicated tactic such as `certify_bound 20` remains
+fixed at `20`; only Dyadic precision (and spatial depth where relevant) is
+refined.
+
+This scheduling logic is untrusted search. Every successful stage still runs
+the existing Boolean checker and applies its Golden Theorem; an unsuccessful
+stage cannot create a proof. Rational fallback is attempted once, after the
+last Dyadic stage, rather than once per stage.
+
 The effective default is the scoped `leancert.trust` option, whose repository
 default is `native`. An inline `(trust := ...)` overrides it. Non-default
 options that made a proof succeed should be retained in the final proof.
@@ -134,7 +148,7 @@ LeanCert recognized: univariate interval bound
 
 Selected strategy:
   recursive interval subdivision
-  Taylor depth 10; maximum recursive depth 8
+  Taylor depth and spatial depth refine together up to maximum recursive depth 8
 
 Numerical computation:
   Rational interval evaluation
@@ -143,7 +157,7 @@ Certificate verification:
   requested auto → used kernel (several checks)
 
 Subdivision:
-  Taylor depth: 10
+  Taylor depth: 30
   Configured maximum depth: 8
   Deepest depth used: 5
   Boxes examined: 27
@@ -153,10 +167,6 @@ Subdivision:
 Suggested proof:
   by
     leancert (subdivisions := 8) (trust := auto)
-
-Advanced control:
-  by
-    interval_bound_subdiv 10 8 (trust := auto)
 ```
 
 If `auto` uses native verification, the report distinguishes a

--- a/docs/reference/tactics.md
+++ b/docs/reference/tactics.md
@@ -148,6 +148,15 @@ fragment use the executable `QPoly.checkExactIntegral` checker. Integral
 inequalities fall back to checked rational partition search. State ordinary
 integral equalities or inequalities and use `leancert`.
 
+For numerical interval strategies, `taylorDepth` is the initial analytic
+depth and `subdivisions` is the maximum spatial depth. The default adaptive
+schedule tries three coordinated stages with Dyadic precisions `-53`, `-85`,
+and `-117`; Taylor depth increases by 10 per stage and spatial depth ramps to
+the requested maximum. Supplying a positional Taylor depth to a dedicated
+tactic such as `certify_bound 20` holds Taylor depth fixed while precision
+still refines. The scheduler only searches for candidates: all accepted
+results continue through the ordinary checked certificate theorem.
+
 Conjunctions of recognized numerical goals are routed recursively, including
 goals exposed by `forall_and`. Every child must be independently supported and
 proved. Disjunctions are intentionally not routed: choosing a logical branch

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -144,6 +144,7 @@ roots = [
   "LeanCert.Test.LeanCertRouter",
   "LeanCert.Test.LeanCertIntegrals",
   "LeanCert.Test.NaturalSyntaxRepairs",
+  "LeanCert.Test.NumericalRefinement",
   "LeanCert.Test.Numeral",
   "LeanCert.Test.Pisano",
   "LeanCert.Test.PublicEvalAPI",


### PR DESCRIPTION
## Summary
- introduce one deterministic three-stage policy coordinating Dyadic precision, Taylor depth, and spatial subdivision
- share it across certify_bound, interval_auto, semantic-router point/direct/subdivision strategies, and registered enclosures
- keep the scheduler outside the trust boundary: every successful candidate still passes the existing Boolean checker and Golden Theorem
- run Rational fallback once after the final Dyadic stage
- add tight-bound regressions, router diagnostics, a compiled benchmark suite, and user/architecture documentation

## Schedule
- Dyadic precision: -53, -85, -117
- default Taylor depth: d, d + 10, d + 20
- subdivision: linearly ramps from zero to the configured maximum
- explicit dedicated-tactic Taylor depths remain fixed while precision refines

## Validation
- lake build FunctionalTests
- lake build LeanCert.Benchmark.Main
- numerical-refinement benchmark suite passes all five expected outcomes

## Benchmark interpretation
The new suite times compiled checked-Dyadic candidate evaluation only. It distinguishes cheap first-stage success from final-stage retry overhead; it does not claim to measure tactic elaboration or kernel proof replay.